### PR TITLE
Fix unclickable new-tab (+) button in Electron (closes #9)

### DIFF
--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -258,6 +258,7 @@ body.appearance-light *::-webkit-scrollbar-thumb:hover {
 }
 .app-header .icon-button,
 .app-header .tab-button,
+.app-header .tab-add,
 .app-header .dropdown,
 .app-header .dropdown-menu,
 .app-header .tab-menu-list {


### PR DESCRIPTION
Closes #9

## Summary
The `+` button in the tab bar did nothing when clicked (and showed no hover feedback) in the Electron app. Cause: the button lives inside `.app-header`, which is a `-webkit-app-region: drag` region, and it was missing from the `no-drag` opt-out CSS rule that every other interactive header element already has. Adding `.tab-add` to that rule restores normal click and hover behaviour.

## Background
Issue #9 reports: *"I am unable to click on the + sign in the tab bar to create a new tab. Nothing happens when I click or hover on it."*

The Electron browser windows use `titleBarStyle: "hiddenInset"`, so the native title bar is gone. To keep the window draggable, `styles.css` marks the entire `.app-header` as `-webkit-app-region: drag`. That turns the header into an OS-level drag surface, which means the OS captures pointer events on it (clicks and hover effects are swallowed unless a child opts back out).

The existing rule at `web/src/jsMain/resources/styles.css:259` opts a hand-picked set of children back into normal interactivity:

```
.app-header .icon-button,
.app-header .tab-button,
.app-header .dropdown,
.app-header .dropdown-menu,
.app-header .tab-menu-list { -webkit-app-region: no-drag; app-region: no-drag; }
```

`.tab-add` — the `<button class="tab-add">+</button>` element created dynamically in `WindowConnection.kt:397-401` and appended to `#tab-bar` inside `.app-header` — was simply missing from that list. In a plain browser (`-webkit-app-region` is a no-op there) the button worked fine, which is presumably why this wasn't caught earlier. In Electron it's been silently broken.

## Approach
One-line CSS change: add `.app-header .tab-add` to the `no-drag` selector list. The existing comment block above the rule already documents why this list exists, so no new explanation was needed in the stylesheet.

## Decisions & reasoning

### Opt `.tab-add` into the existing `no-drag` list rather than set `no-drag` inline on the button
`WindowConnection.kt` already relies on CSS class matching to grant `no-drag` to every other header button, and the opt-out list is colocated with the `.app-header { drag }` rule that creates the problem in the first place. Keeping the decision in CSS keeps all native-chrome opt-ins in one place — if someone later tweaks the drag policy they'll find every opt-out in the same rule. Setting the style inline on the DOM-built button would scatter the policy.

### Scope kept to `.tab-add` only
I audited every other element that currently lives inside `.app-header`:

- `.icon-button` (sidebar toggle, new-window, appearance, theme, settings, about, debug): already listed.
- `.tab-button` (each tab): already listed.
- `.tab-menu` / `.tab-menu-button` (per-tab hover menu): these are descendants of `.tab-button`, and `-webkit-app-region` inherits, so `no-drag` on the ancestor carries down.
- `.tab-menu-list`: already listed (it's appended to `document.body`, so the rule is technically a no-op at that location, but harmless).
- `.tab-active-indicator`: has `pointer-events: none`, not an interactive element — drag behaviour is irrelevant.
- `.dropdown`, `.dropdown-menu`: already listed.

`.tab-add` is the only missing case. A wider refactor (e.g. a `.app-header-interactive` umbrella class, or inverting the rule to tag the header background as `drag` instead of the whole header) would be cleaner in principle but out of scope for a bug fix — and would risk introducing its own regressions in Electron drag behaviour.

## Assumptions
- The user reported the bug while running the Electron build. A plain browser is unaffected by `-webkit-app-region`, so the diagnosis only explains the Electron failure mode. If the bug also reproduces in a plain browser, there is a separate cause that this PR does not fix — but the issue text (no click *and* no hover) matches exactly the Electron drag-region symptom.

## Alternatives considered and rejected
- **Move `.tab-add` out of `.app-header` into `.header-actions` or a sibling container.** Would also work but changes layout/CSS ordering and is a bigger blast radius for a one-line bug fix.
- **Set `addBtn.style.webkitAppRegion = "no-drag"` in `WindowConnection.kt`.** Works, but splits the native-chrome policy between CSS and Kotlin.
- **Invert the whole policy (default no-drag, tag only a blank drag strip at the top).** Correct long-term design but well outside the scope of #9, and risks changing feel of window dragging across both platforms.

## Verification
- `./gradlew :web:jsBrowserProductionWebpack` — **passes locally** (webpack compiles with 2 pre-existing size-limit warnings unrelated to this change).
- **Manual in-app verification: not performed.** I could not launch the Electron shell from this environment. The fix is a one-line CSS addition that mirrors the pattern already proven to work for `.icon-button`, `.tab-button`, and the dropdowns — but the repo owner should click `+` in an Electron build to confirm the symptom is gone before merging. Hover feedback (`.tab-add:hover` background/colour change) should also return alongside the click.

## Files of note
- `web/src/jsMain/resources/styles.css` — the one-line change: add `.app-header .tab-add` to the existing no-drag opt-out rule (around line 262).

## Follow-ups
- Consider inverting the drag-region policy (default no-drag, tag a dedicated blank strip as drag) so that future header elements don't have to remember to opt out. Out of scope for this fix.
- No unit/UI test is added. `-webkit-app-region` is Electron-only; asserting it in jsDOM-style tests would require mocking that the repo doesn't currently do. The policy is one CSS rule, easy to eyeball, so a targeted test feels like overkill vs. the ongoing maintenance cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)