### PR TITLE
Inset the Android terminal surface so text clears the screen edges

### DIFF
--- a/androidApp/src/main/kotlin/se/soderbjorn/termtastic/android/ui/TerminalScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/termtastic/android/ui/TerminalScreen.kt
@@ -491,10 +491,23 @@ fun TerminalScreen(
                 .padding(paddingValues)
                 .background(bgComposeColor),
         ) {
+            // Small inset around the terminal render surface so glyphs in
+            // the leftmost column / topmost row don't sit flush against the
+            // screen edge. Termux's TerminalView draws directly against its
+            // own getWidth()/getHeight() — it ignores Android view padding —
+            // so we apply the inset at the Compose layer by shrinking the
+            // Box that hosts it. The resulting smaller viewport flows back
+            // through TerminalView.updateSize() to produce an appropriate
+            // (slightly smaller) cols/rows grid automatically.
+            // Horizontal inset is larger than vertical because the
+            // screenshot in issue #15 shows horizontal crowding on phones
+            // while the IME toolbar already provides vertical separation
+            // at the bottom and the top app bar does the same at the top.
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .padding(horizontal = 6.dp, vertical = 2.dp),
             ) {
             AndroidView(
                 modifier = Modifier


### PR DESCRIPTION
Closes #15

## Summary
Adds a small Compose-level inset around the Termux `TerminalView` on the Android terminal screen so rendered glyphs no longer sit flush against the screen's left/right edges on phones. The inset is 6 dp horizontal and 2 dp vertical, applied to the `Box` that hosts the `AndroidView` holding `TerminalView`; this flows naturally through `TerminalView.updateSize()` to produce a slightly narrower cols grid without touching any vendored terminal code.

## Background
Issue #15 reports that "text appears sometimes slightly off the edge (or at least slightly too close to the edge) in the Android app while viewing a terminal" and asks for "some (minimal) padding". The attached screenshot shows a phone portrait view with the output column rendering right up against the left edge of the screen. Nothing is actually clipped by the OS — the letterforms just have zero breathing room against the bezel, which reads as cramped.

## Approach
The terminal is rendered by a Termux `TerminalView` embedded via `AndroidView` inside a `Scaffold` `Column` → `Box` in `TerminalScreen.kt`. Previously the `Box` was sized with just `.weight(1f).fillMaxWidth()`, so the `TerminalView` filled it edge-to-edge. The change adds `.padding(horizontal = 6.dp, vertical = 2.dp)` to that `Box`. The inner `AndroidView` still calls `.fillMaxSize()`, so the `TerminalView` gets the inset-reduced area. `TerminalView.updateSize()` reads `getWidth()` / `getHeight()` on every size change and derives new cols/rows from the font metrics — so the grid automatically adapts to the slightly smaller viewport and the server receives the correct resize. No grid-metrics code, no color/theme code, and nothing in the vendored `terminal-view` or `terminal-emulator` modules had to change.

## Decisions & reasoning

### Padding at the Compose `Box` layer, not as Android view-padding on `TerminalView`
The obvious-looking alternative is `AndroidView(modifier = Modifier.padding(...))` or calling `view.setPadding(...)` on the `TerminalView` in the `factory` lambda. Both would fail silently: `TerminalRenderer` in the vendored `terminal-view` module draws against `view.getWidth()` / `view.getHeight()` and `mRenderer.mFontWidth` — it does not consult `getPaddingLeft()` / `getPaddingTop()` at all (see `TerminalView.java:989-995`). Setting Android view padding would therefore reserve the space but still paint over it, moving the problem rather than fixing it. Shrinking the hosting `Box` at the Compose layer makes the `TerminalView` itself measure smaller, so its internal draw math stays consistent. The trade-off is that the padded band has the surface background colour rather than the terminal background colour — since the hosting `Column` already paints with the resolved terminal `bgComposeColor`, these colours match and the inset is invisible as a seam.

### Asymmetric inset: 6 dp horizontal, 2 dp vertical
The crowding in the issue's screenshot is a horizontal problem: the leftmost column of characters touches the screen edge. Vertical spacing is already comfortable because the `TopAppBar` sits above the terminal and the `ImeHelperToolbar` (plus optional `SwipeInputBar`) sits below — both provide generous vertical separation from the screen bezel. A small 2 dp vertical inset keeps the topmost row / bottommost row from sitting right on the edge of the internal background rectangle while still being effectively invisible. The horizontal value (6 dp) is a judgement call — enough to visibly lift glyphs off the edge on a 1080 px-wide phone (≈18 px at xxhdpi) without sacrificing a whole column on narrow devices. The issue explicitly asks for a "minimal" amount, so I stayed conservative; if it reads too tight on physical hardware the value is a one-line tweak.

### No new user-facing setting for the inset
I considered exposing the inset as a setting (so power users can go back to edge-to-edge), but the issue frames this as a fix rather than a preference, and the inset is small enough that it shouldn't bother anyone. Adding a preference would also expand the `UiSettings` shape for a cosmetic toggle, which runs against the "simple JSON settings" preference recorded in the user's project memory. If demand surfaces, a global terminal-padding knob can be added later as a single numeric value in the settings JSON.

### Scoped to Android (no web / iOS / Electron changes)
The issue is tagged `ai-dev` and describes the Android app specifically. The web front-end already wraps the xterm.js surface in a padded container (the `.pane-inner` / terminal wrapper rules in `styles.css`), and the Electron app reuses the same web UI. iOS uses a different terminal stack entirely. So the fix lives only in `TerminalScreen.kt` — no cross-platform parity work was needed here.

## Assumptions
- The screenshot in the issue represents the general case, not an edge case of a specific theme or column count. If there's a particular device / configuration where the crowding is worse, the 6 dp value may need bumping.
- The surface behind the inset band is the terminal's own background, which is correct because the hosting `Column` already uses `bgComposeColor` from the resolved palette. I verified this in code but not in a running app.

## Alternatives considered and rejected
- **`view.setPadding(...)` on the `TerminalView`** — silently ineffective; `TerminalRenderer` ignores view padding and paints over it.
- **Modifying the vendored `terminal-view` renderer to respect padding** — out of scope and the `terminal-view` / `terminal-emulator` modules are explicitly excluded from the project's documentation / modification rules in `CLAUDE.md`. Keeping the fix on the consumer side avoids divergence from the upstream fork.
- **Adding the inset on the outer `Column` (the one that takes `paddingValues`)** — that would also pad the `ImeHelperToolbar` and `SwipeInputBar`, which are already correctly flush; only the terminal surface needs the breathing room.

## Verification
- `./gradlew :androidApp:assembleDebug` passes locally (clean build, no warnings introduced by the change).
- Manual on-device visual verification **not performed** — this sandbox has no Android device / emulator available. The user should sanity-check the result on hardware: (a) the leftmost column of terminal text no longer touches the screen edge, (b) the padded band is not visible as a colour seam (should blend with the terminal background), (c) column count on resize / rotation still matches what the server expects (check by running `stty -a` or observing that Claude Code's UI doesn't reflow incorrectly), and (d) no regression to the pinch-to-zoom gesture (the `TerminalView` still fills the padded `Box`, so gestures work as before).

## Files of note
- `androidApp/src/main/kotlin/se/soderbjorn/termtastic/android/ui/TerminalScreen.kt` — one change: the inner `Box` that hosts the `TerminalView` gains `.padding(horizontal = 6.dp, vertical = 2.dp)`, and an inline comment explains why the inset has to live here rather than on the `AndroidView` or the `TerminalView` itself.

## Follow-ups
- If the inset value turns out to be wrong on real hardware (too tight on large phones, too loose on small tablets), it could be promoted to a density-aware constant or made theme-configurable. Starting with a hard-coded conservative value keeps this PR minimal, in line with the issue's "minimal" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)