### PR TITLE
Add per-tab 'Hide in side bar' toggle (#12)

### DIFF
--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowCommand.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowCommand.kt
@@ -320,6 +320,26 @@ sealed class WindowCommand {
     data class SetTabHidden(val tabId: String, val hidden: Boolean) : WindowCommand()
 
     /**
+     * Mark a tab as hidden or visible in the left sidebar's tab tree. Hidden-
+     * from-sidebar tabs keep all their panes and PTY sessions alive and stay
+     * reachable through the tab strip; the web client simply skips them when
+     * rendering the sidebar so the user can declutter it independently of the
+     * tab bar. Unlike [SetTabHidden] there is no overflow-menu surfacing on
+     * the sidebar itself — the tab bar remains the way to reach a sidebar-
+     * hidden tab.
+     *
+     * Dispatched from the same far-right "⋯" tab-bar overflow menu as
+     * [SetTabHidden], via the "Show in side bar" / "Hide in side bar" entry.
+     *
+     * @param tabId the id of the tab to hide or unhide in the sidebar
+     * @param hidden `true` to hide the tab from the sidebar, `false` to show it
+     * @see TabConfig.isHiddenFromSidebar
+     */
+    @Serializable
+    @SerialName("setTabHiddenFromSidebar")
+    data class SetTabHiddenFromSidebar(val tabId: String, val hidden: Boolean) : WindowCommand()
+
+    /**
      * Add a new terminal pane to an existing tab (creates a new PTY session).
      *
      * @param tabId the id of the tab to add the pane to

--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
@@ -73,6 +73,24 @@ data class TabConfig(
      * @see WindowCommand.SetTabHidden
      */
     val isHidden: Boolean = false,
+    /**
+     * Whether this tab is hidden from the left sidebar's tab tree. Hidden-
+     * from-sidebar tabs still exist with all their panes and PTY sessions
+     * intact and still participate in the tab bar — the web client merely
+     * skips them when rendering the sidebar tree so the user can declutter
+     * the sidebar independently of the tab strip. Toggled from the tab-bar
+     * overflow menu's "Show in side bar" / "Hide in side bar" entry via
+     * [WindowCommand.SetTabHiddenFromSidebar]. Defaults to `false` so
+     * legacy persisted configs round-trip as fully visible.
+     *
+     * This is orthogonal to [isHidden]: a tab can be shown in the strip but
+     * hidden from the sidebar, and vice versa. Unlike [isHidden] there is
+     * no "overflow menu" surfacing for sidebar-hidden tabs — the tab bar
+     * remains the authoritative place to reach them.
+     *
+     * @see WindowCommand.SetTabHiddenFromSidebar
+     */
+    val isHiddenFromSidebar: Boolean = false,
 )
 
 /**

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
@@ -874,6 +874,7 @@ private suspend fun handleWindowCommand(text: String, ctx: WindowConnectionConte
         is WindowCommand.RenameTab -> WindowState.renameTab(cmd.tabId, cmd.title)
         is WindowCommand.MoveTab -> WindowState.moveTab(cmd.tabId, cmd.targetTabId, cmd.before)
         is WindowCommand.SetTabHidden -> WindowState.setTabHidden(cmd.tabId, cmd.hidden)
+        is WindowCommand.SetTabHiddenFromSidebar -> WindowState.setTabHiddenFromSidebar(cmd.tabId, cmd.hidden)
         is WindowCommand.AddPaneToTab -> {
             // Inherit cwd from the anchor pane so a new terminal split off
             // from an existing pane starts in the same directory instead of

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
@@ -431,6 +431,37 @@ object WindowState {
     }
 
     /**
+     * Mark [tabId] as hidden or visible in the left sidebar's tab tree.
+     * Sidebar-hidden tabs keep every pane and PTY session intact and still
+     * participate in the tab bar; the web client simply omits them from the
+     * sidebar render. No-op if the id is unknown or the flag already matches
+     * the requested value.
+     *
+     * Orthogonal to [setTabHidden]: a tab can be shown in the strip but
+     * hidden from the sidebar, and vice versa. The active tab and focus
+     * state are left unchanged — sidebar-hiding is a pure UI affordance.
+     *
+     * Called from `handleWindowCommand` on
+     * [WindowCommand.SetTabHiddenFromSidebar], dispatched by the tab-bar
+     * overflow menu's "Show in side bar" / "Hide in side bar" entry.
+     *
+     * @param tabId the id of the tab to hide or unhide in the sidebar
+     * @param hidden `true` to hide from the sidebar, `false` to show it
+     * @see TabConfig.isHiddenFromSidebar
+     * @see WindowCommand.SetTabHiddenFromSidebar
+     */
+    fun setTabHiddenFromSidebar(tabId: String, hidden: Boolean) = synchronized(this) {
+        val cfg = _config.value
+        val idx = cfg.tabs.indexOfFirst { it.id == tabId }
+        if (idx < 0) return@synchronized
+        val tab = cfg.tabs[idx]
+        if (tab.isHiddenFromSidebar == hidden) return@synchronized
+        val newTabs = cfg.tabs.toMutableList()
+        newTabs[idx] = tab.copy(isHiddenFromSidebar = hidden)
+        _config.value = cfg.copy(tabs = newTabs)
+    }
+
+    /**
      * Set the display title of [tabId] to [title] (trimmed, max 80 chars).
      * No-op if the title is empty or unchanged.
      *

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Sidebar.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Sidebar.kt
@@ -61,6 +61,11 @@ fun renderSidebar(config: dynamic) {
     val tabsArr = config.tabs as? Array<dynamic> ?: return
 
     for (tab in tabsArr) {
+        // Respect the per-tab sidebar-visibility flag. Tabs flagged as
+        // sidebar-hidden still render in the tab bar and retain all their
+        // panes and PTY sessions — they are merely omitted from the sidebar
+        // tree so the user can declutter it independently of the strip.
+        if ((tab.isHiddenFromSidebar as? Boolean) == true) continue
         val tabId = tab.id as String
         val tabTitle = tab.title as String
         val isActiveTab = tabId == activeTabId

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TabBarMenu.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TabBarMenu.kt
@@ -17,7 +17,9 @@
  *
  * @see renderConfig — the single caller; invoked after the visible tab
  *   buttons and the `+` add button have been appended.
- * @see WindowCommand.SetTabHidden for the hide/unhide server round-trip.
+ * @see WindowCommand.SetTabHidden for the tab-bar hide/unhide round-trip.
+ * @see WindowCommand.SetTabHiddenFromSidebar for the sidebar hide/unhide
+ *   round-trip.
  * @see WindowCommand.CloseTab / WindowCommand.RenameTab / WindowCommand.SetActiveTab
  *   for the other actions dispatched from this menu.
  */
@@ -155,12 +157,17 @@ private fun menuSeparator(): HTMLElement {
  *  - "Rename"  — opens the inline rename UI on the active tab's label.
  *  - "Close"   — closes the active tab (only when there is more than one
  *    tab, matching `canCloseTab` elsewhere in the renderer).
- *  - "Hide" / "Unhide" — toggles [TabConfig.isHidden] on the active tab.
- *    A hidden active tab stays active (its content still renders in the
- *    wrap) so the user doesn't lose their place.
+ *  - "Hide" / "Unhide" in tab bar — toggles [TabConfig.isHidden] on the
+ *    active tab. A hidden active tab stays active (its content still
+ *    renders in the wrap) so the user doesn't lose their place.
+ *  - "Hide" / "Unhide" in side bar — toggles
+ *    [TabConfig.isHiddenFromSidebar] on the active tab, independently of
+ *    the tab-bar flag. Dispatched via
+ *    [WindowCommand.SetTabHiddenFromSidebar].
  *  - A separator and one row per hidden tab — clicking a hidden tab
  *    activates it; the user can then Unhide it if they want the strip
- *    entry back.
+ *    entry back. (Hidden-from-sidebar tabs remain reachable through the
+ *    tab strip and so have no separate overflow section.)
  *
  * Invoked once per render from [renderConfig], after the visible tab
  * buttons have been appended. The `New tab` row at the top of the
@@ -198,6 +205,7 @@ internal fun appendTabBarOverflowMenu(
 
     val activeTab: dynamic = tabsArr.firstOrNull { (it.id as? String) == activeTabIdArg }
     val activeIsHidden = (activeTab?.isHidden as? Boolean) == true
+    val activeIsHiddenFromSidebar = (activeTab?.isHiddenFromSidebar as? Boolean) == true
     val hiddenTabs = tabsArr.filter { (it.isHidden as? Boolean) == true }
 
     // Add tab — the standalone `+` button has been folded into the dropdown
@@ -252,11 +260,29 @@ internal fun appendTabBarOverflowMenu(
             })
         }
 
-        // Hide / Unhide — always present so the affordance is discoverable.
+        // Hide / Unhide (tab bar) — always present so the affordance is
+        // discoverable.
         val (icon, label) = if (activeIsHidden) ICON_UNHIDE to "Show in tab bar" else ICON_HIDE to "Hide in tab bar"
         menuList.appendChild(menuRow(icon, label) { _ ->
             menuWrap.classList.remove("open"); menuList.classList.remove("open")
             launchCmd(WindowCommand.SetTabHidden(tabId = activeTabId, hidden = !activeIsHidden))
+        })
+
+        // Hide / Unhide (sidebar) — mirror affordance for the left sidebar
+        // tree, persisted server-side alongside the tab-bar flag. Independent
+        // of the tab-bar toggle: either or both can be set.
+        val (sidebarIcon, sidebarLabel) = if (activeIsHiddenFromSidebar)
+            ICON_UNHIDE to "Show in side bar"
+        else
+            ICON_HIDE to "Hide in side bar"
+        menuList.appendChild(menuRow(sidebarIcon, sidebarLabel) { _ ->
+            menuWrap.classList.remove("open"); menuList.classList.remove("open")
+            launchCmd(
+                WindowCommand.SetTabHiddenFromSidebar(
+                    tabId = activeTabId,
+                    hidden = !activeIsHiddenFromSidebar,
+                )
+            )
         })
     }
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
@@ -180,7 +180,10 @@ private fun isOnlyFocusChange(prev: dynamic, next: dynamic): Boolean {
         if ((pt.title as? String) != (nt.title as? String)) return false
         // Hidden-state toggles change what the tab strip renders (and what
         // the overflow menu offers), so they are *not* focus-only changes.
+        // The sidebar-visibility flag likewise changes what the sidebar tree
+        // renders, so toggling it must trigger a full rebuild.
         if ((pt.isHidden as? Boolean ?: false) != (nt.isHidden as? Boolean ?: false)) return false
+        if ((pt.isHiddenFromSidebar as? Boolean ?: false) != (nt.isHiddenFromSidebar as? Boolean ?: false)) return false
         if (stringify(pt.panes) != stringify(nt.panes)) return false
     }
     return true


### PR DESCRIPTION
Closes #12

## Summary
Adds a new "Show in side bar" / "Hide in side bar" entry to the tab-bar overflow (`⋯`) menu, mirroring the existing "Show/Hide in tab bar" affordance. Hiding a tab from the sidebar removes it from the left sidebar tree but leaves it present in the tab strip and keeps all its panes and PTY sessions alive. The setting is persisted server-side in SQLite alongside the rest of `WindowConfig`.

## Background
From issue #12:

> The drop-down menu for a tab has a "Show in tabbar" / "Hide in tab bar" toggle. I would like a similar one called "Show in side bar" / "Hide in side bar", which should -- as you would expect -- hide it in the sidebar. This setting should be persisted in the server DB. And by the way, the other setting (tab bar toggle) should also be, if it's not already done.

The existing `TabConfig.isHidden` flag (tab-bar visibility) is **already** persisted via `SettingsRepository.saveWindowConfig()` — it round-trips through the same JSON blob under the `window.config.v3` key. No migration was needed for the existing toggle; the new flag follows the same path.

## Approach

The change follows the same layered pattern as the existing tab-bar hide toggle, end to end:

1. **Data model (`clientServer/WindowConfig.kt`)** — a new `isHiddenFromSidebar: Boolean = false` property on `TabConfig`. The default ensures legacy persisted configs deserialize as fully visible.
2. **Command (`clientServer/WindowCommand.kt`)** — a new `WindowCommand.SetTabHiddenFromSidebar(tabId, hidden)` sealed-class variant, registered with `@SerialName("setTabHiddenFromSidebar")`.
3. **Server handler (`server/WindowState.kt`)** — `setTabHiddenFromSidebar()` mirrors `setTabHidden()`: idempotent copy-on-write update to the `_config` StateFlow, synchronized, no-op when the flag already matches. Persistence is automatic — the existing debounced `collectLatest` loop in `Application.kt` picks up every `_config` mutation and upserts the serialized blob into SQLite.
4. **Command dispatch (`server/Application.kt`)** — one new branch in the `handleWindowCommand` `when` block.
5. **Web UI — tab-bar menu (`web/TabBarMenu.kt`)** — a second "Hide/Show" row is appended to the active-tab section of the overflow menu, directly below the existing tab-bar toggle. Shares the same `ICON_HIDE` / `ICON_UNHIDE` SVGs and `menuRow` builder.
6. **Web UI — sidebar render (`web/Sidebar.kt`)** — `renderSidebar` now skips tabs whose `isHiddenFromSidebar` flag is `true` before building the header/children DOM.

## Decisions & reasoning

### Separate flag rather than reusing `isHidden`
I considered reusing the existing `isHidden` property to drive both surfaces, but the issue explicitly asks for an independent toggle — a user who declutters the sidebar likely still wants the tab in the strip (the sidebar is where the project already pre-filters mentally, so it's the natural place to hide rarely-used tabs). A single shared flag would couple two orthogonal affordances. Two flags makes each surface independently togglable and the intent readable at a glance in the config blob.

### Plain `continue` in the sidebar loop, no "Unlisted tabs" surfacing
The tab-bar overflow menu has a dedicated "Unlisted tabs" section that surfaces tab-bar-hidden tabs so they remain reachable. I deliberately did **not** mirror that for the sidebar: if a tab is hidden from the sidebar it is still present in the tab strip, so the user has an obvious alternate route to reach it. Adding a second surfacing section to the sidebar would (a) defeat the "declutter the sidebar" user intent and (b) create a redundant second entry point. The tab bar stays authoritative for reachability; the sidebar is a nav-convenience view.

### Placement in the overflow menu
The new row sits immediately after the existing "Hide in tab bar" row inside the "Active tab" section. Keeping them adjacent makes the two affordances self-documenting (you read them in a group), and places the new row in the same visual band the user is already used to finding visibility controls in.

### Shared icons (`ICON_HIDE` / `ICON_UNHIDE`)
Both toggles use the eye / eye-with-slash SVGs that the existing tab-bar toggle already uses. A sidebar-specific icon would add visual noise without improving scannability — the label text already distinguishes "in tab bar" vs "in side bar". This matches the guidance in `CLAUDE.md` around augmenting existing patterns rather than inventing new ones.

### Backward compatibility
`isHiddenFromSidebar: Boolean = false` as a defaulted Kotlin serializer field means:
- Existing persisted `window.config.v3` blobs without the field deserialize as fully visible — no migration needed.
- Older clients connecting to a newer server harmlessly ignore the field when round-tripping the JSON (kotlinx-serialization skips unknown fields by default on the ignore path this project already uses).
- Newer clients connecting to an older server never receive the field and use the default — also safe.

No schema version bump is required.

## Assumptions
- The issue's note that the tab-bar toggle "should also be [persisted], if it's not already done" is satisfied by the existing implementation (I verified `SettingsRepository.saveWindowConfig()` already encodes the full `WindowConfig` including every `TabConfig.isHidden` into the SQLite `settings` row).
- The user is fine with the new row living directly under the existing tab-bar toggle in the same "Active tab" section rather than in a new subsection.
- No sidebar-side context-menu affordance is required for now — the issue scopes the request to mirroring the existing drop-down, which lives in the tab bar.

## Alternatives considered and rejected
- **Reuse `isHidden` for both surfaces** — rejected, see decision above.
- **Add a sidebar-side right-click menu to toggle visibility from the sidebar itself** — out of scope; the issue explicitly scopes the ask to the tab-bar drop-down. Easy follow-up if the user wants it.
- **Localize via client localStorage** — rejected per project convention: settings live server-side in SQLite only; no localStorage (see the project's client-server split).
- **Separate typed DTO for "visibility settings"** — rejected per project convention favouring a generic JSON blob over typed DTOs.

## Verification
- `./gradlew assemble` passes cleanly end to end (`BUILD SUCCESSFUL in 1m 13s`, 438 tasks) — covers `clientServer` (common), server, web JS (production bundle), androidApp, and the iOS framework link steps.
- Manual runtime verification was not performed — I did not launch the server + web client in this environment. Reviewer should smoke-test: open the `⋯` menu, toggle "Hide in side bar" on the active tab, confirm the tab disappears from the sidebar tree but stays in the strip and all its panes remain usable; then toggle back and confirm the tab reappears. Restart the server and confirm the setting persists.
- No existing tests exercise this area (the project does not ship unit tests for `WindowState` mutations in the changed file).

## Files of note
Load-bearing:
- `clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt` — new `TabConfig.isHiddenFromSidebar` field.
- `clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowCommand.kt` — new `SetTabHiddenFromSidebar` command.
- `server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt` — new `setTabHiddenFromSidebar()` handler.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/Sidebar.kt` — sidebar filter.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/TabBarMenu.kt` — new menu row + doc updates.

Mechanical:
- `server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt` — one-line dispatch branch added.

## Follow-ups
- Optional: add a sidebar-side affordance (e.g. right-click on a sidebar tab header) to toggle visibility from the sidebar itself. Not asked for in this issue.
- Optional: if more visibility dimensions get added in the future (e.g. "hide in tab bar on mobile only"), consider collapsing them into a single visibility mask to keep `TabConfig` flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)