### PR TITLE
Soften Panel theme lightBg values for bold light configs

### DIFF
--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/DefaultThemeConfigs.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/DefaultThemeConfigs.kt
@@ -677,11 +677,13 @@ val defaultThemeConfigs: List<ThemeConfigPreset> = listOf(
     ),
 
     // ── Bold light-mode configurations ────────────────────────────────
-    // Each pairs a pastel content theme with a deeply saturated "Panel"
+    // Each pairs a pastel content theme with a medium-saturated "Panel"
     // sidebar/chrome and a vivid "Bar" tab strip so the UI never
-    // collapses to white/yellow/grey. The bottomBar is intentionally
-    // pulled to the panel hue so the chrome reads as a single coloured
-    // frame around the soft content.
+    // collapses to white/yellow/grey. The panel tone is deliberately
+    // mid-weight — clearly coloured, but not so dark it turns the light
+    // mode into a near-dark mode. The bottomBar is pulled to the panel
+    // hue so the chrome reads as a single coloured frame around the
+    // soft content.
 
     ThemeConfigPreset(
         name = "Midnight Library",

--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/Themes.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/Themes.kt
@@ -494,38 +494,45 @@ val recommendedThemes: List<TerminalTheme> = listOf(
 
     // ── Panel themes ──────────────────────────────────────────────────
     // Designed to be assigned to sidebar / chrome / windows / bottomBar
-    // sections of light-mode configs so those panels stay deeply
-    // saturated even when the content area is pastel. They keep dark
-    // backgrounds in BOTH appearance modes (just slightly darker in dark
-    // mode), pairing each with appropriate light foreground text.
+    // sections of light-mode configs so those panels stay saturated and
+    // recognisably coloured even when the content area is pastel. The
+    // light-mode backgrounds are medium-dark mid-tones (not near-black):
+    // they read as "a confident colour" on a bright page rather than a
+    // slab of darkness. Dark-mode backgrounds stay deep for dark-mode
+    // bold configs, where the pairing is meant to be near-black.
+    //
+    // Slack* panels are kept a step darker than the rest because the
+    // Slack preset depends on a three-tier hierarchy (darkest top bar →
+    // medium slate sidebar → white content) that would collapse if the
+    // navy lifted too far toward the slate.
     TerminalTheme("Midnight Panel",   darkFg = "#c8d3e8", lightFg = "#ffffff",
-                                      darkBg = "#0d1326", lightBg = "#1a2847"),
+                                      darkBg = "#0d1326", lightBg = "#3a4d7a"),
     TerminalTheme("Forest Panel",     darkFg = "#c0e0c8", lightFg = "#f0f5e8",
-                                      darkBg = "#0a1f14", lightBg = "#1f3a2e"),
+                                      darkBg = "#0a1f14", lightBg = "#3d6b52"),
     TerminalTheme("Royal Plum Panel", darkFg = "#e0c8e8", lightFg = "#f5e8ff",
-                                      darkBg = "#1a0d20", lightBg = "#3d1f4d"),
+                                      darkBg = "#1a0d20", lightBg = "#6b3d82"),
     TerminalTheme("Burgundy Panel",   darkFg = "#f0c8d0", lightFg = "#fff0f5",
-                                      darkBg = "#200a14", lightBg = "#4a1c2e"),
+                                      darkBg = "#200a14", lightBg = "#7a3a52"),
     TerminalTheme("Espresso Panel",   darkFg = "#e8d4b8", lightFg = "#f5e8d4",
-                                      darkBg = "#1a0d05", lightBg = "#3d2418"),
+                                      darkBg = "#1a0d05", lightBg = "#6b4a35"),
     TerminalTheme("Deep Teal Panel",  darkFg = "#b8e0e0", lightFg = "#e8fafa",
-                                      darkBg = "#051f1f", lightBg = "#0d3a3a"),
+                                      darkBg = "#051f1f", lightBg = "#2d6b6b"),
     TerminalTheme("Slate Panel",      darkFg = "#c8d2e0", lightFg = "#f7fafc",
-                                      darkBg = "#0d1320", lightBg = "#2d3748"),
+                                      darkBg = "#0d1320", lightBg = "#4a5a75"),
     TerminalTheme("Indigo Panel",     darkFg = "#cad0f0", lightFg = "#e0e7ff",
-                                      darkBg = "#0d0a24", lightBg = "#1e1b4b"),
+                                      darkBg = "#0d0a24", lightBg = "#4a3d80"),
     TerminalTheme("Terracotta Panel", darkFg = "#f0d4b8", lightFg = "#ffe8d4",
-                                      darkBg = "#200a05", lightBg = "#4a2418"),
+                                      darkBg = "#200a05", lightBg = "#7a4830"),
     TerminalTheme("Olive Panel",      darkFg = "#e0e8c0", lightFg = "#f0f5d4",
-                                      darkBg = "#14140a", lightBg = "#3a3d1f"),
+                                      darkBg = "#14140a", lightBg = "#6b6b3d"),
     TerminalTheme("Mocha Panel",      darkFg = "#e0d0b8", lightFg = "#f5e8d4",
-                                      darkBg = "#1a0f0a", lightBg = "#3d2818"),
+                                      darkBg = "#1a0f0a", lightBg = "#6b4e38"),
     TerminalTheme("Charcoal Panel",   darkFg = "#d8d8d8", lightFg = "#f5f5f5",
-                                      darkBg = "#1a1a1a", lightBg = "#2d2d2d"),
+                                      darkBg = "#1a1a1a", lightBg = "#525559"),
     TerminalTheme("Slack Navy Panel",  darkFg = "#e8eaf0", lightFg = "#ffffff",
-                                       darkBg = "#0f1220", lightBg = "#1a1d29"),
+                                       darkBg = "#0f1220", lightBg = "#2d3245"),
     TerminalTheme("Slack Slate Panel", darkFg = "#d8dcea", lightFg = "#f0f2f8",
-                                       darkBg = "#242a47", lightBg = "#3d4266"),
+                                       darkBg = "#242a47", lightBg = "#4f5778"),
 
     // ── Bar themes ────────────────────────────────────────────────────
     // Vivid saturated colours intended for the tab strip (or any other


### PR DESCRIPTION
Closes #3

## Summary
The "bold light-mode" theme configurations shipped in the most recent theme revamp came out too dark — the Panel themes (used for sidebar / chrome / bottomBar in those configs) had `lightBg` values in the #0d–#1e range, so what was meant to be "pastel content with a saturated coloured panel" rendered as "pastel content with a near-black panel", making light mode feel like dark mode with a bright middle pane. This PR retunes each Panel's `lightBg` to a medium-saturated mid-tone in the same hue, keeping the colour identity intact while letting the overall light-mode UI actually read as light.

## Background
From the issue: *"Recently a number of more colorful themes were added. The light ones typically have light content but dark sidebars, etc. While a good attempt, those ones have become too dark instead. So it was a little bit too bold. Try to adjust them."*

The recent commit 511d215 ("More themes") introduced 14 "Panel" themes designed to be assigned to sidebar / chrome / windows / bottomBar sections of light-mode configs, plus 20 `ConfigMode.Light` presets under a "Bold light-mode configurations" header in `DefaultThemeConfigs.kt` that consume them. The Panel `lightBg` values were chosen very dark so the panels would stay "punchy" against pastel content — but they overshot and effectively inverted the mode.

## Approach
Two files change:

- `client/src/commonMain/kotlin/se/soderbjorn/termtastic/Themes.kt` — `lightBg` on all 14 Panel themes is lifted to a medium-dark mid-tone in the same hue. `darkBg` values are left alone (dark-mode "bold" configs still want near-black panels). `lightFg` is unchanged — the existing white / tinted-white values still clear WCAG AA against every new background.
- `client/src/commonMain/kotlin/se/soderbjorn/termtastic/DefaultThemeConfigs.kt` — the "Bold light-mode configurations" header comment is rewritten to describe the new medium-saturated tone rather than the old "deeply saturated" intent, so the inline design note matches reality.

No presets, no `ThemeConfigPreset` wiring, no client callers change — lifting the colour values is a local tweak that every existing config inherits for free.

### Before → after lightBg per panel
| Panel | Before | After |
|---|---|---|
| Midnight Panel | `#1a2847` | `#3a4d7a` |
| Forest Panel | `#1f3a2e` | `#3d6b52` |
| Royal Plum Panel | `#3d1f4d` | `#6b3d82` |
| Burgundy Panel | `#4a1c2e` | `#7a3a52` |
| Espresso Panel | `#3d2418` | `#6b4a35` |
| Deep Teal Panel | `#0d3a3a` | `#2d6b6b` |
| Slate Panel | `#2d3748` | `#4a5a75` |
| Indigo Panel | `#1e1b4b` | `#4a3d80` |
| Terracotta Panel | `#4a2418` | `#7a4830` |
| Olive Panel | `#3a3d1f` | `#6b6b3d` |
| Mocha Panel | `#3d2818` | `#6b4e38` |
| Charcoal Panel | `#2d2d2d` | `#525559` |
| Slack Navy Panel | `#1a1d29` | `#2d3245` |
| Slack Slate Panel | `#3d4266` | `#4f5778` |

## Decisions & reasoning

### Retune `lightBg` rather than add new "light" variants or a brightness knob
The simplest option that actually fixes the complaint. An alternative was to leave the Panel palette as-is and add a parallel "Panel Soft" set that the existing Bold light configs would point to — but that would have grown the theme list by 14 entries and left the original Panel names in the picker as traps that still render too dark if any preset or custom config references them. Since the Panels are *defined* for use as light-mode sidebars (their dark-mode role is separate and uses `darkBg`), it's more honest to fix the colour value at the source and have every existing preset inherit the correction.

### Keep `darkBg` untouched
The issue is specifically about light mode reading as too dark. The "bold dark-mode configurations" in `DefaultThemeConfigs.kt` (Neon Carnival, Deep Sea Trench, Galactic Drift, Phoenix Rise, etc.) reuse the same Panel themes and deliberately want near-black panels paired with saturated dark content. Lifting `darkBg` would have been a scope creep that fixes something nobody complained about.

### Hue preservation over uniform lightness
Each new value stays in the same hue family as the old one (navy stays navy, forest stays forest green, burgundy stays wine-red). I deliberately did *not* normalise them all to the same lightness — different hues carry saturation differently at the same L value, and the point of these themes is visual variety. The Olive Panel is now a medium olive-khaki, not a muted neutral the same luminance as Midnight.

### Slack-family panels softened less than the others
`Slack` is a `ConfigMode.Both` preset that depends on a three-tier visual hierarchy (darkest navy top bar → medium slate sidebar → white content area). That pattern is the entire identity of the Slack look — it would collapse if the Navy panel got lifted into the same brightness band as the Slate panel. So `Slack Navy Panel` moves only `#1a1d29 → #2d3245` and `Slack Slate Panel` only `#3d4266 → #4f5778`, preserving the darkness-delta between them. Every non-Slack panel moves much further.

### Leave Bar themes alone
The issue explicitly targets "dark sidebars". The Bar themes (Tangerine / Hot Magenta / Cyan / Lime) are used only on narrow tab-strip surfaces and are deliberately vivid so they pop against the pastel content. Dampening them would flatten the intentional "soft content ↔ medium panel ↔ vivid accent bar" layering and wasn't what was asked for.

### Leave `lightFg` values alone
Each Panel's existing `lightFg` (white or a hue-tinted near-white like `#f0f5e8`, `#f5e8d4`, `#ffe8d4`) still clears WCAG AA against the new medium backgrounds — the lightest new `lightBg` is `#6b7290`-ish territory, giving ~5:1+ with white. Changing the foregrounds would have been a visible tonal shift, not a contrast fix.

## Assumptions
- The `ConfigMode.Both` Slack preset renders with `lightBg` when the app is in light appearance mode and `darkBg` when it's in dark appearance mode — i.e., my change to Slack panels' `lightBg` only affects Slack in light mode. This is the documented behaviour in the data-class KDoc.
- The client renders `lightBg` directly without further adjustment for sidebar use — i.e., there's no server-side or derivation-layer darkening that would turn my new mid-tone back into a near-black. Based on the `TerminalTheme` KDoc and the inline comment on the Panel block (sidebar/chrome/bottomBar → light backgrounds directly), this appears correct, but a UI eyeball pass would confirm.

## Alternatives considered and rejected
- **Parametric derivation (single "panel brightness" knob on the picker)** — too much new surface area for a colour-balance fix.
- **Introduce a `PanelSoft*` parallel set** — leaves the old too-dark panels in the picker as traps; doubles the Panel entry count.
- **Tone the Bar themes too** — explicitly out of scope per the issue; would flatten the tab-strip pop.
- **Per-preset override of `lightBg` at the `ThemeConfigPreset` call sites** — no mechanism for that, and even if there were, 20 preset-local overrides hide the real problem (the Panel values themselves).

## Verification
- `./gradlew :client:compileKotlinJvm :client:compileCommonMainKotlinMetadata` — BUILD SUCCESSFUL on both Kotlin/JVM and commonMain metadata targets, so the change compiles for every non-native downstream.
- Colour-contrast check against WCAG AA (white text on every new `lightBg`): all 14 clear ≥4.5:1; most are ≥6.5:1.
- **Gap:** I did not launch the app to eyeball the 20 light-mode configs in a real session. The change is a pure value swap with no logic touched, and every config inherits the new value automatically, but a visual pass by the author would catch any specific pairing that now feels wrong (e.g. a particular pastel content theme that now has too little contrast against its softened panel). Flagging this explicitly rather than claiming visual verification I didn't do.

## Files of note
- `client/src/commonMain/kotlin/se/soderbjorn/termtastic/Themes.kt` — load-bearing: the 14 `lightBg` value changes and the updated block comment describing Panel intent.
- `client/src/commonMain/kotlin/se/soderbjorn/termtastic/DefaultThemeConfigs.kt` — small: the "Bold light-mode configurations" header comment now says "medium-saturated" instead of "deeply saturated" so the design-intent note matches what the Panel values actually deliver.

## Follow-ups
- Author visual pass on the 20 bold light-mode configs to confirm each content/panel pairing still reads the way its name suggests (e.g. "Emerald Garden" should still feel emerald, not minty-grey).
- If any pairing now feels *too* soft, the fix is a targeted tweak on one panel's `lightBg` — the structure above localises that to a single line per hue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)