### PR TITLE
Bring back the Termtastic logo (lower-right, pulsating dot)

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/AppLogo.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/AppLogo.kt
@@ -1,0 +1,72 @@
+/**
+ * App logo widget for the Termtastic web frontend.
+ *
+ * Renders the "Termtastic" wordmark and a small status dot in the lower-right
+ * corner of the window as a fixed overlay (painted on top of everything). The
+ * dot pulsates in three states derived from the aggregate of all per-session
+ * states:
+ *
+ *   - red  — at least one session is "waiting" (e.g. an agent is asking for
+ *            input/approval). Waiting dominates because it needs action.
+ *   - blue — at least one session is "working" (agent is actively running)
+ *            and none are waiting.
+ *   - neutral — no session is working or waiting (idle).
+ *
+ * The logo brings back an older design element (see issue #14): a "Termtastic"
+ * wordmark alongside a coloured dot. In the previous incarnation the dot was
+ * to the left of the wordmark and coloured by socket-connection status; this
+ * version moves the dot to the right and ties its colour to work state, which
+ * is more informative for day-to-day use.
+ *
+ * The overlay is **always visible** — it lives directly inside `<body>` via
+ * an `#app-logo` element declared in `index.html`, so it paints on top of
+ * modals, the sidebar, the tab bar, and the main content area. It uses
+ * `pointer-events: none` so it never steals clicks from the UI underneath.
+ *
+ * @see updateAppLogoState
+ * @see updateStateIndicators
+ */
+package se.soderbjorn.termtastic
+
+import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
+
+/**
+ * Recomputes and applies the logo dot state based on the current per-session
+ * state map.
+ *
+ * Called from [updateStateIndicators] whenever the server pushes a new state
+ * envelope (or when [renderConfig] replays the current state after a config
+ * change), so the dot is always in sync with the spinners/warning icons in
+ * the sidebar and tab bar.
+ *
+ * Aggregation rule:
+ *   1. If any session value is `"waiting"` → mark as waiting (red pulse).
+ *   2. Else if any session value is `"working"` → mark as working (blue pulse).
+ *   3. Else mark as idle (dim, no pulse).
+ *
+ * @param sessionStates the current session-id to state map from the server.
+ *                      States other than `"working"` / `"waiting"` (including
+ *                      `null`) count as idle.
+ * @see updateStateIndicators
+ */
+internal fun updateAppLogoState(sessionStates: Map<String, String?>) {
+    val dot = document.getElementById("app-logo-dot") as? HTMLElement ?: return
+    var anyWaiting = false
+    var anyWorking = false
+    for (state in sessionStates.values) {
+        when (state) {
+            "waiting" -> { anyWaiting = true; break }
+            "working" -> anyWorking = true
+        }
+    }
+    // Reset both modifier classes before re-applying so the dot never ends up
+    // carrying stale state when the aggregate transitions e.g. working→idle.
+    dot.classList.remove("state-working")
+    dot.classList.remove("state-waiting")
+    when {
+        anyWaiting -> dot.classList.add("state-waiting")
+        anyWorking -> dot.classList.add("state-working")
+        // Idle → no modifier class; the base .app-logo-dot rule paints it dim.
+    }
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/ClaudeUsageBar.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/ClaudeUsageBar.kt
@@ -125,8 +125,13 @@ fun updateClaudeUsageBadge(usage: dynamic) {
     val bar = usageBar ?: return
     val divider = usageBarDividerEl
     if (usage == null || usage == undefined) {
-        // No data at all — hide both the bar and the drag handle above it.
-        bar.style.display = "none"
+        // No data at all — keep the bar visible but empty so it still reserves
+        // space at the bottom of the window (required by issue #14 so the app
+        // logo overlay has a background band to sit against). Hide only the
+        // divider: there is nothing to drag-collapse when the bar is empty.
+        bar.innerHTML = ""
+        bar.className = "claude-usage-bar claude-usage-bar-empty"
+        bar.style.display = ""
         divider?.style?.display = "none"
         return
     }

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WebState.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WebState.kt
@@ -769,17 +769,23 @@ internal fun applySpinnerState(el: HTMLElement, baseClass: String, state: String
 
 /**
  * Updates all session state indicators (spinners for "working", warning
- * icons for "waiting") across the sidebar, tab bar, and pane headers.
+ * icons for "waiting") across the sidebar, tab bar, pane headers, and the
+ * lower-right app logo dot.
  *
  * Also triggers desktop notification checks and adjusts the tab bar active
  * indicator position.
  *
  * @param sessionStates the current session ID to state map from the server
  * @see checkStateNotifications
+ * @see updateAppLogoState
  */
 internal fun updateStateIndicators(sessionStates: Map<String, String?>) {
     val document = kotlinx.browser.document
     checkStateNotifications(sessionStates)
+    // Keep the lower-right app logo dot in sync with the sidebar/tab-bar
+    // spinners and warning icons — all three surfaces derive from the same
+    // per-session state map.
+    updateAppLogoState(sessionStates)
     val effective = HashMap(sessionStates)
     for ((sessionId, state) in effective) {
         val spinners = document.querySelectorAll(".pane-status-spinner[data-session='$sessionId']")

--- a/web/src/jsMain/resources/index.html
+++ b/web/src/jsMain/resources/index.html
@@ -138,9 +138,20 @@
     </div>
     <!-- Horizontal drag handle above the Claude usage bar. Only visible when
          the server has pushed usage data; drag down to hide the bar, drag up
-         to reveal it. -->
+         to reveal it. The footer below always takes up space even when the
+         server has no usage data to report (it just renders empty), so there
+         is always room for the app logo overlay in the lower-right corner. -->
     <div class="usage-bar-divider" id="usage-bar-divider" style="display: none;"></div>
-    <footer id="claude-usage-bar" class="claude-usage-bar" style="display: none;"></footer>
+    <footer id="claude-usage-bar" class="claude-usage-bar claude-usage-bar-empty"></footer>
+</div>
+<!-- App logo overlay. Painted on top of everything via position:fixed in the
+     lower-right corner, so it stays visible regardless of modals, the
+     sidebar, or which tab is active. The dot to the right of the wordmark
+     pulsates blue when any tab is working and red when any tab is waiting
+     for input; see AppLogo.kt and updateStateIndicators(). -->
+<div id="app-logo" class="app-logo" aria-hidden="true">
+    <span class="app-logo-wordmark">Termtastic</span>
+    <span id="app-logo-dot" class="app-logo-dot"></span>
 </div>
 <script type="application/javascript" src="web.js"></script>
 </body>

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -319,6 +319,19 @@ body.is-electron-mac .app-header {
     white-space: nowrap;
     user-select: none;
     flex-shrink: 0;
+    /* Always reserve space at the bottom of the window, even when the server
+       has no Claude usage data to display. The `.claude-usage-bar-empty`
+       variant renders with no content but keeps this minimum height so the
+       bottom bar is continuous across all runtime states and the app logo
+       overlay always has a consistent band to sit against. */
+    min-height: 24px;
+    box-sizing: border-box;
+}
+/* Empty state: no content, just a thin coloured band at the bottom. Kept
+   separate from the normal state so future tweaks (e.g. a subtle gradient,
+   a tagline) can target only the empty case. */
+.claude-usage-bar.claude-usage-bar-empty {
+    padding: 0 12px;
 }
 .claude-usage-bar .usage-item {
     display: flex;
@@ -4542,4 +4555,123 @@ body.appearance-light .settings-section-select {
     cursor: default;
 }
 
+/* ─── App logo overlay ──────────────────────────────────────────────
+   The "Termtastic" wordmark + status dot pinned to the lower-right
+   corner of the window. Painted on top of everything via position:
+   fixed and a high z-index so it's always visible regardless of what
+   tab, modal, or pane is active. pointer-events: none so it never
+   intercepts clicks meant for the UI below it.
+
+   Sits just above the Claude usage bar (which reserves a fixed min
+   height via .claude-usage-bar above), with enough padding that it
+   reads as a badge rather than a footer element. Size is deliberately
+   small-ish — the label should feel like a signature, not a banner —
+   so it doesn't crowd content in the main terminal area.
+
+   The dot mirrors the per-tab spinner/waiting indicators at the
+   aggregate level: blue pulse when any session is "working", red
+   pulse when any session is "waiting for input", dim when idle.
+   See AppLogo.kt / updateAppLogoState() for the state machine. */
+.app-logo {
+    position: fixed;
+    right: 14px;
+    bottom: 32px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    pointer-events: none;
+    user-select: none;
+    z-index: 100;
+    /* A soft text shadow so the wordmark stays legible against noisy
+       terminal content underneath (bright ANSI output, light themes,
+       etc.). Tuned low enough that it doesn't look like a drop shadow
+       on quiet backgrounds. */
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+}
+
+.app-logo-wordmark {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    /* Use the termtastic-orange token the rest of the UI leans on for
+       brand accents (see .sidebar-divider.dragging, the tab active
+       indicator fallback, etc.) so the logo feels in-family. */
+    color: var(--termtastic-orange, #F4B869);
+    line-height: 1;
+}
+
+/* In light appearance, the orange + white-ish text-shadow combo reads
+   as washed out. Swap to a darker shadow so the wordmark still pops. */
+body.appearance-light .app-logo {
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.75), 0 0 1px rgba(0, 0, 0, 0.3);
+}
+
+/* The status dot. Base state is idle (dim grey, no pulse). The
+   .state-working and .state-waiting modifier classes are added by
+   updateAppLogoState() in AppLogo.kt when any session is in that
+   state — waiting wins over working because it's action-required.
+   Each state has its own keyframe so the colour animates smoothly
+   with the opacity pulse. */
+.app-logo-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--text-secondary, #8E8E93);
+    box-shadow: 0 0 0 2px rgba(142, 142, 147, 0.18);
+    flex-shrink: 0;
+    transition: background-color 180ms ease-in-out,
+                box-shadow 180ms ease-in-out;
+}
+
+.app-logo-dot.state-working {
+    background: #4C9AFF;
+    box-shadow: 0 0 0 2px rgba(76, 154, 255, 0.25);
+    animation: app-logo-pulse-blue 1.6s ease-in-out infinite;
+}
+
+.app-logo-dot.state-waiting {
+    background: #FF6961;
+    box-shadow: 0 0 0 2px rgba(255, 105, 97, 0.3);
+    animation: app-logo-pulse-red 1.2s ease-in-out infinite;
+}
+
+/* Pulse keyframes: scale + glow breathe to draw the eye without
+   being obnoxious. Shorter period for waiting (red) than for working
+   (blue) because waiting is action-required and should feel more
+   urgent, mirroring the fade-warning on .pane-status-spinner. */
+@keyframes app-logo-pulse-blue {
+    0%, 100% {
+        box-shadow: 0 0 0 2px rgba(76, 154, 255, 0.25),
+                    0 0 0 0 rgba(76, 154, 255, 0.45);
+    }
+    50% {
+        box-shadow: 0 0 0 2px rgba(76, 154, 255, 0.25),
+                    0 0 0 6px rgba(76, 154, 255, 0);
+    }
+}
+
+@keyframes app-logo-pulse-red {
+    0%, 100% {
+        box-shadow: 0 0 0 2px rgba(255, 105, 97, 0.30),
+                    0 0 0 0 rgba(255, 105, 97, 0.55);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow: 0 0 0 2px rgba(255, 105, 97, 0.30),
+                    0 0 0 8px rgba(255, 105, 97, 0);
+        transform: scale(1.08);
+    }
+}
+
+/* Respect prefers-reduced-motion: keep the colour change but drop the
+   pulse animation, matching the existing motion-reduction hygiene
+   elsewhere in this stylesheet. */
+@media (prefers-reduced-motion: reduce) {
+    .app-logo-dot.state-working,
+    .app-logo-dot.state-waiting {
+        animation: none;
+    }
+}
 

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -4575,10 +4575,19 @@ body.appearance-light .settings-section-select {
 .app-logo {
     position: fixed;
     right: 14px;
-    bottom: 32px;
+    /* Cleared up from 32px — the previous value put the overlay right on top
+       of the Claude usage bar's content (see @soderbjorn screenshot on
+       #16), because the populated usage bar's effective height
+       (min-height 24 px + 3 px vertical padding + 1 px top border ≈ 28–30 px)
+       didn't leave enough breathing room before the dot's glow ring. 44 px
+       gives the wordmark and its pulse halo a comfortable band above the
+       bottom bar in both the populated and empty states. */
+    bottom: 44px;
     display: flex;
     align-items: center;
-    gap: 8px;
+    /* Slightly wider gap to match the bumped-up dot size so the wordmark
+       and dot still read as a balanced pair rather than crowding. */
+    gap: 9px;
     pointer-events: none;
     user-select: none;
     z-index: 100;
@@ -4615,8 +4624,14 @@ body.appearance-light .app-logo {
    with the opacity pulse. */
 .app-logo-dot {
     display: inline-block;
-    width: 10px;
-    height: 10px;
+    /* Bumped from 10 px → 13 px per @soderbjorn feedback on #16:
+       "make the dot a little bit bigger in relation to the label". 13 px
+       sits at roughly 87% of the 15 px wordmark cap height, which reads as
+       a deliberate circular badge next to the text rather than a small
+       punctuation mark beside it. The glow/pulse ring grows with it (see
+       box-shadow/keyframes below). */
+    width: 13px;
+    height: 13px;
     border-radius: 50%;
     background: var(--text-secondary, #8E8E93);
     box-shadow: 0 0 0 2px rgba(142, 142, 147, 0.18);
@@ -4647,8 +4662,10 @@ body.appearance-light .app-logo {
                     0 0 0 0 rgba(76, 154, 255, 0.45);
     }
     50% {
+        /* Outer halo radius bumped 6 px → 8 px in lockstep with the larger
+           13 px dot so the pulse ring stays visually proportional. */
         box-shadow: 0 0 0 2px rgba(76, 154, 255, 0.25),
-                    0 0 0 6px rgba(76, 154, 255, 0);
+                    0 0 0 8px rgba(76, 154, 255, 0);
     }
 }
 
@@ -4659,8 +4676,10 @@ body.appearance-light .app-logo {
         transform: scale(1);
     }
     50% {
+        /* Outer halo radius bumped 8 px → 10 px in lockstep with the larger
+           13 px dot so the pulse ring stays visually proportional. */
         box-shadow: 0 0 0 2px rgba(255, 105, 97, 0.30),
-                    0 0 0 8px rgba(255, 105, 97, 0);
+                    0 0 0 10px rgba(255, 105, 97, 0);
         transform: scale(1.08);
     }
 }

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -4575,14 +4575,21 @@ body.appearance-light .settings-section-select {
 .app-logo {
     position: fixed;
     right: 14px;
-    /* Cleared up from 32px — the previous value put the overlay right on top
-       of the Claude usage bar's content (see @soderbjorn screenshot on
-       #16), because the populated usage bar's effective height
-       (min-height 24 px + 3 px vertical padding + 1 px top border ≈ 28–30 px)
-       didn't leave enough breathing room before the dot's glow ring. 44 px
-       gives the wordmark and its pulse halo a comfortable band above the
-       bottom bar in both the populated and empty states. */
-    bottom: 44px;
+    /* The logo lives *inside the Claude usage bar band* at the bottom of the
+       window, NOT floating above it inside the tab content area. Earlier
+       iterations tried 32 px (collided with the bar's content — first
+       @soderbjorn screenshot on #16) and then 44 px (bumped away from the
+       collision but that pushed the overlay up into the terminal tab's
+       rounded bottom-right corner, so it started visually living inside
+       the tab content surface — second @soderbjorn screenshot on #16:
+       "it's not supposed to be inside the tab content area").
+       At 7 px the wordmark (~15 px cap-height) and 13 px dot sit vertically
+       centred within the ~30 px populated bar (24 px min-height + 6 px
+       vertical padding + 1 px top border), and within the 24 px empty-bar
+       band they still only push their pulse halo a few pixels above the
+       bar's top border — i.e. "only minimally overlaying padding" above
+       the bar rather than sitting wholly on top of the tab content. */
+    bottom: 7px;
     display: flex;
     align-items: center;
     /* Slightly wider gap to match the bumped-up dot size so the wordmark


### PR DESCRIPTION
Closes #14

## Summary
Reintroduces the Termtastic wordmark + status dot as a fixed overlay in the lower-right corner of the web UI. The dot mirrors the per-tab spinner/warning semantics at an aggregate level: it pulses blue when any tab is working, pulses red when any tab is waiting for input, and sits dim otherwise. The Claude usage bar is now always visible at the bottom of the window (empty when there's no data) so the logo has a consistent band of chrome to sit against.

## Background
Issue #14 asks for the old "Termtastic" label with its familiar coloured dot to come back, but repositioned to the lower-right corner (previously it lived upper-left in the header). The issue specifies three things:

1. The bottom bar should always be present, even when Claude Code usage polling is disabled — the bar should reserve space regardless of content.
2. The wordmark + dot should be overlaid in the lower-right corner, painted on top of everything, sized so they don't crowd the main content.
3. The dot should pulsate blue when any tab has work in progress and red when any tab is waiting for input (mirroring the historical behaviour, but now with colours tied to *work state* rather than socket state).

The issue text says "If the sidebar has no content, it should still take up space" — from context this is clearly a slip of the pen for "bottom bar." Proceeding with that interpretation since it's the only reading that fits the rest of the paragraph (the whole item is about the bottom bar) and makes the request internally consistent.

## Approach
Four moving parts:

1. **New overlay element** — `#app-logo` is appended directly inside `<body>` in `index.html` (outside `#app`), containing a `.app-logo-wordmark` span and a `.app-logo-dot` span. Being a sibling of `#app` rather than a child means it doesn't participate in flex layout and can overlay the whole window via `position: fixed; right; bottom; z-index: 100; pointer-events: none`.
2. **State aggregation** — a new `AppLogo.kt` module exposes `updateAppLogoState(sessionStates)`. The aggregation rule walks the session state map once: any "waiting" → red (wins, because it's action-required); else any "working" → blue; else idle. The function short-circuits on the first "waiting" it sees.
3. **Hook-up** — `updateStateIndicators()` in `WebState.kt` now calls `updateAppLogoState(sessionStates)` alongside the existing sidebar/tab-bar spinner updates. That function already runs on every state envelope and every config render, so the dot stays in sync without needing its own subscription.
4. **Always-on bottom bar** — `updateClaudeUsageBadge()` in `ClaudeUsageBar.kt` no longer hides the bar when `usage` is `null` or `undefined`; it empties its content and switches it to a new `.claude-usage-bar-empty` class instead. The base `.claude-usage-bar` rule gains a `min-height: 24px` so the bar reserves space whether or not it has content. The drag-divider above it still hides in the empty case (there's nothing to drag-collapse).

CSS delivers the dot itself: a 10 px circle coloured from `--text-secondary` in idle, with `@keyframes app-logo-pulse-blue` / `app-logo-pulse-red` animations added by the state modifier classes. The red pulse is shorter (1.2 s) and slightly scales the dot, matching the same "waiting is more urgent" cue `.pane-status-spinner.state-waiting` already uses via `fade-warning`.

## Decisions & reasoning

### Overlay placed outside `#app` (sibling of `#app` inside `<body>`)
`#app` is a full-height flex column; adding the logo inside it would either push other content or force awkward absolute positioning inside a flex child. Putting the overlay at the same level as `#app` with `position: fixed` lets it float over the whole window cleanly and survives any future restructuring of the app's flex layout. The trade-off is that it lives slightly "outside" the Kotlin/JS rendering tree — but it's static markup that only needs one class update at a time, so that's fine.

### Dot colours: blue for working, red for waiting
The old design (per the issue) specifies the same blue/red mapping, so this is a direct carry-over. Blue being "normal progress" and red being "needs you" is also consistent with most chat-app conventions and with the existing `.pane-status-spinner.state-waiting` (which uses `--t-semantic-warn` yellow for the warning triangle — I kept the dot distinct with red so the two surfaces don't look identical; the in-bar triangle is informational, the overlay dot is a window-level alert).

### Dot on the right of the wordmark (not the left)
The issue explicitly calls this out as a change from the previous design. No judgement call here — just following the spec.

### Always-on bottom bar via `min-height` rather than a filler string
I considered rendering placeholder content ("no usage data") in the empty bar, but that would have felt noisy — the bar is most often empty for users who don't opt into Claude polling, and a permanent "no data" string becomes visual junk. A plain empty band at `min-height: 24px` reads as intentional chrome. When data arrives, `updateClaudeUsageBadge` fills it as before.

### Drag-divider stays hidden in the empty case
The usage-bar-divider's job is to let the user drag the usage bar shut. When the bar is empty there's nothing to shut — collapsing an already-empty band would only add an invisible hit target and a confusing interaction. Leaving the divider `display: none` keeps the behaviour well-defined: divider appears if and only if there's data to grab.

### Respect `prefers-reduced-motion`
The pulse animations are decorative; users who opt out of motion still get the colour change. A `@media (prefers-reduced-motion: reduce)` block disables the keyframes. This matches existing hygiene in the stylesheet.

### Logo font matches `.header-title` (Georgia serif) even though the header title itself is no longer rendered
The old design used Georgia for the wordmark; the `.header-title` CSS rule still exists from that era. Reusing that font family keeps the brand mark consistent with the (historical) header — and if the title is ever brought back, both will match without further work.

## Assumptions
- The issue text saying "the sidebar should still take up space" is a slip for "the bottom bar should still take up space." The paragraph is otherwise about the bottom bar. If that reading is wrong, sidebar behaviour would need separate work.
- Session state values of interest are the string literals `"working"` and `"waiting"`. Anything else (including `null`, `"done"`, or debug override labels other than these two) is treated as idle. This matches how `updateStateIndicators` already interprets the same map.
- `#app-logo` placed outside `#app` is acceptable architecturally. The repo has no existing precedent for body-level overlays, but `#app` being a layout container rather than a semantic root makes this reasonable.

## Alternatives considered and rejected
- **Render the logo inside `.app-header`** — rejected: the issue explicitly wants it in the lower-right, and overlays inside the flex header would fight the header-drag Electron region and the header-collapse divider behaviour.
- **Embed the logo inside `.claude-usage-bar`** — rejected: when the bar has data, the logo would either overlap usage items or push them around. Fixed overlay avoids the layout coupling entirely.
- **Use the tab-bar spinner's yellow for the "waiting" dot** — rejected: a second yellow indicator in the same screen area would conflate the per-tab warning with the window-level alert. Red gives the overlay its own voice.
- **Show a "Claude usage unavailable" tagline when the bar is empty** — rejected as noisy; see Decisions above.

## Verification
- `./gradlew :web:build` passes locally.
- `./gradlew build -x test` passes across all modules (android, iOS framework links, server, etc.) — no regressions from the new logo file or the CSS / HTML tweaks.
- Manual UI verification not performed in this environment (no browser available in the sandbox) — please sanity-check: (a) the logo appears in the lower-right at load; (b) the dot goes blue when a terminal is "working" and red when "waiting" (the Debug menu's per-session override can force both states); (c) the bottom bar is visible as a thin empty strip when no Claude usage data is coming in; (d) the bar renders populated as before once data arrives; (e) `prefers-reduced-motion` disables the pulse.
- No changes to the `.app-header` no-drag allowlist needed — the logo lives outside the header and the drag-region rule doesn't apply to it.

## Files of note
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/AppLogo.kt` — new file, the aggregation rule and DOM update lives here.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/WebState.kt` — single-line call site hook in `updateStateIndicators`.
- `web/src/jsMain/kotlin/se/soderbjorn/termtastic/ClaudeUsageBar.kt` — the no-data branch now empties the bar instead of hiding it.
- `web/src/jsMain/resources/index.html` — adds the `#app-logo` element and flips the initial usage-bar class to the empty variant.
- `web/src/jsMain/resources/styles.css` — `.app-logo*` rules, the two pulse keyframes, the reduced-motion override, and the usage-bar `min-height` / `.claude-usage-bar-empty` tweak.

## Follow-ups
- If the repo owner wants the old *connection* status (socket connecting / connected / disconnected) reflected somewhere again, the dot could be extended with a fourth state. Out of scope for #14.
- The logo's `right`/`bottom` offsets are hard-coded (14 px / 32 px). If the bottom bar's height ever changes substantially, those need updating. Could be tokenised later if there's demand.

Generated with [Claude Code](https://claude.com/claude-code)