### PR TITLE
Tab-bar overflow dropdown with hide/unhide support

### DIFF
--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowCommand.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowCommand.kt
@@ -286,6 +286,22 @@ sealed class WindowCommand {
     data class RenameTab(val tabId: String, val title: String) : WindowCommand()
 
     /**
+     * Toggle whether [tabId] is hidden from the tab strip. Hidden tabs are
+     * still listed in the tab-bar overflow dropdown so the user can recover
+     * them. The server refuses to hide the last visible tab (the strip would
+     * be empty); when hiding the active tab, the server switches the active
+     * selection to the next visible neighbour so the user lands on a tab
+     * with a strip button instead of nothing.
+     *
+     * @param tabId the id of the tab to hide or unhide
+     * @param hidden `true` to hide the tab from the strip, `false` to restore it
+     * @see TabConfig.hidden
+     */
+    @Serializable
+    @SerialName("setTabHidden")
+    data class SetTabHidden(val tabId: String, val hidden: Boolean) : WindowCommand()
+
+    /**
      * Reorder a tab by moving it before or after another tab via drag-and-drop.
      *
      * @param tabId the id of the tab being moved

--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
@@ -62,6 +62,16 @@ data class TabConfig(
      * "let the client default to the first pane in DOM order".
      */
     val focusedPaneId: String? = null,
+    /**
+     * Whether this tab is hidden from the tab strip. Hidden tabs still exist
+     * (their panes and PTY sessions are preserved) and are still listed in
+     * the tab-bar overflow dropdown so the user can re-activate or unhide
+     * them. Defaults to `false` so existing persisted blobs deserialize as
+     * fully visible. Toggled by [WindowCommand.SetTabHidden].
+     *
+     * @see WindowCommand.SetTabHidden
+     */
+    val hidden: Boolean = false,
 )
 
 /**

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
@@ -872,6 +872,7 @@ private suspend fun handleWindowCommand(text: String, ctx: WindowConnectionConte
         is WindowCommand.AddTab -> WindowState.addTab()
         is WindowCommand.CloseTab -> WindowState.closeTab(cmd.tabId)
         is WindowCommand.RenameTab -> WindowState.renameTab(cmd.tabId, cmd.title)
+        is WindowCommand.SetTabHidden -> WindowState.setTabHidden(cmd.tabId, cmd.hidden)
         is WindowCommand.MoveTab -> WindowState.moveTab(cmd.tabId, cmd.targetTabId, cmd.before)
         is WindowCommand.AddPaneToTab -> {
             // Inherit cwd from the anchor pane so a new terminal split off

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
@@ -399,6 +399,60 @@ object WindowState {
     }
 
     /**
+     * Toggle [TabConfig.hidden] on [tabId]. Hidden tabs are dropped from the
+     * tab strip rendering on the client and surfaced only via the tab-bar
+     * overflow dropdown — the rest of the tab (panes, focus, PTY sessions)
+     * survives untouched.
+     *
+     * Policy:
+     *  - Refuse if the tab id is unknown or the flag is already in the
+     *    requested state (no-op snapshot churn).
+     *  - Refuse if hiding [tabId] would leave zero visible tabs — the strip
+     *    must always have at least one button so the user can navigate.
+     *  - When hiding the currently active tab, switch the active selection
+     *    to the next visible neighbour (preferring the tab that takes the
+     *    same visual slot, mirroring [closeTab]'s neighbour fallback).
+     *
+     * Called from `handleWindowCommand` for [WindowCommand.SetTabHidden].
+     *
+     * @param tabId the id of the tab to hide or unhide
+     * @param hidden `true` to hide, `false` to unhide
+     * @see TabConfig.hidden
+     * @see WindowCommand.SetTabHidden
+     */
+    fun setTabHidden(tabId: String, hidden: Boolean) = synchronized(this) {
+        val cfg = _config.value
+        val idx = cfg.tabs.indexOfFirst { it.id == tabId }
+        if (idx < 0) return@synchronized
+        val tab = cfg.tabs[idx]
+        if (tab.hidden == hidden) return@synchronized
+        // Refuse to hide the last visible tab — the strip must always show
+        // at least one button.
+        if (hidden) {
+            val visibleAfter = cfg.tabs.count { !it.hidden && it.id != tabId }
+            if (visibleAfter == 0) return@synchronized
+        }
+        val newTabs = cfg.tabs.toMutableList()
+        newTabs[idx] = tab.copy(hidden = hidden)
+        // If we just hid the active tab, hop to the next visible neighbour
+        // so the strip still highlights something. Same fallback shape as
+        // closeTab: pick the visible tab whose new index is closest to the
+        // hidden one's old index, biased toward the tab that took its slot.
+        val newActive = if (hidden && cfg.activeTabId == tabId) {
+            val visibleIds = newTabs.filter { !it.hidden }.map { it.id }
+            // Walk forward from the hidden tab's old slot, then backward,
+            // looking for the first visible tab in either direction.
+            val forward = (idx until newTabs.size).firstNotNullOfOrNull { i ->
+                newTabs[i].takeIf { !it.hidden }?.id
+            }
+            forward ?: visibleIds.lastOrNull()
+        } else {
+            cfg.activeTabId
+        }
+        _config.value = cfg.copy(tabs = newTabs, activeTabId = newActive)
+    }
+
+    /**
      * Set the display title of [tabId] to [title] (trimmed, max 80 chars).
      * No-op if the title is empty or unchanged.
      *

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/OverflowMenu.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/OverflowMenu.kt
@@ -1,0 +1,309 @@
+/**
+ * Tab-bar overflow menu for the Termtastic web frontend.
+ *
+ * Anchored at the far-right edge of the tab strip via a static button in
+ * `index.html` (`#tab-overflow-button`). Opens a dropdown containing:
+ *
+ *  1. **Rename** — inline-rename the active tab. Falls back to a
+ *     `window.prompt` when the active tab is hidden (no strip button for
+ *     its label to become an input).
+ *  2. **Close** — close the active tab. Disabled when only one tab exists,
+ *     so the user can't end up with zero tabs. Triggers the same
+ *     confirmation dialog the old per-tab menu used.
+ *  3. **Hide / Unhide** — toggle [TabConfig.hidden] on the active tab.
+ *     Disabled when there is only one visible tab left (the strip must
+ *     always show something). Hiding the active tab makes the server
+ *     switch the active selection to the next visible neighbour — see
+ *     [WindowState.setTabHidden] for the server-side rule.
+ *  4. **A separator**, followed by one entry per hidden tab. Each entry
+ *     shows the content-kind icon of the tab's first pane (via
+ *     [iconSvgForLeafKind]) so the user can tell a file-browser tab from
+ *     a terminal tab at a glance. Clicking an entry sends
+ *     [WindowCommand.SetActiveTab] — the tab becomes active but stays
+ *     hidden; the user chooses whether to unhide afterwards.
+ *
+ * This file replaces the per-tab hover-menu that used to open next to each
+ * tab label. The overflow menu is a single, always-reachable affordance
+ * that doesn't steal horizontal space from the tab strip the way the old
+ * hover icon did.
+ *
+ * @see WindowCommand.SetTabHidden for the hide/unhide command
+ * @see WindowCommand.SetActiveTab for the activate-hidden-tab path
+ * @see iconSvgForLeafKind for the per-kind icon used in the hidden list
+ * @see renderConfig the tab-strip renderer that skips `hidden == true` tabs
+ */
+package se.soderbjorn.termtastic
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.HTMLElement
+
+/** Pencil glyph for the "Rename tab" row. Stroke-only so it inherits the
+ *  menu row's `currentColor`. Sized to match the 14×14 leaf icons. */
+private val ICON_OVERFLOW_PENCIL =
+    """<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 13.5l1-3 7-7a1.4 1.4 0 0 1 2 2l-7 7-3 1z"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5"/></svg>"""
+
+/** Close (X) glyph for the "Close tab" row. Mirrors the pane-header close
+ *  icon style at 14×14 instead of 16×16 so it fits inline with the leaf-
+ *  kind icons used for hidden tabs. */
+private val ICON_OVERFLOW_CLOSE =
+    """<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>"""
+
+/** Eye-with-slash glyph for the "Hide tab" row — same eye outline as
+ *  [ICON_OVERFLOW_EYE] with a diagonal strike-through. */
+private val ICON_OVERFLOW_EYE_OFF =
+    """<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8c1.6-2.5 3.6-4 6-4s4.4 1.5 6 4c-1.6 2.5-3.6 4-6 4s-4.4-1.5-6-4z"/><circle cx="8" cy="8" r="1.6"/><line x1="2.5" y1="13.5" x2="13.5" y2="2.5"/></svg>"""
+
+/** Open-eye glyph for the "Unhide tab" row. Identical to [ICON_OVERFLOW_EYE_OFF]
+ *  minus the slash so the toggled state reads at a glance. */
+private val ICON_OVERFLOW_EYE =
+    """<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8c1.6-2.5 3.6-4 6-4s4.4 1.5 6 4c-1.6 2.5-3.6 4-6 4s-4.4-1.5-6-4z"/><circle cx="8" cy="8" r="1.6"/></svg>"""
+
+/**
+ * Wire up the overflow-button click and outside-click/Esc dismissal.
+ *
+ * Called once from [main.kt][main] at boot after the rest of the header
+ * toolbar has been initialised. The click handlers stay attached for the
+ * lifetime of the page.
+ *
+ * @see populateTabOverflowMenu for the menu body rebuild
+ */
+fun initTabOverflowMenu() {
+    val wrap = document.getElementById("tab-overflow-dropdown") as? HTMLElement ?: return
+    val button = document.getElementById("tab-overflow-button") as? HTMLElement ?: return
+    val menu = document.getElementById("tab-overflow-menu") as? HTMLElement ?: return
+
+    button.addEventListener("click", { ev ->
+        ev.stopPropagation()
+        if (wrap.classList.contains("open")) {
+            wrap.classList.remove("open")
+        } else {
+            populateTabOverflowMenu(menu)
+            wrap.classList.add("open")
+        }
+    })
+
+    // Close on any outside click / Esc. Same pattern as the layout menu.
+    document.addEventListener("click", { ev ->
+        val t = ev.target as? HTMLElement ?: return@addEventListener
+        if (wrap.contains(t)) return@addEventListener
+        wrap.classList.remove("open")
+    })
+    document.addEventListener("keydown", { ev ->
+        val key = ev.asDynamic().key as? String ?: return@addEventListener
+        if (key == "Escape") wrap.classList.remove("open")
+    })
+}
+
+/**
+ * Rebuild the menu body against the current server config every time the
+ * dropdown opens. Kept fresh (rather than wired once at init) so the hidden
+ * tab list reflects the latest push and the Hide/Unhide item label tracks
+ * the active tab's current state.
+ *
+ * @param menu the `#tab-overflow-menu` container element
+ */
+private fun populateTabOverflowMenu(menu: HTMLElement) {
+    menu.innerHTML = ""
+    val cfg = currentConfig
+    if (cfg == null) {
+        menu.appendChild(emptyOverflowItem("No tabs"))
+        return
+    }
+
+    val tabsArr = (cfg.tabs as? Array<dynamic>) ?: emptyArray()
+    if (tabsArr.isEmpty()) {
+        menu.appendChild(emptyOverflowItem("No tabs"))
+        return
+    }
+
+    val active = activeTabId
+    val activeTab = tabsArr.firstOrNull { (it.id as? String) == active }
+    val totalTabs = tabsArr.size
+    val visibleTabs = tabsArr.count { (it.hidden as? Boolean) != true }
+    val activeHidden = (activeTab?.hidden as? Boolean) == true
+
+    // --- Active-tab actions ---------------------------------------------
+
+    val renameItem = buildActionItem(
+        label = "Rename tab",
+        iconSvg = ICON_OVERFLOW_PENCIL,
+        enabled = activeTab != null,
+    ) {
+        val tabId = activeTab?.id as? String ?: return@buildActionItem
+        val tabBar = tabBarEl
+        val labelEl = tabBar?.querySelector(
+            ".tab-button[data-tab=\"$tabId\"] .tab-label"
+        ) as? HTMLElement
+        if (labelEl != null) {
+            startTabRename(labelEl, tabId)
+        } else {
+            // Active tab is hidden so has no strip label to edit inline.
+            // Fall back to a browser prompt; same effect, uglier UX.
+            val current = (activeTab.title as? String) ?: ""
+            val next = window.prompt("Rename tab", current) ?: return@buildActionItem
+            val trimmed = next.trim()
+            if (trimmed.isEmpty() || trimmed == current) return@buildActionItem
+            launchCmd(WindowCommand.RenameTab(tabId = tabId, title = trimmed))
+        }
+    }
+    menu.appendChild(renameItem)
+
+    val closeItem = buildActionItem(
+        label = "Close tab",
+        iconSvg = ICON_OVERFLOW_CLOSE,
+        // Server refuses if only one tab exists (the UI has no path out of
+        // zero tabs). Grey it out here for parity.
+        enabled = activeTab != null && totalTabs > 1,
+    ) {
+        val tabId = activeTab?.id as? String ?: return@buildActionItem
+        val tabTitle = (activeTab.title as? String) ?: ""
+        showConfirmDialog(
+            "Close tab",
+            "Are you sure you want to close tab <strong>${tabTitle}</strong> and all its panes?",
+            "Close",
+        ) {
+            launchCmd(WindowCommand.CloseTab(tabId = tabId))
+        }
+    }
+    menu.appendChild(closeItem)
+
+    val hideLabel = if (activeHidden) "Unhide tab" else "Hide tab"
+    val hideIcon = if (activeHidden) ICON_OVERFLOW_EYE else ICON_OVERFLOW_EYE_OFF
+    // Hiding the last visible tab would leave the strip empty. The server
+    // refuses it; the client also disables the menu entry so the user gets
+    // immediate feedback instead of a silent no-op.
+    val hideEnabled = activeTab != null && (activeHidden || visibleTabs > 1)
+    val hideItem = buildActionItem(
+        label = hideLabel,
+        iconSvg = hideIcon,
+        enabled = hideEnabled,
+    ) {
+        val tabId = activeTab?.id as? String ?: return@buildActionItem
+        launchCmd(WindowCommand.SetTabHidden(tabId = tabId, hidden = !activeHidden))
+    }
+    menu.appendChild(hideItem)
+
+    // --- Hidden tab list ------------------------------------------------
+
+    val hiddenTabs = tabsArr.filter { (it.hidden as? Boolean) == true }
+    if (hiddenTabs.isEmpty()) return
+
+    val separator = document.createElement("div") as HTMLElement
+    separator.className = "tab-overflow-separator"
+    separator.setAttribute("role", "separator")
+    menu.appendChild(separator)
+
+    val header = document.createElement("div") as HTMLElement
+    header.className = "tab-overflow-section-header"
+    header.textContent = "Hidden tabs"
+    menu.appendChild(header)
+
+    for (tab in hiddenTabs) {
+        val tabId = tab.id as? String ?: continue
+        val title = (tab.title as? String) ?: ""
+        val panes = (tab.panes as? Array<dynamic>) ?: emptyArray()
+        // Pick the first pane's content kind for the row icon. Empty tabs
+        // fall back to the terminal icon (same default the sidebar uses).
+        val firstLeaf = panes.firstOrNull()?.leaf
+        val kind = (firstLeaf?.content?.kind as? String) ?: "terminal"
+        val isLinked = (firstLeaf?.isLink as? Boolean) ?: false
+
+        val row = document.createElement("button") as HTMLElement
+        row.className = "tab-overflow-item tab-overflow-hidden-tab"
+        row.setAttribute("type", "button")
+        row.setAttribute("data-tab", tabId)
+        row.setAttribute("title", "Activate '$title' (stays hidden)")
+
+        val iconSpan = document.createElement("span") as HTMLElement
+        iconSpan.className = "tab-overflow-item-icon"
+        iconSpan.innerHTML = iconSvgForLeafKind(kind, isLinked)
+        row.appendChild(iconSpan)
+
+        val labelSpan = document.createElement("span") as HTMLElement
+        labelSpan.className = "tab-overflow-item-label"
+        labelSpan.textContent = title
+        row.appendChild(labelSpan)
+
+        row.addEventListener("click", { ev ->
+            ev.stopPropagation()
+            closeOverflowMenu()
+            // Activate the hidden tab. It stays hidden — the user unhides
+            // separately via the Hide/Unhide item once it's active. Per
+            // issue #2: "A tab that is hidden is not shown on the tab strip.
+            // It's shown only in the dropdown instead."
+            setActiveTab(tabId)
+        })
+        menu.appendChild(row)
+    }
+}
+
+/**
+ * Build a standard action row (Rename / Close / Hide). Centralised so every
+ * row gets the same class list, icon slot, disabled behaviour, and click
+ * plumbing.
+ *
+ * @param label text shown on the row
+ * @param iconSvg inline SVG markup for the leading icon. The icon inherits
+ *   `currentColor` so disabled rows (which dim the row's text) also dim
+ *   the icon. The issue spec requires every menu item to carry an icon.
+ * @param enabled when `false`, the row renders disabled and its click is a
+ *   no-op — matches server-side refusals so the UI never lies to the user
+ * @param onClick handler fired when the row is clicked and enabled; the
+ *   menu is closed before the handler runs
+ * @return the fully-wired HTML element, ready to append to the menu
+ */
+private fun buildActionItem(
+    label: String,
+    iconSvg: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+): HTMLElement {
+    val item = document.createElement("button") as HTMLElement
+    item.className = "tab-overflow-item tab-overflow-action"
+    item.setAttribute("type", "button")
+
+    val iconSpan = document.createElement("span") as HTMLElement
+    iconSpan.className = "tab-overflow-item-icon"
+    iconSpan.innerHTML = iconSvg
+    item.appendChild(iconSpan)
+
+    val labelSpan = document.createElement("span") as HTMLElement
+    labelSpan.className = "tab-overflow-item-label"
+    labelSpan.textContent = label
+    item.appendChild(labelSpan)
+
+    if (!enabled) {
+        item.classList.add("disabled")
+        item.setAttribute("aria-disabled", "true")
+    }
+    item.addEventListener("click", { ev ->
+        ev.stopPropagation()
+        if (!enabled) return@addEventListener
+        closeOverflowMenu()
+        onClick()
+    })
+    return item
+}
+
+/**
+ * Render a placeholder row for the rare case where the menu opens but there
+ * are no tabs (should not happen in practice — the server never lets the
+ * window drop to zero tabs — but the menu renders gracefully if it does).
+ */
+private fun emptyOverflowItem(text: String): HTMLElement {
+    val el = document.createElement("div") as HTMLElement
+    el.className = "tab-overflow-empty"
+    el.textContent = text
+    return el
+}
+
+/**
+ * Close the overflow dropdown if it is open. Called after any click on a
+ * menu row so the user sees immediate dismissal even before the server
+ * pushes a new config.
+ */
+private fun closeOverflowMenu() {
+    val wrap = document.getElementById("tab-overflow-dropdown") as? HTMLElement ?: return
+    wrap.classList.remove("open")
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
@@ -72,9 +72,14 @@ fun startRename(titleEl: HTMLElement, paneId: String) {
 /**
  * Starts an inline rename interaction for a tab label.
  *
- * Similar to [startRename] but operates on tab labels in the tab bar. Closes
- * any open tab menus, adds a "renaming" CSS class during editing, and sends
- * [WindowCommand.RenameTab] to the server on commit.
+ * Similar to [startRename] but operates on tab labels in the tab bar. Adds
+ * a "renaming" CSS class during editing and sends [WindowCommand.RenameTab]
+ * to the server on commit.
+ *
+ * Called from the tab-bar overflow dropdown's "Rename tab" item via
+ * [populateTabOverflowMenu] when the active tab is currently visible (has
+ * a strip button); the overflow menu falls back to a `window.prompt` for
+ * hidden active tabs since they have no on-screen label to mutate.
  *
  * @param labelEl the DOM element displaying the current tab label
  * @param tabId the unique tab identifier for the rename command
@@ -84,8 +89,6 @@ fun startTabRename(labelEl: HTMLElement, tabId: String) {
     val current = labelEl.textContent ?: ""
     val parent = labelEl.parentElement ?: return
     parent.classList.add("renaming")
-    val openMenu = parent.querySelector(".tab-menu.open") as? HTMLElement
-    openMenu?.classList?.remove("open")
     val input = document.createElement("input") as HTMLInputElement
     input.type = "text"
     input.className = "tab-label-input"

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Sidebar.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Sidebar.kt
@@ -43,6 +43,31 @@ fun collectLeaves(leaf: dynamic, into: MutableList<LeafInfo>) {
 }
 
 /**
+ * Returns the inline SVG markup for the icon that represents a leaf of the
+ * given content kind. Centralised so the sidebar tree and the tab-bar
+ * overflow dropdown render identical icons for the same pane type.
+ *
+ * @param contentKind the leaf's content kind ("terminal", "fileBrowser", "git").
+ *   Unknown values fall back to the terminal icon.
+ * @param isLink `true` if this leaf is a linked view of another session;
+ *   takes precedence over a plain "terminal" kind so linked terminals show
+ *   the chain icon instead of the terminal icon. Ignored when [contentKind]
+ *   is "fileBrowser" or "git" (those keep their own icons).
+ * @return inline `<svg>...</svg>` markup with `currentColor` strokes/fills,
+ *   ready to drop into an `innerHTML` assignment.
+ */
+fun iconSvgForLeafKind(contentKind: String, isLink: Boolean): String = when {
+    contentKind == "fileBrowser" ->
+        """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M2 4.5 a0.5 0.5 0 0 1 0.5 -0.5 h3.5 l1.25 1.75 h6.25 a0.5 0.5 0 0 1 0.5 0.5 v7.25 a0.5 0.5 0 0 1 -0.5 0.5 H2.5 a0.5 0.5 0 0 1 -0.5 -0.5 Z"/></svg>"""
+    contentKind == "git" ->
+        """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><circle cx="5" cy="4" r="1.5"/><circle cx="5" cy="12" r="1.5"/><circle cx="11" cy="8" r="1.5"/><line x1="5" y1="5.5" x2="5" y2="10.5"/><path d="M5 5.5 C5 8 8 8 9.5 8"/></svg>"""
+    isLink ->
+        """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M6.5 9.5a3 3 0 0 0 4.24 0l2.5-2.5a3 3 0 0 0-4.24-4.24L7.5 3.76"/><path d="M9.5 6.5a3 3 0 0 0-4.24 0l-2.5 2.5a3 3 0 0 0 4.24 4.24l1-1"/></svg>"""
+    else ->
+        """<svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14"><rect x="1" y="2" width="14" height="12" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.3"/><polyline points="4,7 6,5 4,3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><line x1="7" y1="7" x2="11" y2="7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>"""
+}
+
+/**
  * Re-renders the entire sidebar tree from the current server configuration.
  *
  * Builds a collapsible tree with tab headers and pane items. Tab sections can
@@ -126,15 +151,7 @@ fun renderSidebar(config: dynamic) {
 
             val icon = document.createElement("span") as HTMLElement
             icon.className = "sidebar-pane-icon"
-            icon.innerHTML = if (contentKind == "fileBrowser") {
-                """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M2 4.5 a0.5 0.5 0 0 1 0.5 -0.5 h3.5 l1.25 1.75 h6.25 a0.5 0.5 0 0 1 0.5 0.5 v7.25 a0.5 0.5 0 0 1 -0.5 0.5 H2.5 a0.5 0.5 0 0 1 -0.5 -0.5 Z"/></svg>"""
-            } else if (contentKind == "git") {
-                """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><circle cx="5" cy="4" r="1.5"/><circle cx="5" cy="12" r="1.5"/><circle cx="11" cy="8" r="1.5"/><line x1="5" y1="5.5" x2="5" y2="10.5"/><path d="M5 5.5 C5 8 8 8 9.5 8"/></svg>"""
-            } else if (isLinked) {
-                """<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M6.5 9.5a3 3 0 0 0 4.24 0l2.5-2.5a3 3 0 0 0-4.24-4.24L7.5 3.76"/><path d="M9.5 6.5a3 3 0 0 0-4.24 0l-2.5 2.5a3 3 0 0 0 4.24 4.24l1-1"/></svg>"""
-            } else {
-                """<svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14"><rect x="1" y="2" width="14" height="12" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.3"/><polyline points="4,7 6,5 4,3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><line x1="7" y1="7" x2="11" y2="7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>"""
-            }
+            icon.innerHTML = iconSvgForLeafKind(contentKind, isLinked)
             item.appendChild(icon)
 
             val sidebarSpinner = document.createElement("span") as HTMLElement

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
@@ -250,15 +250,18 @@ fun renderConfig(config: dynamic) {
 
     val savedIndicator = tabBar.querySelector(".tab-active-indicator") as? HTMLElement
     savedIndicator?.let { it.parentElement?.removeChild(it) }
-    val staleMenus = document.querySelectorAll(".tab-menu-list, .pane-split-flyout")
-    for (i in 0 until staleMenus.length) {
-        val el = staleMenus.item(i) as HTMLElement; el.parentElement?.removeChild(el)
+    val stalePaneMenus = document.querySelectorAll(".pane-split-flyout")
+    for (i in 0 until stalePaneMenus.length) {
+        val el = stalePaneMenus.item(i) as HTMLElement; el.parentElement?.removeChild(el)
     }
     tabBar.innerHTML = ""
-    val canCloseTab = tabsArr.size > 1
     val renderedTabIds = HashSet<String>()
 
+    // Hidden tabs are excluded from the strip. They still get a content
+    // section below (so a hidden+active tab keeps rendering its panes) and
+    // they're surfaced through the tab-bar overflow dropdown.
     for (tab in tabsArr) {
+        if (tab.hidden as? Boolean == true) continue
         val tabId = tab.id as String
         val title = tab.title as String
         val tabWrap = document.createElement("div") as HTMLElement
@@ -335,57 +338,6 @@ fun renderConfig(config: dynamic) {
             launchCmd(WindowCommand.MoveTab(tabId = sourceId, targetTabId = tabId, before = before))
         })
 
-        run {
-            val menuWrap = document.createElement("div") as HTMLElement
-            menuWrap.className = "tab-menu"
-            val menuBtn = document.createElement("button") as HTMLElement
-            menuBtn.className = "tab-menu-button"; menuBtn.setAttribute("type", "button")
-            menuBtn.setAttribute("title", "Tab menu"); menuBtn.textContent = "\u22EF"
-            val menuList = document.createElement("div") as HTMLElement
-            menuList.className = "tab-menu-list"
-
-            val renameItem = document.createElement("div") as HTMLElement
-            renameItem.className = "tab-menu-item"; renameItem.textContent = "Rename tab"
-            renameItem.addEventListener("click", { ev ->
-                ev.stopPropagation(); menuWrap.classList.remove("open"); menuList.classList.remove("open")
-                startTabRename(label, tabId)
-            })
-            menuList.appendChild(renameItem)
-
-            if (canCloseTab) {
-                val closeItem = document.createElement("div") as HTMLElement
-                closeItem.className = "tab-menu-item"; closeItem.textContent = "Close tab"
-                closeItem.addEventListener("click", { ev ->
-                    ev.stopPropagation(); menuWrap.classList.remove("open"); menuList.classList.remove("open")
-                    showConfirmDialog("Close tab", "Are you sure you want to close tab <strong>${title}</strong> and all its panes?", "Close") {
-                        tabWrap.classList.add("leaving")
-                        window.setTimeout({ launchCmd(WindowCommand.CloseTab(tabId = tabId)) }, 220)
-                    }
-                })
-                menuList.appendChild(closeItem)
-            }
-
-            menuBtn.addEventListener("click", { ev ->
-                ev.stopPropagation()
-                val openWraps = document.querySelectorAll(".tab-menu.open, .pane-menu.open")
-                for (i in 0 until openWraps.length) { val other = openWraps.item(i) as HTMLElement; if (other !== menuWrap) other.classList.remove("open") }
-                val openLists = document.querySelectorAll(".tab-menu-list.open")
-                for (i in 0 until openLists.length) { val other = openLists.item(i) as HTMLElement; if (other !== menuList) other.classList.remove("open") }
-                val opening = !menuWrap.classList.contains("open")
-                menuWrap.classList.toggle("open"); menuList.classList.toggle("open")
-                if (opening) {
-                    val listWidth = menuList.asDynamic().offsetWidth as Number
-                    val rect = menuBtn.asDynamic().getBoundingClientRect()
-                    val right = rect.right as Double; val bottom = rect.bottom as Double
-                    val leftPos = (right - listWidth.toDouble()).coerceAtLeast(4.0)
-                    menuList.style.left = "${leftPos}px"; menuList.style.top = "${bottom + 4}px"
-                }
-            })
-            menuBtn.setAttribute("draggable", "false")
-            menuBtn.addEventListener("dragstart", { ev -> ev.preventDefault(); ev.stopPropagation() })
-            menuWrap.appendChild(menuBtn); tabWrap.appendChild(menuWrap)
-            document.body?.appendChild(menuList)
-        }
         tabBar.appendChild(tabWrap)
     }
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
@@ -639,6 +639,11 @@ private fun start() {
     // Layout dropdown in the header toolbar.
     initLayoutMenu()
 
+    // Tab-bar overflow (three-dots) dropdown. Anchored at the far right of
+    // the tab strip; exposes rename/close/hide-or-unhide for the active tab
+    // and lists hidden tabs so they can be re-activated.
+    initTabOverflowMenu()
+
     // Connect and go.
     connectWindow()
 

--- a/web/src/jsMain/resources/index.html
+++ b/web/src/jsMain/resources/index.html
@@ -27,6 +27,25 @@
                  tab buttons. Skipped during the first paint (no width). -->
             <div class="tab-active-indicator" aria-hidden="true"></div>
         </nav>
+        <!-- Tab overflow menu. Anchored to the far-right edge of the tab
+             strip (outside the scrolling nav so it's always visible). Opens
+             a dropdown with Rename / Close / Hide-or-Unhide for the active
+             tab, followed by one entry per hidden tab so the user can
+             re-activate a hidden tab from here. Wired up by
+             initTabOverflowMenu() at boot. -->
+        <div class="dropdown" id="tab-overflow-dropdown">
+            <button class="icon-button" id="tab-overflow-button" type="button"
+                    title="Tab menu">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                     viewBox="0 0 24 24" fill="currentColor"
+                     aria-hidden="true">
+                    <circle cx="12" cy="5" r="1.6"/>
+                    <circle cx="12" cy="12" r="1.6"/>
+                    <circle cx="12" cy="19" r="1.6"/>
+                </svg>
+            </button>
+            <div class="dropdown-menu tab-overflow-menu" id="tab-overflow-menu" role="menu"></div>
+        </div>
         <div class="header-actions">
             <!-- Debug menu. Only shown on dev server (JS checks at boot). -->
             <div class="dropdown" id="debug-dropdown" style="display: none;">

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -259,8 +259,7 @@ body.appearance-light *::-webkit-scrollbar-thumb:hover {
 .app-header .icon-button,
 .app-header .tab-button,
 .app-header .dropdown,
-.app-header .dropdown-menu,
-.app-header .tab-menu-list {
+.app-header .dropdown-menu {
     -webkit-app-region: no-drag;
     app-region: no-drag;
 }
@@ -460,86 +459,6 @@ body.is-electron-mac .app-header {
     z-index: 1;
 }
 
-/* The menu element is attached to every tab (active and inactive) so every
-   tab reserves the same horizontal space for the ⋯ button — the box never
-   resizes when the active class flips or the user hovers. At rest the
-   glyph is just `visibility: hidden`; it fades in after ~1.5s of hover on
-   the active tab. */
-.tab-menu {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    visibility: hidden;
-}
-
-.tab-button.active:hover .tab-menu {
-    visibility: visible;
-    /* The delay applies on the hover-in transition; on hover-out there is
-       no transition, so the button disappears immediately. */
-    transition: visibility 0s linear 1.5s;
-}
-
-/* Suppress the ⋯ button entirely while the tab is being renamed. */
-.tab-button.renaming .tab-menu {
-    visibility: hidden !important;
-}
-
-/* Once opened, force visibility regardless of hover state so the menu
-   stays put while the dropdown is on screen. */
-.tab-menu.open {
-    visibility: visible !important;
-}
-
-.tab-menu-button {
-    appearance: none;
-    background: transparent;
-    border: none;
-    color: inherit;
-    font-family: inherit;
-    font-size: 14px;
-    line-height: 1;
-    cursor: pointer;
-    padding: 2px 6px;
-    border-radius: 4px;
-    letter-spacing: 1px;
-}
-
-.tab-menu-button:hover {
-    background: var(--separator);
-}
-
-.tab-menu-list {
-    display: none;
-    /* The .tab-bar ancestor uses overflow-x:auto, which would clip an
-       absolutely-positioned dropdown. Render it as a fixed-position layer
-       and let JS place it at the button's screen rect. */
-    position: fixed;
-    top: 0;
-    left: 0;
-    min-width: 160px;
-    background: var(--surface);
-    border: 1px solid var(--separator);
-    border-radius: 6px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
-    padding: 4px;
-    z-index: 1000;
-}
-
-.tab-menu-list.open {
-    display: block;
-}
-
-.tab-menu-item {
-    padding: 6px 10px;
-    border-radius: 4px;
-    font-size: 12px;
-    color: var(--text-primary);
-    cursor: pointer;
-}
-
-.tab-menu-item:hover {
-    background: var(--separator);
-}
 
 .tab-button {
     position: relative;
@@ -1389,6 +1308,100 @@ body.is-electron-mac .app-header {
 /* Dropdowns in header */
 .dropdown {
     position: relative;
+}
+
+/* Tab-bar overflow dropdown sits between the (flex:1) tab strip and the
+   (margin-left:auto) header-actions cluster. Bottom-align it so the three-
+   dots button sits flush with the tab buttons rather than floating up to
+   the top of the header. */
+#tab-overflow-dropdown {
+    align-self: flex-end;
+    flex-shrink: 0;
+    margin-bottom: 1px;
+}
+
+#tab-overflow-button {
+    height: 30px;
+    width: 30px;
+    padding: 0;
+    border-radius: 6px;
+}
+
+/* The overflow menu reuses the .dropdown-menu base for positioning,
+   border, and background; these rules tune width and item layout. */
+.tab-overflow-menu {
+    min-width: 220px;
+    padding: 6px;
+}
+
+.tab-overflow-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 7px 10px;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 13px;
+    text-align: left;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.tab-overflow-item:hover {
+    background: var(--separator);
+}
+
+.tab-overflow-item.disabled {
+    color: var(--text-secondary);
+    opacity: 0.5;
+    cursor: default;
+}
+
+.tab-overflow-item.disabled:hover {
+    background: transparent;
+}
+
+.tab-overflow-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.tab-overflow-item-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.tab-overflow-separator {
+    height: 1px;
+    background: var(--separator);
+    margin: 6px 4px;
+}
+
+.tab-overflow-section-header {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    padding: 4px 10px 6px;
+}
+
+.tab-overflow-empty {
+    padding: 10px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    text-align: center;
 }
 
 .icon-button {


### PR DESCRIPTION
Closes #2

## Summary
Replaces the old per-tab hover menu with a single global "⋮" overflow button at the far-right edge of the tab strip. The dropdown carries Rename / Close / Hide-or-Unhide actions for the active tab plus a separator and one entry per hidden tab so the user can re-activate hidden tabs from one always-reachable place. Tabs flagged as hidden are dropped from the strip rendering but still keep their content area, so an active+hidden tab keeps showing its panes.

## Background
From the issue: a new far-right three-dots button should open a dropdown containing Rename / Close / Hide-or-Unhide (state-dependent), a separator, and the list of all hidden tabs (each shown with its type-dependent icon). A hidden tab is not rendered on the strip, only in the dropdown. The previous per-tab hover-to-the-right-of-the-label menu — and the horizontal space its hover icon reserved on every tab — is to be discarded.

The issue is short on UX edge cases (e.g. what happens when the active tab gets hidden, what the menu shows for a hidden+active tab, what to do about hiding the last visible tab). The "Decisions & reasoning" section below records every interpretation I made.

## Approach
The change spans four layers:

1. **Data model (`clientServer/.../WindowConfig.kt`)** — add `hidden: Boolean = false` to `TabConfig`. Default false means existing persisted blobs deserialize as fully visible — no migration needed.

2. **Wire protocol (`clientServer/.../WindowCommand.kt`)** — new `WindowCommand.SetTabHidden(tabId, hidden)` mutation, wired through `Application.handleWindowCommand` to a new `WindowState.setTabHidden(tabId, hidden)` server function. The server refuses to hide the last visible tab and hops the active selection to the next visible neighbour when the active tab is hidden — same fallback shape as `closeTab`.

3. **Tab strip rendering (`web/.../WindowConnection.kt`)** — the strip render loop now skips tabs with `hidden == true`. The content section loop is unchanged, so an active+hidden tab still renders its panes (the active indicator just hides, since `positionActiveIndicator` already handles a missing `.tab-button.active` gracefully). The whole `run { ... }` block that built the per-tab `.tab-menu`, hover button, and floating menu list is gone, along with its CSS.

4. **Overflow menu (`web/.../OverflowMenu.kt`, new)** — a single dropdown wired up in `index.html` between the tab strip and the header actions cluster. `initTabOverflowMenu()` is called once at boot; `populateTabOverflowMenu()` rebuilds the body on every open so the hidden-tab list and the Hide/Unhide label always reflect the latest server push. Each row carries an inline-SVG icon per the issue spec (pencil for Rename, X for Close, eye / eye-with-slash for Unhide / Hide, and per-pane-kind icons for hidden tabs).

A small refactor extracts the shared leaf-icon SVG palette from `Sidebar.kt` into `iconSvgForLeafKind(contentKind, isLink)` so the sidebar tree and the new overflow dropdown render identical icons for the same pane type.

## Decisions & reasoning

### Hidden flag lives on `TabConfig`, not in a separate UI-settings blob
Hidden is per-tab and changes transactionally with tab creation/closure; storing it inside the same `WindowConfig` JSON blob means it persists in lock-step with the rest of the tab state and survives server restarts via the existing debounced save flow. Putting it in the `ui.settings.v1` blob (which `SettingsRepository` keeps for sidebar collapse state, appearance, etc.) would have introduced a separate persistence path the client would have to keep coherent with the tab list, and the memory note "all UI settings stored server-side in SQLite only" explicitly endorses the existing tab-config blob as the right home.

### Hiding the active tab auto-switches to the next visible neighbour
The alternative is to allow `active && hidden` quietly. I went with auto-switching for the *Hide* action because:
  1. It mirrors how `CloseTab` already behaves (the user lands on a neighbour, never on nothing).
  2. It keeps the strip visually meaningful — there is always a highlighted tab unless the user explicitly activates a hidden one from the dropdown.

The active+hidden state is still reachable: clicking a hidden tab in the dropdown activates it without unhiding (so the user can preview a hidden tab without committing to restoring it). This is the only path into the active+hidden state, and the menu's Hide → "Unhide" toggle handles the exit.

### Refuse to hide the last visible tab (server *and* client)
Keeping at least one tab on the strip avoids the dead-end UX where the strip is empty and the only way to recover is the dropdown. The server rejects the command and the client also disables the menu item, so the user gets immediate feedback instead of a silent no-op. Same posture as `CloseTab` refusing to close the last tab.

### Single global overflow button vs. one-per-tab menu
The issue asks for "a new button at the far right with the three dots as a label" — singular, far-right. A per-tab variant would have brought back the very horizontal-space tax we just removed. The single button means Rename / Close / Hide always operate on the *active* tab. To rename or close an inactive tab, the user clicks it first to make it active. This is a small UX regression for editing inactive tab titles, but it keeps the strip uncluttered and matches the issue's wording.

### Overflow dropdown anchored *outside* the scrolling tab bar
The tab bar uses `flex: 1` plus horizontal scroll for overflow tabs. Placing the new button *inside* the bar would let it scroll out of view exactly when the user has lots of tabs (the case where they most want to hide some of them). Placing it in the header between the tab bar and `.header-actions` keeps it always reachable; with `align-self: flex-end` it sits flush with the tab buttons.

### Rename for a hidden+active tab falls back to `window.prompt`
`startTabRename` mutates the tab's strip label into an `<input>`. A hidden tab has no label to mutate. Three options: (a) auto-unhide first, (b) build a custom in-app dialog, (c) browser `window.prompt`. Option (a) silently changes user state (the tab unhides without an explicit ask). Option (b) is more code than the rare flow warrants. Option (c) is ugly but functional and obvious. Picked (c) — if the flow proves common in practice, an in-app dialog is a one-file follow-up.

### Per-hidden-tab icon = first-pane content kind
Tabs do not have an intrinsic type — only their panes do. The issue says hidden tabs "will have their ordinary type-dependent icon", so I picked the most natural single-icon mapping: the first pane's content kind, with `terminal` as the fallback for empty tabs. This matches what the sidebar does conceptually (icon-per-pane) compressed to one-icon-per-tab. A composite "stack of icons" would have been fancier but not asked for.

### Click a hidden tab → activate without unhiding
The issue says "It's shown only in the dropdown instead" but doesn't specify what clicking it does. Activating without unhiding lets the user *preview* a hidden tab from the dropdown without committing to restoring it (and the Hide/Unhide toggle then becomes "Unhide", giving them the explicit path back). The alternative — auto-unhide on activation — would never let the user view a hidden tab without immediately altering its hidden state.

### Refactor `iconSvgForLeafKind` rather than duplicate the SVGs
The four leaf icons (terminal / file browser / git / link) were inline literals in `Sidebar.kt`. I needed identical icons in `OverflowMenu.kt`. Pulling them into a shared function keeps the two surfaces from drifting; future changes to the icon set live in one place.

## Assumptions
- Existing persisted `WindowConfig` blobs in users' SQLite databases will deserialize cleanly with `hidden = false` (kotlinx-serialization treats absent fields as the default).
- The existing Hide/Unhide toggle on the *active* tab is the most natural place for the action; no per-tab right-click menu in the strip is required. (The issue does not mention one.)
- The horizontal space saved by removing the per-tab `.tab-menu` is welcome — the issue explicitly asks for it. No existing UX flow depends on the hover icon being there.

## Alternatives considered and rejected
- **Per-tab right-click context menu** — would re-introduce a per-tab menu surface immediately after the issue asked us to remove one; not in the spec.
- **Auto-unhide a hidden tab on activation from the dropdown** — would prevent any "preview without unhiding" flow.
- **Move the overflow button inside the tab bar (right of `+`)** — scrolls out of view when there are many tabs, defeating the purpose.
- **Parallel `ui.settings.v1` storage for the hidden flags** — splits the source of truth; server would have to merge two stores on every render.

## Verification
- `./gradlew :clientServer:compileKotlinJvm :server:compileKotlin :web:compileKotlinJs` — BUILD SUCCESSFUL. Only pre-existing warnings (`@DelicateApi` notes in unrelated files).
- `./gradlew :clientServer:assemble :web:jsBrowserDevelopmentWebpack` — BUILD SUCCESSFUL on JS bundle and Kotlin/Native iOS framework links, so the data-model addition doesn't break iOS or the web bundler.
- `./gradlew :server:test` — BUILD SUCCESSFUL (the existing `StateDetectorTest` passes; no new tests added — `WindowState.setTabHidden` is small enough that the policy is enforced in a single function readable end-to-end, and the existing `WindowState` has no test scaffolding to extend).
- **Gap:** I did not exercise the dropdown end-to-end in a live browser session — I have no way to launch the server + open `localhost` in this environment. Flows that should be eyeballed before merge:
  1. Open the menu, click Hide on the active tab, confirm the strip drops the tab and the next visible tab takes over as active.
  2. Open the menu again, click the now-listed hidden tab, confirm it activates (its panes show up) and the orange ring disappears from the strip.
  3. Click Unhide, confirm the tab reappears in the strip with the ring back on it.
  4. Try to hide when only one visible tab remains — the menu item should appear greyed out.
  5. Rename + Close still work for the active tab (they go through the same server commands as before).

## Files of note
- `web/.../OverflowMenu.kt` — new file; the dropdown's controller plus the four leading-icon SVG literals (pencil, X, eye, eye-off).
- `web/.../WindowConnection.kt` — strip render now skips hidden tabs; the entire per-tab `.tab-menu` block is deleted.
- `web/.../Sidebar.kt` — `iconSvgForLeafKind()` extracted; the existing render call site is one line shorter.
- `server/.../WindowState.kt` — new `setTabHidden()` with the last-visible refusal and active-hop policy.
- `web/.../resources/styles.css` — new `.tab-overflow-*` rules; the dead `.tab-menu*` block is deleted.
- `web/.../resources/index.html` — new `<div id="tab-overflow-dropdown">` between the tab nav and `.header-actions`.

## Follow-ups
- Replace the `window.prompt` fallback for renaming a hidden+active tab with a small in-app dialog if the flow turns out to be common.
- Consider a quick "Unhide" affordance on each hidden-tab row in the dropdown (e.g. an inline icon button) so the user does not have to activate-then-unhide.
- The shared leaf-icon palette in `iconSvgForLeafKind` is a natural home for any future pane content kinds — adding one means updating just that function instead of two surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)