### PR TITLE
Delay split-bar hover highlight by 1 s (closes #6)

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/FileBrowserPane.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/FileBrowserPane.kt
@@ -447,6 +447,7 @@ fun buildFileBrowserView(paneId: String, leaf: dynamic, headerEl: HTMLElement? =
         launchCmd(WindowCommand.FileBrowserOpenFile(paneId = paneId, relPath = state.selectedRelPath!!))
     }
 
+    attachDelayedHoverArm(divider)
     divider.addEventListener("mousedown", { ev ->
         val mev = ev as MouseEvent
         mev.preventDefault()

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/GitPane.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/GitPane.kt
@@ -885,6 +885,7 @@ fun buildGitView(paneId: String, leaf: dynamic, headerEl: HTMLElement? = null): 
     }
     if (initialAutoRefresh) launchCmd(WindowCommand.SetGitAutoRefresh(paneId = paneId, enabled = true))
 
+    attachDelayedHoverArm(divider)
     divider.addEventListener("mousedown", { ev ->
         val mev = ev as MouseEvent; mev.preventDefault()
         divider.classList.add("dragging")

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
@@ -47,6 +47,56 @@ private const val MOON_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="1
 private const val AUTO_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 0 1 0 18" fill="currentColor"/></svg>"""
 
 /**
+ * Dwell (in milliseconds) before a split-bar reveals its resize affordance on
+ * hover. Picked to match the existing rename-arm timer in [PaneHeader], so the
+ * two "settle before you act" interactions feel consistent.
+ *
+ * @see attachDelayedHoverArm
+ */
+private const val SPLIT_BAR_HOVER_ARM_MS = 1000
+
+/**
+ * Wire a split-bar divider so its hover-state styling (colored highlight and
+ * resize cursor) is applied only after the pointer has dwelled on it for
+ * [SPLIT_BAR_HOVER_ARM_MS]. Incidental mouse movement across the divider no
+ * longer causes an immediate color/cursor flicker — the affordance fades in
+ * only when the user is clearly lingering on the bar with intent to resize.
+ *
+ * Adds `.hover-armed` to [element] after the dwell elapses, and removes it on
+ * `mouseleave` or when a drag begins (`mousedown`) — while dragging, the
+ * existing `.dragging` class takes over as the source of the highlight.
+ *
+ * Called from [start] for the sidebar / header / usage-bar dividers, and from
+ * [mountFileBrowserPane] and [mountGitPane] for the Markdown and Git list
+ * dividers. Mirrors the `armed` timer pattern used in `PaneHeader.createHeader`
+ * for the rename-on-hover interaction.
+ *
+ * @param element The divider element to attach listeners to. Must have its
+ *   hover styling in CSS gated on `.hover-armed` (and/or `.dragging`) rather
+ *   than the `:hover` pseudo-class.
+ * @see PaneHeader
+ */
+internal fun attachDelayedHoverArm(element: HTMLElement) {
+    var armTimer: Int = -1
+    fun disarm() {
+        if (armTimer != -1) { window.clearTimeout(armTimer); armTimer = -1 }
+        element.classList.remove("hover-armed")
+    }
+    element.addEventListener("mouseenter", { _ ->
+        disarm()
+        armTimer = window.setTimeout(
+            { armTimer = -1; element.classList.add("hover-armed") },
+            SPLIT_BAR_HOVER_ARM_MS,
+        )
+    })
+    element.addEventListener("mouseleave", { _ -> disarm() })
+    // Once a drag starts, the .dragging class owns the highlight — cancel
+    // any pending arm so we don't layer both classes or leave a stale
+    // hover-armed behind when the mouse leaves mid-drag.
+    element.addEventListener("mousedown", { _ -> disarm() })
+}
+
+/**
  * Returns whether the host reports a dark system colour-scheme preference.
  * Consulted only when the user's [Appearance] is [Appearance.Auto] — in
  * [Appearance.Dark] / [Appearance.Light] the explicit choice always wins.
@@ -452,6 +502,7 @@ private fun start() {
 
     // Sidebar resize via divider drag.
     run {
+        attachDelayedHoverArm(sidebarDividerLocal)
         var dragging = false
         var startX = 0.0
         var startWidth = 0.0
@@ -517,6 +568,7 @@ private fun start() {
     run {
         val hdr = appHeaderEl ?: return@run
         val divider = headerDividerEl ?: return@run
+        attachDelayedHoverArm(divider)
         var dragging = false
         var startY = 0.0
         var startHeight = 0.0
@@ -575,6 +627,7 @@ private fun start() {
     run {
         val bar = usageBar ?: return@run
         val divider = usageBarDividerEl ?: return@run
+        attachDelayedHoverArm(divider)
         var dragging = false
         var startY = 0.0
         var startHeight = 0.0

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -688,10 +688,17 @@ body.is-electron-mac .app-header {
     width: 9px;
     margin: 0 -2px;
     flex-shrink: 0;
-    cursor: col-resize;
     background: transparent;
     position: relative;
     z-index: 5;
+}
+/* Cursor + colored highlight are gated on the JS-driven .hover-armed class
+   (applied after ~1s of dwell — see attachDelayedHoverArm) so incidental
+   mouse movement across the divider stays visually quiet. The .dragging
+   class keeps the highlight on while the user is actively resizing. */
+.sidebar-divider.hover-armed,
+.sidebar-divider.dragging {
+    cursor: col-resize;
 }
 .sidebar-divider::after {
     content: "";
@@ -702,7 +709,7 @@ body.is-electron-mac .app-header {
     width: 1px;
     background: var(--separator, #333);
 }
-.sidebar-divider:hover::after,
+.sidebar-divider.hover-armed::after,
 .sidebar-divider.dragging::after {
     background: var(--termtastic-orange);
     width: 2px;
@@ -719,10 +726,17 @@ body.is-electron-mac .app-header {
     height: 9px;
     margin: -2px 0;
     flex-shrink: 0;
-    cursor: row-resize;
     background: transparent;
     position: relative;
     z-index: 5;
+}
+/* See .sidebar-divider above for why cursor + highlight are gated on the
+   .hover-armed / .dragging classes rather than the :hover pseudo-class. */
+.header-divider.hover-armed,
+.header-divider.dragging,
+.usage-bar-divider.hover-armed,
+.usage-bar-divider.dragging {
+    cursor: row-resize;
 }
 .header-divider::after,
 .usage-bar-divider::after {
@@ -734,9 +748,9 @@ body.is-electron-mac .app-header {
     height: 1px;
     background: var(--separator, #333);
 }
-.header-divider:hover::after,
+.header-divider.hover-armed::after,
 .header-divider.dragging::after,
-.usage-bar-divider:hover::after,
+.usage-bar-divider.hover-armed::after,
 .usage-bar-divider.dragging::after {
     background: var(--termtastic-orange);
     height: 2px;
@@ -2229,11 +2243,16 @@ body.appearance-light .pane-picker-btn:hover:not(.disabled) {
 .md-divider {
     width: 9px;
     margin: 0 -2px;
-    cursor: col-resize;
     background: transparent;
     flex-shrink: 0;
     position: relative;
     z-index: 1;
+}
+/* See .sidebar-divider — cursor + highlight are gated on .hover-armed
+   (set after a dwell delay) and .dragging, not the :hover pseudo-class. */
+.md-divider.hover-armed,
+.md-divider.dragging {
+    cursor: col-resize;
 }
 .md-divider::after {
     content: "";
@@ -2244,7 +2263,7 @@ body.appearance-light .pane-picker-btn:hover:not(.disabled) {
     width: 1px;
     background: var(--separator, #333);
 }
-.md-divider:hover::after,
+.md-divider.hover-armed::after,
 .md-divider.dragging::after {
     background: var(--accent, #0e639c);
     width: 2px;
@@ -2929,11 +2948,14 @@ body.appearance-light .link-picker-card:hover {
 .git-divider {
     width: 9px;
     margin: 0 -2px;
-    cursor: col-resize;
     background: transparent;
     flex-shrink: 0;
     position: relative;
     z-index: 1;
+}
+.git-divider.hover-armed,
+.git-divider.dragging {
+    cursor: col-resize;
 }
 .git-divider::after {
     content: "";
@@ -2944,7 +2966,7 @@ body.appearance-light .link-picker-card:hover {
     width: 1px;
     background: var(--separator, #333);
 }
-.git-divider:hover::after,
+.git-divider.hover-armed::after,
 .git-divider.dragging::after {
     background: var(--accent, #0e639c);
     width: 2px;


### PR DESCRIPTION
Closes #6

## Summary
Resize dividers (sidebar, header, usage bar, Markdown-browser, Git pane) no longer flash their colored highlight or switch the mouse cursor the instant the pointer crosses them. The affordance now fades in only after the pointer has dwelled on the divider for ~1 second, matching the settle-before-act rename interaction already in `PaneHeader`. Dragging still works exactly as before.

## Background
From the issue: "As soon as I hover over a split bar (like the one for left sidebar, top tab bar and bottom bar) the bar changes color and mouse pointer changes. This is distracting as the user moves the mouse around the window. I want this hover effect to be delayed so it only shows after I hover for a second, that way there is no immediate visual effect on hover."

The issue explicitly calls out both symptoms: color change **and** pointer change. Both were driven by CSS on the base divider class (`cursor: col-resize` / `row-resize`) and the `:hover::after` pseudo-class (color swap + thicker line). This PR delays both.

## Approach
End-to-end:

1. **CSS** — for each of the five divider classes (`.sidebar-divider`, `.header-divider`, `.usage-bar-divider`, `.md-divider`, `.git-divider`), move the resize cursor off the base class and gate both the cursor and the colored `::after` highlight on a new `.hover-armed` class (or the existing `.dragging` class). The `:hover` pseudo-class is no longer referenced for dividers.
2. **JS helper** — introduce `attachDelayedHoverArm(element: HTMLElement)` in `main.kt`. It wires `mouseenter` / `mouseleave` / `mousedown` on the given element: on enter it starts a 1 s `window.setTimeout` that adds `.hover-armed`; on leave or drag start it cancels the timer and removes the class.
3. **Wiring** — the helper is called once per divider at setup time: three calls inside `start()` in `main.kt` (sidebar, header, usage bar) and one each in `FileBrowserPane.kt` (Markdown divider) and `GitPane.kt` (Git changes divider).

The existing `.dragging` class continues to provide immediate visual feedback during an actual drag, so once the user commits to resizing the bar stays highlighted instantly — only the casual-hover path is delayed.

## Decisions & reasoning

### Timing constant (1000 ms)
The issue asks for "a second." A named private `SPLIT_BAR_HOVER_ARM_MS = 1000` makes it trivial to tune later without hunting for magic numbers, and matches the exact value already used by `PaneHeader`'s `armTimer` for the rename-on-hover interaction — so the two "settle then reveal" affordances feel consistent. A shorter 300–500 ms dwell was considered but rejected because the complaint is specifically about incidental pointer motion, and sub-second delays still trigger during ordinary mouse movement across the layout.

### Class-gated CSS instead of CSS transition delay
An alternative was to keep `:hover` and add `transition-delay: 1s` to the highlight. Rejected because:
- `transition-delay` delays the visual *animation* but `:hover` still matches instantly, so `cursor: col-resize` would still switch immediately — the issue explicitly complains about the cursor change too.
- Cancellation semantics are awkward: if the user hovers briefly and leaves, the transition never starts but the cursor already changed and back, producing flicker.
- The class-based approach mirrors an existing, proven pattern in the codebase (`PaneHeader.armed`), so it's easier to reason about and maintain.

### Shared helper instead of per-site inline timer
Five divider sites would each need the same ~15 lines of timer bookkeeping. A single `attachDelayedHoverArm(element)` helper removes five copies of near-identical code and gives the interaction a single place to evolve (e.g. if the dwell needs tuning, or if we later want pointer-type awareness for touch devices). Kept it to a single `HTMLElement` parameter so the call site is a one-liner.

### Placement of the helper in `main.kt`
Three of the five divider setups already live in `main.kt`; the other two (`FileBrowserPane.kt`, `GitPane.kt`) are in the same `se.soderbjorn.termtastic` package so no import gymnastics are needed. Creating a new `DividerHelpers.kt` file felt heavier than the one-function helper warrants. If more divider utilities accrete later, extracting is cheap.

### Cancel on `mousedown`, not on adding `.dragging`
`attachDelayedHoverArm` listens for `mousedown` on the divider to cancel the pending arm timer. An alternative was to have each divider's existing `mousedown` handler manually clear any pending timer. The helper-level approach avoids threading state out of the helper and keeps each call site a single `attachDelayedHoverArm(divider)` line. The two mousedown listeners on the same element both fire; order doesn't matter because the helper's listener only cancels a timer — it doesn't interact with the drag state.

### Post-drag behavior
When a drag ends (`mouseup`), the `.dragging` class is removed and the pointer is often still over the divider. The user will not see `.hover-armed` re-apply until they leave and re-enter, because `mouseenter` doesn't re-fire without a leave. This is acceptable: the user just finished a deliberate drag and knows the bar is there; the distracting-hover case is about passive movement, not post-interaction state. Re-arming on `mouseup` while the pointer is over the divider was considered but adds complexity for an edge case that's not visually jarring.

## Assumptions
- The 1 s dwell chosen to match the rename-arm timer is acceptable as the default. If the repo owner wants this shorter (say 500 ms) the single constant makes it a one-line change.
- The `.dragging` class-based "instant highlight while resizing" behavior should be preserved — users actively dragging expect immediate feedback, and the issue only talks about hover.
- Touch / pen pointers are out of scope. Dividers are a desktop-mouse affordance; `mouseenter` / `mouseleave` won't fire meaningfully on touch and the existing `mousedown` drag path is unchanged.

## Alternatives considered and rejected
- **`transition-delay: 1s` on the existing `:hover::after`** — doesn't delay the cursor change, has awkward cancellation, and still leaves `:hover` matching instantly. (See above.)
- **Global CSS variable for the dwell** — overkill for one constant used in one helper.
- **Re-arming on `mouseup` after drag** — adds state tracking for negligible UX benefit. (See above.)

## Verification
- `./gradlew :web:compileKotlinJs` — passes. Only pre-existing warnings (`DelicateCoroutinesApi`, redundant conversion) remain; no new ones from this change.
- `./gradlew :web:jsBrowserProductionWebpack` — passes; production bundle builds cleanly.
- Static review of the CSS: every `:hover::after` rule that existed for a divider class has been replaced by a `.hover-armed::after` rule that preserves the previous colors and widths. The original `.dragging` selectors are preserved verbatim.
- Static review of the JS: the helper is invoked once per divider site, before any `mousedown` handler; the `disarm()` path runs on both `mouseleave` and `mousedown`, so no stale class can survive a drag.
- **Not verified in a live browser session** — I did not launch the Electron app or a dev server in this environment, so I have not visually confirmed the 1 s dwell looks right in practice. The repo owner should spot-check each of the five dividers: (a) sweep across quickly — no highlight, no cursor change; (b) park on one for ~1 s — highlight + resize cursor appear; (c) drag — highlight stays on throughout; (d) release — no flicker.

## Files of note
- `web/src/jsMain/resources/styles.css` — five divider rule groups converted from `:hover` to `.hover-armed`. Base cursor declaration removed from each base class. This is the load-bearing CSS change.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt` — adds the `SPLIT_BAR_HOVER_ARM_MS` constant, the `attachDelayedHoverArm` helper, and three call sites (sidebar, header, usage-bar dividers).
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/FileBrowserPane.kt` — one-line call to `attachDelayedHoverArm(divider)` for the Markdown browser's divider.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/GitPane.kt` — one-line call to `attachDelayedHoverArm(divider)` for the Git pane's divider.

## Follow-ups
- If touch/pen users ever want to resize from a tablet, we'd need a separate affordance (a persistent grab handle) since `mouseenter` dwell doesn't translate.
- If the 1 s dwell feels too slow (or too fast) in practice, tune `SPLIT_BAR_HOVER_ARM_MS` in `main.kt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)