### PR TITLE
Encrypt all transport with TLS + TOFU pinning; auto-trust bootstrap localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Termtastic is a terminal replacement suitable for the modern age of agentic software development.
 
-The code has not undergone thorough review. Some parts are more well-tested and complete while others are very much work in progress. **One important note is that if you enable remote connections from other devices, take note that these are plain HTTP, not HTTPS.**
+The code has not undergone thorough review. Some parts are more well-tested and complete while others are very much work in progress.
+
+The server speaks **HTTPS only**, using a self-signed certificate that's generated on first boot. Native clients (Android, iOS) trust the certificate via SSH-style fingerprint pinning: the first successful connect captures the leaf cert's SHA-256, and every subsequent connect verifies against that pin. Web browsers will show a one-time "self-signed certificate" warning the first time you visit the server's URL — accept it once and the browser remembers. The packaged Electron app accepts the loopback certificate silently; loopback traffic can't be MITM'd, so pinning it would only complicate the dev cycle. To rotate the certificate, delete `~/Library/Application Support/Termtastic/tls/` and restart — pinned mobile clients will then surface a "cert changed, re-pair?" prompt on next connect.
 
 ## Features
 

--- a/androidApp/src/main/kotlin/se/soderbjorn/termtastic/android/ui/HostsScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/termtastic/android/ui/HostsScreen.kt
@@ -79,6 +79,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import se.soderbjorn.termtastic.android.data.ConnectionRepository
 import se.soderbjorn.termtastic.client.HostEntry
@@ -132,6 +134,12 @@ fun HostsScreen(
     var editTarget by remember { mutableStateOf<EditTarget?>(null) }
     var deleteTarget by remember { mutableStateOf<HostEntry?>(null) }
     var connectingId by remember { mutableStateOf<String?>(null) }
+    // When non-null, the user just attempted to connect to this host and the
+    // server presented a TLS certificate that doesn't match the pinned
+    // fingerprint we captured on a previous connect. The dialog gives them
+    // the choice to re-pair (clearing the pin so the next connect captures
+    // anew) or cancel.
+    var pinMismatchTarget by remember { mutableStateOf<HostEntry?>(null) }
     val pendingApproval by (ConnectionHolder.pendingApproval
         ?: kotlinx.coroutines.flow.MutableStateFlow(false)).collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -192,20 +200,46 @@ fun HostsScreen(
                                     runCatching {
                                         val token = getOrCreateToken(connectionRepo.authTokenStore())
                                         ConnectionHolder.connect(
-                                            serverUrl = ServerUrl(host = entry.host, port = entry.port),
+                                            serverUrl = ServerUrl(
+                                                host = entry.host,
+                                                port = entry.port,
+                                                pinnedFingerprintHex = entry.pinnedFingerprintHex,
+                                            ),
                                             authToken = token,
                                         )
                                     }.onSuccess {
+                                        // TOFU capture: if this host had no pin, the trust
+                                        // manager has just observed and emitted the leaf cert's
+                                        // SHA-256. Persist it back so the next connect runs in
+                                        // verify mode. No-op when a pin was already present.
+                                        if (entry.pinnedFingerprintHex == null) {
+                                            ConnectionHolder.client()?.let { client ->
+                                                scope.launch {
+                                                    val fp = client.observedFingerprint
+                                                        .filterNotNull().first()
+                                                    hostsRepo.update(
+                                                        entry.copy(pinnedFingerprintHex = fp),
+                                                    )
+                                                }
+                                            }
+                                        }
                                         connectingId = null
                                         onConnected()
                                     }.onFailure { e ->
                                         connectingId = null
-                                        val msg = e.message ?: "Connection failed"
-                                        scope.launch {
-                                            snackbarHostState.showSnackbar(
-                                                message = msg,
-                                                actionLabel = "Dismiss",
-                                            )
+                                        if (isPinMismatch(e)) {
+                                            // Surface the dedicated re-pair dialog instead
+                                            // of a generic snackbar — pin mismatch is a
+                                            // security-relevant signal.
+                                            pinMismatchTarget = entry
+                                        } else {
+                                            val msg = e.message ?: "Connection failed"
+                                            scope.launch {
+                                                snackbarHostState.showSnackbar(
+                                                    message = msg,
+                                                    actionLabel = "Dismiss",
+                                                )
+                                            }
                                         }
                                     }
                                 }
@@ -249,6 +283,63 @@ fun HostsScreen(
             },
         )
     }
+
+    pinMismatchTarget?.let { entry ->
+        PinMismatchDialog(
+            entry = entry,
+            onDismiss = { pinMismatchTarget = null },
+            onRepair = {
+                scope.launch {
+                    hostsRepo.update(entry.copy(pinnedFingerprintHex = null))
+                    pinMismatchTarget = null
+                }
+            },
+        )
+    }
+}
+
+/**
+ * Recursively walks the cause chain looking for the `pin-mismatch:` marker
+ * thrown from [se.soderbjorn.termtastic.client.HttpClientFactory]'s Android
+ * trust manager. We can't rely on a specific exception type because the error
+ * surfaces through Ktor + OkHttp wrappers (e.g. `SSLHandshakeException` or
+ * a coroutine `CancellationException`).
+ */
+private fun isPinMismatch(t: Throwable?): Boolean {
+    var cur: Throwable? = t
+    while (cur != null) {
+        if (cur.message?.contains("pin-mismatch") == true) return true
+        cur = cur.cause
+    }
+    return false
+}
+
+/**
+ * Confirmation dialog shown when the server's TLS certificate doesn't match
+ * the previously-pinned fingerprint. Tapping "Re-pair" clears the stored pin
+ * and asks the user to retry the connection — capture mode then runs again
+ * and stores the new fingerprint. Tapping "Cancel" leaves the pin intact.
+ */
+@Composable
+private fun PinMismatchDialog(
+    entry: HostEntry,
+    onDismiss: () -> Unit,
+    onRepair: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Server certificate changed") },
+        text = {
+            Text(
+                "The server at ${entry.host}:${entry.port} is presenting a different " +
+                    "TLS certificate than the one you paired with previously.\n\n" +
+                    "This may mean the server was reinstalled, or that someone is intercepting " +
+                    "your connection. Re-pair only if you trust this network.",
+            )
+        },
+        confirmButton = { TextButton(onClick = onRepair) { Text("Re-pair") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 /**

--- a/client/src/androidMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.android.kt
+++ b/client/src/androidMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.android.kt
@@ -1,0 +1,106 @@
+/**
+ * Android (OkHttp) implementation of [createPlatformHttpClient] with
+ * SSH-style TOFU fingerprint pinning.
+ *
+ * Installs a custom [javax.net.ssl.X509TrustManager] that operates in one of
+ * two modes depending on whether a pin is provided:
+ *
+ *  - **Capture** (`pinnedFingerprintHex == null`): does not validate the cert
+ *    chain (self-signed, no trust anchor). Computes SHA-256 of the leaf cert's
+ *    DER, latches it via an [java.util.concurrent.atomic.AtomicBoolean] so the
+ *    callback fires at most once, and dispatches [onPeerCertCaptured] off the
+ *    network thread. The caller writes the value back to host storage.
+ *  - **Verify**: computes the leaf's SHA-256, compares constant-time against
+ *    the pin. Mismatch throws a [java.security.cert.CertificateException]
+ *    whose message starts with `"pin-mismatch:"` so UI code can detect it via
+ *    cause-chain inspection and show a "cert changed, re-pair?" dialog.
+ *
+ * OkHttp's own `CertificatePinner` is not suitable: it pins on top of a
+ * successful default trust check, which we don't have for self-signed certs.
+ *
+ * @see HttpClientFactory
+ */
+package se.soderbjorn.termtastic.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Build an Android [HttpClient] backed by OkHttp with TLS fingerprint
+ * pinning installed via a custom [X509TrustManager].
+ */
+actual fun createPlatformHttpClient(
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (fingerprintHex: String) -> Unit,
+): HttpClient = HttpClient(OkHttp) {
+    applyCommonClientConfig(this)
+    engine {
+        config {
+            val tm = TermtasticPinningTrustManager(pinnedFingerprintHex, onPeerCertCaptured)
+            val ctx = SSLContext.getInstance("TLS").apply {
+                init(null, arrayOf<X509TrustManager>(tm), SecureRandom())
+            }
+            sslSocketFactory(ctx.socketFactory, tm)
+            // Pinning supersedes hostname identity for self-signed certs
+            // (the SAN list on the server side is for browser convenience).
+            hostnameVerifier(HostnameVerifier { _, _ -> true })
+        }
+    }
+}
+
+/**
+ * Two-mode trust manager. Verify when [pinnedFingerprintHex] is non-null;
+ * capture and emit the observed leaf fingerprint via [onPeerCertCaptured]
+ * (once per client lifetime) when null.
+ */
+private class TermtasticPinningTrustManager(
+    private val pinnedFingerprintHex: String?,
+    private val onPeerCertCaptured: (String) -> Unit,
+) : X509TrustManager {
+
+    private val captured = AtomicBoolean(false)
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        // Server-side authentication only — clients do not present certs.
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        if (chain.isNullOrEmpty()) {
+            throw CertificateException("Empty server certificate chain")
+        }
+        val leafFingerprintHex = sha256Hex(chain[0].encoded)
+        val pin = pinnedFingerprintHex
+        if (pin == null) {
+            if (captured.compareAndSet(false, true)) {
+                // Hop off the TLS handshake thread: storage writes (DataStore
+                // for hosts, etc.) must not block the network handshake.
+                Thread {
+                    runCatching { onPeerCertCaptured(leafFingerprintHex) }
+                }.apply { isDaemon = true; name = "termtastic-tofu-capture" }.start()
+            }
+            return
+        }
+        val pinBytes = pin.lowercase().toByteArray(Charsets.US_ASCII)
+        val leafBytes = leafFingerprintHex.toByteArray(Charsets.US_ASCII)
+        if (!MessageDigest.isEqual(pinBytes, leafBytes)) {
+            throw CertificateException(
+                "pin-mismatch: server presented $leafFingerprintHex but client pinned $pin"
+            )
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+
+    private fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/HostEntry.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/HostEntry.kt
@@ -13,10 +13,14 @@ import kotlinx.serialization.Serializable
 /**
  * A single saved Termtastic server endpoint shown in the host picker UI.
  *
- * @property id    Unique identifier for this entry (typically a UUID).
- * @property label Human-readable display name chosen by the user (e.g. "Home server").
- * @property host  Hostname or IP address of the Termtastic server.
- * @property port  TCP port the server listens on.
+ * @property id                   Unique identifier for this entry (typically a UUID).
+ * @property label                Human-readable display name chosen by the user (e.g. "Home server").
+ * @property host                 Hostname or IP address of the Termtastic server.
+ * @property port                 TCP port the server listens on.
+ * @property pinnedFingerprintHex Lowercase hex SHA-256 of the server's leaf TLS
+ *   certificate, captured TOFU-style on the first successful connect. `null`
+ *   means "not yet captured" — the next connect runs in capture mode and pins
+ *   whatever the server presents.
  */
 @Serializable
 data class HostEntry(
@@ -24,4 +28,5 @@ data class HostEntry(
     val label: String,
     val host: String,
     val port: Int,
+    val pinnedFingerprintHex: String? = null,
 )

--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.kt
@@ -1,0 +1,60 @@
+/**
+ * Per-platform [HttpClient] factory with TLS fingerprint pinning.
+ *
+ * Each Kotlin Multiplatform target supplies an `actual` implementation that
+ * wires the platform's HTTP engine (OkHttp on Android, Darwin on iOS, CIO on
+ * the JVM, browser fetch on JS) and installs a custom trust callback used for
+ * SSH-style Trust-On-First-Use (TOFU) certificate pinning.
+ *
+ * Two operating modes:
+ *   - **Capture** (`pinnedFingerprintHex == null`): no chain validation; the
+ *     leaf cert's SHA-256 is computed, exposed via [onPeerCertCaptured], and
+ *     persisted by the caller (typically off the network thread).
+ *   - **Verify** (`pinnedFingerprintHex != null`): the leaf's SHA-256 is
+ *     constant-time compared against the pin; mismatch aborts the handshake
+ *     and surfaces an exception the UI catches as "cert changed, re-pair?".
+ *
+ * Web/JS does not pin — the browser owns TLS verification and pinning is not
+ * exposed to fetch. Both arguments are ignored on that target.
+ *
+ * @see TermtasticClient
+ */
+package se.soderbjorn.termtastic.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.websocket.WebSockets
+
+/**
+ * Apply the configuration shared by every platform: WebSockets and a strict
+ * connect/request timeout so that an unreachable host fails fast rather than
+ * hanging on SYN retransmits for ~75 seconds.
+ *
+ * @param config the platform's [HttpClientConfig] builder; mutated in place.
+ */
+fun applyCommonClientConfig(config: HttpClientConfig<*>) {
+    config.install(WebSockets)
+    config.install(HttpTimeout) {
+        connectTimeoutMillis = 8_000
+        requestTimeoutMillis = 15_000
+    }
+}
+
+/**
+ * Build a Ktor [HttpClient] for the current platform.
+ *
+ * @param pinnedFingerprintHex lowercase hex SHA-256 of the server's leaf
+ *   certificate that the client should pin against, or `null` to run in TOFU
+ *   capture mode.
+ * @param onPeerCertCaptured invoked at most once per client when the leaf
+ *   cert is observed during the handshake — only fires in capture mode (i.e.
+ *   when [pinnedFingerprintHex] is `null`). The callback receives the same
+ *   lowercase hex SHA-256 the caller is expected to persist.
+ * @return a configured [HttpClient]. The caller owns its lifecycle and must
+ *   call `close()` to release the engine.
+ */
+expect fun createPlatformHttpClient(
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (fingerprintHex: String) -> Unit,
+): HttpClient

--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/ServerUrl.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/ServerUrl.kt
@@ -15,14 +15,23 @@ package se.soderbjorn.termtastic.client
  * the scheme/host/port split so the various websocket and REST endpoints
  * (`/window`, `/pty/{id}`, `/api/ui-settings`) can be derived consistently.
  *
- * @property host   hostname or IP address of the Termtastic server.
- * @property port   TCP port the server listens on (no default).
- * @property useTls if `true`, use `https`/`wss`; otherwise `http`/`ws`.
+ * @property host                 hostname or IP address of the Termtastic server.
+ * @property port                 TCP port the server listens on (no default).
+ * @property useTls               if `true`, use `https`/`wss`; otherwise `http`/`ws`.
+ *   Defaults to `true` — every Termtastic server now serves TLS only. Set to
+ *   `false` only when targeting an explicitly insecure dev setup.
+ * @property pinnedFingerprintHex lowercase hex SHA-256 of the server's leaf
+ *   certificate. When `null`, the underlying client runs in TOFU capture mode
+ *   on first connect and surfaces the observed fingerprint via
+ *   [TermtasticClient.observedFingerprint] so the caller can persist it.
+ *   When set, the platform `createPlatformHttpClient` verifies the leaf cert
+ *   matches and refuses the connection on mismatch.
  */
 data class ServerUrl(
     val host: String,
     val port: Int,
-    val useTls: Boolean = false,
+    val useTls: Boolean = true,
+    val pinnedFingerprintHex: String? = null,
 ) {
     /** `"https"` or `"http"` depending on [useTls]. */
     val httpScheme: String get() = if (useTls) "https" else "http"

--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/TermtasticClient.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/TermtasticClient.kt
@@ -18,11 +18,12 @@
 package se.soderbjorn.termtastic.client
 
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.json.Json
 import se.soderbjorn.termtastic.windowJson
 
@@ -90,22 +91,34 @@ class TermtasticClient(
      */
     internal val json: Json = windowJson
 
-    internal val httpClient: HttpClient = HttpClient {
-        install(WebSockets)
-        // Without this, an unreachable host (device on a different subnet,
-        // Wi-Fi client isolation, wrong port) makes the WebSocket handshake
-        // hang in kernel SYN retransmit for ~75 seconds before OkHttp gives
-        // up. Cap it at 8 s so the UI surfaces the failure quickly.
-        install(HttpTimeout) {
-            connectTimeoutMillis = 8_000
-            requestTimeoutMillis = 15_000
-        }
-        // Note: we don't install HttpCookies here because ws(s):// upgrades
-        // in Ktor don't always thread cookies through all engines reliably.
-        // Instead, every socket URL gets `?auth=<token>` appended — this is
-        // the same belt-and-braces channel the server-side readAuthToken
-        // helper already recognises (see Application.kt:readAuthToken).
-    }
+    /**
+     * Lowercase hex SHA-256 of the server's leaf TLS certificate, observed
+     * during the most recent successful TLS handshake.
+     *
+     * - In **capture mode** (no pin set on [serverUrl]), the platform HTTP
+     *   client emits the captured fingerprint here on first connect; consumers
+     *   subscribe and persist it back to their host-list storage so subsequent
+     *   connections enter verify mode.
+     * - In **verify mode** (pin set), the value mirrors the pin once a connect
+     *   succeeds — useful for diagnostics but no write-back is required.
+     *
+     * Stays `null` until the first successful TLS handshake. Network thread
+     * must not call back into storage; see platform `actual` implementations
+     * for the off-thread emission contract.
+     */
+    private val _observedFingerprint: MutableStateFlow<String?> =
+        MutableStateFlow(serverUrl.pinnedFingerprintHex)
+    val observedFingerprint: StateFlow<String?> = _observedFingerprint.asStateFlow()
+
+    internal val httpClient: HttpClient = createPlatformHttpClient(
+        pinnedFingerprintHex = serverUrl.pinnedFingerprintHex,
+        onPeerCertCaptured = { fp -> _observedFingerprint.value = fp },
+    )
+    // Note: we don't install HttpCookies here because ws(s):// upgrades
+    // in Ktor don't always thread cookies through all engines reliably.
+    // Instead, every socket URL gets `?auth=<token>` appended — this is
+    // the same belt-and-braces channel the server-side readAuthToken
+    // helper already recognises (see Application.kt:readAuthToken).
 
     /**
      * Open (or return) a websocket to `/window`. The returned [WindowSocket]

--- a/client/src/iosMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.ios.kt
+++ b/client/src/iosMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.ios.kt
@@ -1,0 +1,163 @@
+/**
+ * iOS (Darwin) implementation of [createPlatformHttpClient] with TOFU
+ * fingerprint pinning.
+ *
+ * Hooks into Ktor-Darwin's `engine { handleChallenge { ... } }` block. When
+ * iOS's URL loading system invokes the server-trust authentication challenge,
+ * the handler:
+ *
+ *   - Extracts the leaf certificate via `SecTrustGetCertificateAtIndex(trust, 0)`.
+ *   - Computes its SHA-256 via `CC_SHA256` from CommonCrypto.
+ *   - In capture mode (no pin): emits the fingerprint via
+ *     [onPeerCertCaptured] off the network thread, then accepts the cert with
+ *     `challenge.proposedCredential`.
+ *   - In verify mode (pin set): constant-time-compares against the pin and
+ *     either accepts the credential (match) or cancels the challenge (mismatch).
+ *
+ * @see HttpClientFactory
+ */
+package se.soderbjorn.termtastic.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.CoreFoundation.CFDataGetBytePtr
+import platform.CoreFoundation.CFDataGetLength
+import platform.CoreFoundation.CFRelease
+import platform.Foundation.*
+import platform.Security.*
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_global_queue
+import kotlin.concurrent.AtomicReference
+
+/**
+ * Build an iOS [HttpClient] using Ktor Darwin with a TLS fingerprint
+ * pinning challenge handler.
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual fun createPlatformHttpClient(
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (fingerprintHex: String) -> Unit,
+): HttpClient {
+    val captureLatch = AtomicReference(false)
+    return HttpClient(Darwin) {
+        applyCommonClientConfig(this)
+        engine {
+            handleChallenge { _, _, challenge, completionHandler ->
+                handleServerTrust(
+                    challenge = challenge,
+                    pinnedFingerprintHex = pinnedFingerprintHex,
+                    onPeerCertCaptured = onPeerCertCaptured,
+                    captureLatch = captureLatch,
+                    completionHandler = completionHandler,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun handleServerTrust(
+    challenge: NSURLAuthenticationChallenge,
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (String) -> Unit,
+    captureLatch: AtomicReference<Boolean>,
+    completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential?) -> Unit,
+) {
+    val protectionSpace = challenge.protectionSpace
+    if (protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust) {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, null)
+        return
+    }
+    val serverTrust: SecTrustRef? = protectionSpace.serverTrust
+    if (serverTrust == null) {
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
+        return
+    }
+    val leafFingerprintHex = leafSha256Hex(serverTrust)
+    if (leafFingerprintHex == null) {
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
+        return
+    }
+
+    if (pinnedFingerprintHex == null) {
+        // Capture mode — accept whatever the server presents and emit the
+        // fingerprint to the caller off the TLS handshake thread.
+        if (captureLatch.compareAndSet(expected = false, newValue = true)) {
+            val captured = leafFingerprintHex
+            dispatch_async(
+                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u),
+            ) {
+                runCatching { onPeerCertCaptured(captured) }
+            }
+        }
+        // Use the system-proposed credential, which iOS provides for ServerTrust
+        // challenges and which `URLSession` understands as "accept this cert".
+        completionHandler(
+            NSURLSessionAuthChallengeUseCredential,
+            challenge.proposedCredential,
+        )
+    } else {
+        if (constantTimeEquals(leafFingerprintHex, pinnedFingerprintHex.lowercase())) {
+            completionHandler(
+                NSURLSessionAuthChallengeUseCredential,
+                challenge.proposedCredential,
+            )
+        } else {
+            completionHandler(
+                NSURLSessionAuthChallengeCancelAuthenticationChallenge,
+                null,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun leafSha256Hex(serverTrust: SecTrustRef): String? {
+    val count = SecTrustGetCertificateCount(serverTrust)
+    if (count <= 0) return null
+    val leaf = SecTrustGetCertificateAtIndex(serverTrust, 0) ?: return null
+    val der = SecCertificateCopyData(leaf) ?: return null
+    try {
+        val length = CFDataGetLength(der).toInt()
+        if (length <= 0) return null
+        val ptr = CFDataGetBytePtr(der) ?: return null
+        val bytes = ptr.readBytes(length)
+        return sha256Hex(bytes)
+    } finally {
+        CFRelease(der)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun sha256Hex(input: ByteArray): String {
+    val digest = ByteArray(CC_SHA256_DIGEST_LENGTH)
+    input.usePinned { inPinned ->
+        digest.usePinned { outPinned ->
+            CC_SHA256(
+                inPinned.addressOf(0),
+                input.size.convert(),
+                outPinned.addressOf(0).reinterpret<UByteVar>(),
+            )
+        }
+    }
+    return digest.joinToString("") { ((it.toInt() and 0xff).toString(16).padStart(2, '0')) }
+}
+
+private fun constantTimeEquals(a: String, b: String): Boolean {
+    if (a.length != b.length) return false
+    var diff = 0
+    for (i in a.indices) {
+        diff = diff or (a[i].code xor b[i].code)
+    }
+    return diff == 0
+}

--- a/client/src/jsMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.js.kt
+++ b/client/src/jsMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.js.kt
@@ -1,0 +1,30 @@
+/**
+ * JS (browser) implementation of [createPlatformHttpClient].
+ *
+ * The browser owns TLS verification end-to-end: trust anchor selection,
+ * hostname matching, and any per-origin warning interstitial happen in
+ * Chrome/Safari/Firefox themselves. There is no fetch-level hook to install
+ * a custom trust manager, so fingerprint pinning is not enforced from JS —
+ * users instead click through the browser's self-signed-cert warning once
+ * per origin.
+ *
+ * Both pinning arguments are accepted to keep the signature parallel with
+ * the native targets, but are ignored here.
+ *
+ * @see HttpClientFactory
+ */
+package se.soderbjorn.termtastic.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.js.Js
+
+/**
+ * Build a JS [HttpClient]. Both [pinnedFingerprintHex] and
+ * [onPeerCertCaptured] are intentionally unused — the browser handles TLS.
+ */
+actual fun createPlatformHttpClient(
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (fingerprintHex: String) -> Unit,
+): HttpClient = HttpClient(Js) {
+    applyCommonClientConfig(this)
+}

--- a/client/src/jvmMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.jvm.kt
+++ b/client/src/jvmMain/kotlin/se/soderbjorn/termtastic/client/HttpClientFactory.jvm.kt
@@ -1,0 +1,81 @@
+/**
+ * JVM (CIO) implementation of [createPlatformHttpClient] with TOFU pinning.
+ *
+ * Same two-mode behaviour as the Android actual — a custom
+ * [javax.net.ssl.X509TrustManager] either captures the observed fingerprint
+ * on first connect (when `pinnedFingerprintHex` is null) or verifies the
+ * leaf cert against the pin (and throws `pin-mismatch:` on mismatch).
+ *
+ * The JVM target is used by the `:clientServer` test host and any future
+ * Compose Desktop client; it intentionally does not delegate to the OS trust
+ * store, since Termtastic talks to self-signed servers exclusively.
+ *
+ * @see HttpClientFactory
+ */
+package se.soderbjorn.termtastic.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import java.security.MessageDigest
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Build a JVM [HttpClient] backed by Ktor CIO with TLS fingerprint pinning.
+ */
+actual fun createPlatformHttpClient(
+    pinnedFingerprintHex: String?,
+    onPeerCertCaptured: (fingerprintHex: String) -> Unit,
+): HttpClient = HttpClient(CIO) {
+    applyCommonClientConfig(this)
+    engine {
+        https {
+            trustManager = JvmPinningTrustManager(pinnedFingerprintHex, onPeerCertCaptured)
+        }
+    }
+}
+
+/** See android counterpart for a more detailed comment. */
+private class JvmPinningTrustManager(
+    private val pinnedFingerprintHex: String?,
+    private val onPeerCertCaptured: (String) -> Unit,
+) : X509TrustManager {
+
+    private val captured = AtomicBoolean(false)
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        // Server-side auth only.
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        if (chain.isNullOrEmpty()) {
+            throw CertificateException("Empty server certificate chain")
+        }
+        val leafFingerprintHex = sha256Hex(chain[0].encoded)
+        val pin = pinnedFingerprintHex
+        if (pin == null) {
+            if (captured.compareAndSet(false, true)) {
+                Thread {
+                    runCatching { onPeerCertCaptured(leafFingerprintHex) }
+                }.apply { isDaemon = true; name = "termtastic-tofu-capture-jvm" }.start()
+            }
+            return
+        }
+        val pinBytes = pin.lowercase().toByteArray(Charsets.US_ASCII)
+        val leafBytes = leafFingerprintHex.toByteArray(Charsets.US_ASCII)
+        if (!MessageDigest.isEqual(pinBytes, leafBytes)) {
+            throw CertificateException(
+                "pin-mismatch: server presented $leafFingerprintHex but client pinned $pin"
+            )
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+
+    private fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/electron/build.gradle.kts
+++ b/electron/build.gradle.kts
@@ -7,7 +7,7 @@
 // server/build.gradle.kts). The packaged build still talks to SERVER_PORT
 // (8082) — that path is handled inside main.js, not here.
 val devServerPort = 8083
-val targetUrl = "http://localhost:$devServerPort"
+val targetUrl = "https://127.0.0.1:$devServerPort"
 
 val nodeModulesDir = layout.projectDirectory.dir("node_modules")
 val distDir = layout.projectDirectory.dir("dist")

--- a/electron/main.js
+++ b/electron/main.js
@@ -24,7 +24,35 @@ const APP_NAME = "Termtastic";
 // running alongside developer iteration.
 const PROD_PORT = 8082;
 const URL_OVERRIDE = process.env.TERMTASTIC_URL || null;
-const TARGET_URL = URL_OVERRIDE || `http://localhost:${PROD_PORT}`;
+// Server is HTTPS-only with a self-signed cert generated on first boot.
+// The renderer loads from loopback, so the cert can't be MITM'd; the
+// `certificate-error` handler below accepts any cert for loopback hosts
+// without prompting the user to bypass a browser warning.
+const TARGET_URL = URL_OVERRIDE || `https://127.0.0.1:${PROD_PORT}`;
+
+// Accept the server's self-signed TLS cert silently when (and only when) it's
+// served from loopback. Loopback traffic cannot be MITM'd, so pinning here
+// would only complicate the dev cycle. Remote hosts still get the default
+// rejection — TERMTASTIC_URL pointing at a remote box would surface a fatal
+// `did-fail-load`, which is the right behaviour until the renderer learns to
+// fingerprint-pin.
+app.on("certificate-error", (event, _webContents, url, _error, _cert, callback) => {
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    callback(false);
+    return;
+  }
+  const isLoopback =
+    host === "127.0.0.1" || host === "::1" || host === "localhost";
+  if (isLoopback) {
+    event.preventDefault();
+    callback(true);
+  } else {
+    callback(false);
+  }
+});
 
 // Must run before `app.whenReady()` so the menu/about box pick up the name.
 // NOTE: on macOS in *dev mode*, the system menu bar still reads CFBundleName

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.re
 ktor-serverWebsockets = { module = "io.ktor:ktor-server-websockets-jvm", version.ref = "ktor" }
 ktor-serverContentNegotiation = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktor" }
 ktor-serializationKotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
+ktor-networkTlsCertificates = { module = "io.ktor:ktor-network-tls-certificates", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/iosApp/iosApp/Data/HostsStore.swift
+++ b/iosApp/iosApp/Data/HostsStore.swift
@@ -2,11 +2,18 @@ import Foundation
 import Observation
 
 /// Codable mirror of the shared KMP `HostEntry` for JSON file persistence.
+///
+/// `pinnedFingerprintHex` is the SHA-256 of the server's leaf TLS certificate,
+/// captured TOFU-style on the first successful connect. `nil` puts the next
+/// connect in capture mode; non-nil pins the value and refuses connections
+/// presenting any other certificate (UI then surfaces a "cert changed,
+/// re-pair?" prompt).
 struct HostEntryLocal: Codable, Identifiable, Equatable {
     let id: String
     var label: String
     var host: String
     var port: Int32
+    var pinnedFingerprintHex: String?
 }
 
 /// File-based JSON persistence for the saved hosts list, following the
@@ -33,7 +40,8 @@ final class HostsStore {
             id: UUID().uuidString,
             label: label,
             host: host,
-            port: port
+            port: port,
+            pinnedFingerprintHex: nil
         )
         hosts.append(entry)
         save()

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -6,7 +6,20 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<!--
+		  Local-network networking: required so we can reach Termtastic
+		  servers on the LAN by IP/hostname without ATS blocking us.
+		-->
 		<key>NSAllowsLocalNetworking</key>
+		<true/>
+		<!--
+		  ATS-wide bypass: Termtastic talks to self-signed servers and
+		  enforces trust through SHA-256 fingerprint pinning in the
+		  URLSession challenge handler (HttpClientFactory.ios.kt).
+		  Without this key, ATS rejects the connection before the
+		  delegate even gets a chance to accept the leaf certificate.
+		-->
+		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 </dict>

--- a/iosApp/iosApp/ViewModels/HostsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/HostsViewModel.swift
@@ -11,14 +11,35 @@ final class HostsViewModel {
     var errorMessage: String?
     var waitingForApproval: Bool { ConnectionHolder.shared.pendingApproval }
 
+    /// True when the most recent connect attempt failed because the server
+    /// presented a TLS certificate that doesn't match the stored pin. Views
+    /// observe this to show a "Re-pair" alert instead of a generic error.
+    var pinMismatchEntry: HostEntryLocal?
+
     func connect(entry: HostEntryLocal) {
         connectingId = entry.id
         errorMessage = nil
+        pinMismatchEntry = nil
         Task {
             do {
                 let token = Client.AuthTokenKt.getOrCreateToken(store: KeychainAuthTokenStore.shared)
-                let serverUrl = Client.ServerUrl(host: entry.host, port: entry.port, useTls: false)
+                let serverUrl = Client.ServerUrl(
+                    host: entry.host,
+                    port: entry.port,
+                    useTls: true,
+                    pinnedFingerprintHex: entry.pinnedFingerprintHex
+                )
                 try await ConnectionHolder.shared.connect(serverUrl: serverUrl, authToken: token)
+                // TOFU capture: if we connected without a pin, the trust
+                // callback has now observed the leaf cert. Persist the
+                // fingerprint back to the host entry so subsequent connects
+                // run in verify mode.
+                if entry.pinnedFingerprintHex == nil,
+                   let captured = ConnectionHolder.shared.client?.observedFingerprint.value as? String {
+                    var updated = entry
+                    updated.pinnedFingerprintHex = captured
+                    HostsStore.shared.update(updated)
+                }
                 // Fetch the user's theme settings so all views use the
                 // selected theme from the start. Palette.settings is a
                 // static var read by all colour accessors.
@@ -31,10 +52,42 @@ final class HostsViewModel {
             } catch {
                 await MainActor.run {
                     connectingId = nil
-                    errorMessage = error.localizedDescription
+                    if Self.looksLikePinMismatch(error: error) {
+                        pinMismatchEntry = entry
+                    } else {
+                        errorMessage = error.localizedDescription
+                    }
                 }
             }
         }
+    }
+
+    /// Clears the stored pin for [entry] so the next connect runs in capture
+    /// mode and trusts whatever certificate the server presents next. Called
+    /// from the "Re-pair" alert button.
+    func acceptNewServerCertificate(entry: HostEntryLocal) {
+        var cleared = entry
+        cleared.pinnedFingerprintHex = nil
+        HostsStore.shared.update(cleared)
+        pinMismatchEntry = nil
+    }
+
+    /// Heuristic detector for the pin-mismatch case. The Darwin engine's
+    /// challenge handler completes the TLS handshake by *cancelling* the
+    /// auth challenge; URLSession surfaces that as `NSURLErrorDomain` code
+    /// `-999` (`NSURLErrorCancelled`). For our purposes the only way that
+    /// can happen is the pin check failing, so we treat that as the marker.
+    private static func looksLikePinMismatch(error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return true
+        }
+        // Underlying error chain — Ktor wraps cancels.
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError,
+           underlying.domain == NSURLErrorDomain && underlying.code == NSURLErrorCancelled {
+            return true
+        }
+        return false
     }
 
     func addHost(label: String, host: String, port: Int32) {

--- a/iosApp/iosApp/Views/HostsView.swift
+++ b/iosApp/iosApp/Views/HostsView.swift
@@ -74,6 +74,21 @@ struct HostsView: View {
                 Text(msg)
             }
         }
+        .alert("Server certificate changed", isPresented: .init(
+            get: { viewModel.pinMismatchEntry != nil },
+            set: { if !$0 { viewModel.pinMismatchEntry = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { viewModel.pinMismatchEntry = nil }
+            Button("Re-pair", role: .destructive) {
+                if let entry = viewModel.pinMismatchEntry {
+                    viewModel.acceptNewServerCertificate(entry: entry)
+                }
+            }
+        } message: {
+            if let entry = viewModel.pinMismatchEntry {
+                Text("The server at \(entry.host):\(entry.port) is presenting a different TLS certificate than the one you paired with previously. This may mean the server was reinstalled, or that someone is intercepting your connection. Re-pair only if you trust this network.")
+            }
+        }
         .onChange(of: ConnectionHolder.shared.client != nil) { _, connected in
             if connected { onConnected() }
         }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.ktor.serverWebsockets)
     implementation(libs.ktor.serverContentNegotiation)
     implementation(libs.ktor.serializationKotlinxJson)
+    implementation(libs.ktor.networkTlsCertificates)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.pty4j)

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
@@ -32,7 +32,9 @@ import com.pty4j.WinSize
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.engine.applicationEnvironment
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.sslConnector
 import io.ktor.server.http.content.staticFiles
 import io.ktor.server.http.content.staticResources
 import io.ktor.http.HttpStatusCode
@@ -197,16 +199,32 @@ fun main() {
         ?: SERVER_PORT
     SettingsDialog.setListeningPort(port)
 
-    // Bind to all interfaces so the "allow connections from other sources
-    // than localhost" setting can be flipped at runtime without restarting
-    // Netty. The default-off policy is enforced inside DeviceAuth.authorize,
-    // which rejects non-loopback requests until the user opts in via
-    // the settings dialog.
+    // Generate-or-load the self-signed TLS keystore before binding the listener.
+    // Native clients pin the server's leaf cert by SHA-256 (TOFU on first
+    // connect, verify thereafter); browsers fall back to the standard
+    // self-signed-warning interstitial. See se.soderbjorn.termtastic.tls.CertManager.
+    val tlsBundle = se.soderbjorn.termtastic.tls.CertManager.ensureKeystore()
+
+    // Bind HTTPS only on all interfaces. The default-off remote policy is
+    // enforced inside DeviceAuth.authorize, which rejects non-loopback
+    // requests until the user opts in via the settings dialog. There is no
+    // plain-HTTP fallback — every connection is encrypted.
+    val listenPort = port
     val server = embeddedServer(
-        Netty,
-        port = port,
-        host = "0.0.0.0",
-        module = { module(repo, sessionStates, usageMonitor) }
+        factory = Netty,
+        environment = applicationEnvironment {},
+        configure = {
+            sslConnector(
+                keyStore = tlsBundle.keystore,
+                keyAlias = tlsBundle.alias,
+                keyStorePassword = { tlsBundle.password.copyOf() },
+                privateKeyPassword = { tlsBundle.password.copyOf() },
+            ) {
+                this.host = "0.0.0.0"
+                this.port = listenPort
+            }
+        },
+        module = { module(repo, sessionStates, usageMonitor) },
     )
 
     if (java.awt.GraphicsEnvironment.isHeadless()) {

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/auth/DeviceAuth.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/auth/DeviceAuth.kt
@@ -518,6 +518,37 @@ object DeviceAuth {
             }
         }
 
+        // Self-healing bootstrap: if no devices have been trusted yet AND this
+        // is a loopback connection, auto-trust it. This handles the canonical
+        // case of a freshly installed Electron app whose renderer is the very
+        // first client to talk to its embedded server — the user shouldn't be
+        // asked to approve a dialog for their own app spawned ~200ms ago.
+        //
+        // Once any device is trusted, this branch never fires again. Every
+        // later loopback connection (including from a different process on the
+        // same machine) goes through the normal approval flow. If the user
+        // later wipes all trusted entries, the next loopback connect bootstraps
+        // again — that's the "self-healing" property the project owner asked for.
+        if (
+            hash != null &&
+            isLoopback(remoteAddress) &&
+            loadDevices(repo).devices.isEmpty()
+        ) {
+            log.info(
+                "DeviceAuth: auto-trusting bootstrap loopback connection from {} hashPrefix={}",
+                remoteAddress,
+                hash.take(10),
+            )
+            return@withLock persistTrusted(repo, hash, client, now).also {
+                val roundTrip = loadDevices(repo)
+                log.info(
+                    "DeviceAuth: bootstrap auto-trust persisted; readback count={} prefixes={}",
+                    roundTrip.devices.size,
+                    roundTrip.devices.joinToString(",") { it.tokenHash.take(10) },
+                )
+            }
+        }
+
         if (GraphicsEnvironment.isHeadless()) {
             log.warn(
                 "Rejecting connection from {}: no token or unknown token, and JVM is headless so no approval dialog can be shown",
@@ -565,28 +596,7 @@ object DeviceAuth {
             log.info("User approved cookie-less connection from {} (not persisted)", remoteAddress)
             return@withLock Decision.APPROVED
         }
-        val devices = loadDevices(repo)
-        val initialConnection = ClientConnection(
-            type = client.type,
-            hostname = client.hostname,
-            selfReportedIp = client.selfReportedIp,
-            remoteAddress = remoteAddress,
-            firstSeenEpochMs = now,
-            lastSeenEpochMs = now,
-        )
-        val added = TrustedDevice(
-            tokenHash = hash,
-            label = null,
-            firstSeenEpochMs = now,
-            lastSeenEpochMs = now,
-            lastIp = remoteAddress,
-            connections = listOf(initialConnection),
-        )
-        saveDevices(repo, TrustedDevices(devices.devices + added))
-        recentDecisions[hash] = CachedDecision(
-            Decision.APPROVED,
-            now + RECENT_DECISION_TTL_MS,
-        )
+        persistTrusted(repo, hash, client, now)
         // Read back immediately and log what we just persisted so we can
         // tell mid-debug if the write/read round-trip is broken.
         val roundTrip = loadDevices(repo)
@@ -598,6 +608,46 @@ object DeviceAuth {
             roundTrip.devices.joinToString(",") { it.tokenHash.take(10) },
         )
         Decision.APPROVED
+    }
+
+    /**
+     * Append a new trusted device entry for [hash] observed from [client] at
+     * [now], and prime the recent-decisions cache so concurrent in-flight
+     * requests from the same token short-circuit without re-prompting.
+     *
+     * Called by both the manual-approve tail of [promptOrReject] and the
+     * auto-accept-bootstrap branch above it. Returns [Decision.APPROVED] for
+     * convenience so callers can `return persistTrusted(...)` directly.
+     */
+    private fun persistTrusted(
+        repo: SettingsRepository,
+        hash: String,
+        client: ClientInfo,
+        now: Long,
+    ): Decision {
+        val devices = loadDevices(repo)
+        val initialConnection = ClientConnection(
+            type = client.type,
+            hostname = client.hostname,
+            selfReportedIp = client.selfReportedIp,
+            remoteAddress = client.remoteAddress,
+            firstSeenEpochMs = now,
+            lastSeenEpochMs = now,
+        )
+        val added = TrustedDevice(
+            tokenHash = hash,
+            label = null,
+            firstSeenEpochMs = now,
+            lastSeenEpochMs = now,
+            lastIp = client.remoteAddress,
+            connections = listOf(initialConnection),
+        )
+        saveDevices(repo, TrustedDevices(devices.devices + added))
+        recentDecisions[hash] = CachedDecision(
+            Decision.APPROVED,
+            now + RECENT_DECISION_TTL_MS,
+        )
+        return Decision.APPROVED
     }
 
     /**

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/persistence/AppPaths.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/persistence/AppPaths.kt
@@ -61,6 +61,16 @@ object AppPaths {
     }
 
     /**
+     * Directory for TLS state — the self-signed keystore and its random
+     * password file. Lives under [dataDir] so a `-Dtermtastic.dbPath`
+     * override keeps the cert next to the database (matters for tests
+     * and isolated dev installs).
+     *
+     * @return the `tls/` subdirectory; created on demand by [CertManager].
+     */
+    fun tlsDir(): File = File(dataDir(), "tls")
+
+    /**
      * Determine the default application data directory based on the OS.
      *
      * - macOS: `~/Library/Application Support/Termtastic`

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/tls/CertManager.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/tls/CertManager.kt
@@ -1,0 +1,149 @@
+/**
+ * Self-signed TLS keystore lifecycle for Termtastic.
+ *
+ * On first server start, generates an RSA-2048 self-signed certificate with
+ * SAN entries for `localhost`, `127.0.0.1`, and `::1`, persists it as a PKCS12
+ * keystore at `AppPaths.tlsDir()/server.p12`, and stores the random keystore
+ * password next to it (`keystore.pass`, file mode 0600 on POSIX). On subsequent
+ * starts, the existing keystore is loaded.
+ *
+ * This is the trust anchor pinned by native clients (Android, iOS) via SHA-256
+ * fingerprint comparison after a TOFU first-connect. Web/Electron browsers
+ * trust it via the standard "click-through self-signed warning" interstitial,
+ * with Electron's loopback-accept handler skipping the warning for the bundled
+ * app.
+ *
+ * Called by [Application.main] just before the Ktor `embeddedServer` is built.
+ *
+ * @see AppPaths.tlsDir
+ */
+package se.soderbjorn.termtastic.tls
+
+import io.ktor.network.tls.certificates.buildKeyStore
+import io.ktor.network.tls.extensions.HashAlgorithm
+import io.ktor.network.tls.extensions.SignatureAlgorithm
+import org.slf4j.LoggerFactory
+import se.soderbjorn.termtastic.persistence.AppPaths
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * Bundle returned by [CertManager.ensureKeystore] containing everything the
+ * Ktor `sslConnector` needs to bind a TLS listener, plus the SHA-256 fingerprint
+ * of the leaf certificate (logged at startup so users / scripts can verify
+ * what their pinned clients should be locked to).
+ *
+ * @property keystore the loaded PKCS12 [KeyStore] containing the cert + private key.
+ * @property alias the alias under which the keypair is stored.
+ * @property password the in-memory password chars used for both the keystore
+ *   and the private key entry. Treated as a secret; do not log.
+ * @property sha256Fingerprint lowercase hex SHA-256 of the leaf certificate's
+ *   DER encoding. 64 characters, no separators.
+ */
+data class KeyStoreBundle(
+    val keystore: KeyStore,
+    val alias: String,
+    val password: CharArray,
+    val sha256Fingerprint: String,
+)
+
+/**
+ * Loads the existing TLS keystore from `AppPaths.tlsDir()` or generates a
+ * fresh self-signed one if missing or corrupt.
+ *
+ * Called once per server boot before the Ktor `sslConnector` is wired up.
+ */
+object CertManager {
+
+    private val log = LoggerFactory.getLogger(CertManager::class.java)
+    private const val ALIAS = "termtastic"
+    private const val KEYSTORE_FILE = "server.p12"
+    private const val PASSWORD_FILE = "keystore.pass"
+
+    /**
+     * Ensure a usable keystore exists on disk and return its in-memory form.
+     *
+     * Behaviour:
+     *  - If `tls/server.p12` and `tls/keystore.pass` both exist and the keystore
+     *    loads successfully, returns it as-is.
+     *  - Otherwise generates a fresh RSA-2048 self-signed cert (SAN list:
+     *    `localhost`, `127.0.0.1`, `::1`; validity 10 years), writes both files,
+     *    and returns the new bundle.
+     *
+     * Regeneration is the only "rotation" mechanism: deleting the keystore and
+     * restarting the server forces every pinned client to re-pair. This is by
+     * design — pinning detects the change exactly because the cert is new.
+     *
+     * @return the loaded or freshly generated [KeyStoreBundle].
+     */
+    fun ensureKeystore(): KeyStoreBundle {
+        val dir = AppPaths.tlsDir().apply { mkdirs() }
+        val ksFile = dir.resolve(KEYSTORE_FILE)
+        val pwFile = dir.resolve(PASSWORD_FILE)
+
+        if (ksFile.isFile && pwFile.isFile) {
+            runCatching {
+                val pw = pwFile.readText().trim().toCharArray()
+                val ks = KeyStore.getInstance("PKCS12").apply {
+                    ksFile.inputStream().use { load(it, pw) }
+                }
+                return KeyStoreBundle(ks, ALIAS, pw, computeFingerprint(ks))
+                    .also { logFingerprint(it, regenerated = false) }
+            }.onFailure {
+                log.warn("Failed to load existing keystore at ${ksFile.absolutePath}; regenerating.", it)
+            }
+        }
+
+        val pw = randomPasswordChars()
+        val ks = buildKeyStore {
+            certificate(ALIAS) {
+                hash = HashAlgorithm.SHA256
+                sign = SignatureAlgorithm.RSA
+                keySizeInBits = 2048
+                password = String(pw)
+                domains = listOf("localhost", "127.0.0.1", "::1")
+                daysValid = 3650
+            }
+        }
+
+        FileOutputStream(ksFile).use { ks.store(it, pw) }
+        pwFile.writeText(String(pw))
+        applyPosixSecretMode(pwFile.toPath())
+        applyPosixSecretMode(ksFile.toPath())
+
+        return KeyStoreBundle(ks, ALIAS, pw, computeFingerprint(ks))
+            .also { logFingerprint(it, regenerated = true) }
+    }
+
+    private fun computeFingerprint(ks: KeyStore): String {
+        val cert = ks.getCertificate(ALIAS)
+            ?: error("Keystore is missing alias '$ALIAS' — cannot derive fingerprint.")
+        val der = cert.encoded
+        val digest = MessageDigest.getInstance("SHA-256").digest(der)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun randomPasswordChars(): CharArray {
+        val bytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        return bytes.joinToString("") { "%02x".format(it) }.toCharArray()
+    }
+
+    private fun applyPosixSecretMode(path: java.nio.file.Path) {
+        runCatching {
+            Files.setPosixFilePermissions(
+                path,
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            )
+        }
+        // Silently ignore on non-POSIX (Windows) — file ACLs there are best-effort.
+    }
+
+    private fun logFingerprint(bundle: KeyStoreBundle, regenerated: Boolean) {
+        val verb = if (regenerated) "Generated" else "Loaded"
+        log.info("$verb TLS keystore. SHA-256 fingerprint: ${bundle.sha256Fingerprint}")
+    }
+}


### PR DESCRIPTION
## Summary

Termtastic now speaks HTTPS only. The server generates a self-signed certificate on first boot; native clients pin its SHA-256 SSH-style (first connect captures, subsequent ones verify); web/Electron rely on the browser's cert-acceptance flow; and the canonical "Electron renderer talking to its own server right after launch" case is auto-trusted to avoid asking the user to approve a dialog for their own app.

This closes the previous gap where enabling remote connections (e.g. so a phone could reach the server on the same WiFi) sent the device-auth token and PTY traffic over plain HTTP, trivially sniffable on a public network.

## Server (HTTPS-only)

- `tls/CertManager.kt` — generates a self-signed RSA-2048 cert on first boot via Ktor's `buildKeyStore`, stores `server.p12` + `keystore.pass` (mode 0600) under `<dataDir>/tls/`, logs SHA-256 fingerprint at startup. If keystore is missing or fails to load → regenerate fresh; this is also the rotation mechanism (delete the keystore and restart).
- `Application.kt` — switched `embeddedServer(Netty, port=, host=, module=)` to the `applicationEnvironment + sslConnector` form. No HTTP fallback.
- `DeviceAuth.kt` — extracted `persistTrusted` helper; added auto-accept branch in `promptOrReject` for `isLoopback && trustedDevices.isEmpty()`. Self-healing variant: triggers whenever the trusted-devices list is empty, so wiping Electron's local data and rebooting still bootstraps silently.
- `AppPaths.kt` — added `tlsDir()`.
- `gradle/libs.versions.toml` + `server/build.gradle.kts` — added `ktor-network-tls-certificates` dependency.

## Shared client (commonMain)

- `ServerUrl.kt` — added `pinnedFingerprintHex: String?`, flipped `useTls` default to `true`.
- `HostEntry.kt` — added `pinnedFingerprintHex: String?` (nullable so old persisted entries deserialize cleanly into capture mode on next connect).
- `HttpClientFactory.kt` — new `expect createPlatformHttpClient(pinnedFingerprintHex, onPeerCertCaptured)` factory plus `applyCommonClientConfig` for the WebSockets/timeout installs that every platform shares.
- `TermtasticClient.kt` — switched to the factory; exposes `observedFingerprint: StateFlow<String?>` so the platform UI layer can persist the captured fingerprint.

## Per-platform `actual` implementations

- **Android (OkHttp)**: custom `X509TrustManager` doing two-mode capture/pin; throws `pin-mismatch:`-prefixed `CertificateException` on mismatch; emits captured fingerprint off the network thread (storage writes never run inside the TLS handshake). OkHttp's built-in `CertificatePinner` deliberately not used — it pins on top of a successful default trust check, which doesn't exist for self-signed certs.
- **iOS (Darwin)**: `engine { handleChallenge { ... } }` with the same two-mode logic via `SecTrustGetCertificateAtIndex` + `CC_SHA256`. Uses `challenge.proposedCredential` for accept; cancels on mismatch.
- **JVM (CIO)**: mirror of Android via `engine { https { trustManager = ... } }` for the `:clientServer` test host and any future Compose Desktop client.
- **JS (browser)**: trivial passthrough — browser owns TLS verification.

## App-side wiring

- **Android `HostsScreen.kt`**: passes the entry's pin into `ServerUrl`, persists captured fingerprint after success, shows a "Server certificate changed" dialog with a "Re-pair" destructive action when the cause chain contains `pin-mismatch`. Re-pair clears the pin so the next connect re-enters capture mode.
- **iOS `HostsViewModel.swift` + `HostsView.swift`**: same pattern. Pin-mismatch detection uses `NSURLErrorCancelled` since that's how the Darwin challenge handler signals a refused cert; alert offers "Re-pair" / "Cancel".
- **iOS `Info.plist`**: added `NSAllowsArbitraryLoads = true` (alongside the existing `NSAllowsLocalNetworking`) since we self-validate via the URLSession challenge handler — without it, ATS rejects the self-signed cert before our delegate gets a chance.

## Electron

- `main.js`: `TARGET_URL` flipped to `https://127.0.0.1:8082`. New `certificate-error` handler accepts loopback (`127.0.0.1`, `::1`, `localhost`) unconditionally and rejects everything else. Loopback can't be MITM'd, so pinning here would only complicate the dev cycle (every regenerated cert would brick the renderer).
- `build.gradle.kts`: `:electron:run` env var `TERMTASTIC_URL` now points at `https://127.0.0.1:8083` for the dev server.

## README

Replaced the "remote connections are plain HTTP" warning with a brief overview of the new TLS + pinning model and a one-liner on cert rotation.

## What's deliberately out of scope

- **QR-code pairing**: the older `docs/TLS_AND_QR_PAIRING_PLAN.md` design closed a marginal first-connect MITM window at the cost of substantial new UI on every platform plus a server-side pairing dialog. TOFU is the SSH-style alternative: same protection after the first connect, with the residual exposure only in the case where an attacker is already MITM'ing the LAN at the very moment of first pair — not the threat this change targets.
- **Bouncy Castle dependency**: not needed; Ktor's `buildKeyStore` covers cert generation.
- **Per-host "Reset trust" UI**: revoking via the existing trusted-devices list + deleting the keystore on disk already covers it.
- **Cert auto-rotation**: 10-year self-signed cert; rotation is "delete the keystore and restart" — pinned clients then surface the re-pair dialog as designed.
- **Electron remote mode**: today Electron is local-only; if/when it grows a "connect to remote server" feature, it'll need the same pinning machinery as native mobile, but that's a separate workstream.

## Test plan

- [x] `./gradlew :server:test` passes.
- [x] `./gradlew :server:compileKotlin :client:compileKotlinJvm :client:compileKotlinJs :client:compileDebugKotlinAndroid :client:compileKotlinIosSimulatorArm64 :androidApp:compileDebugKotlin` passes.
- [ ] Fresh server: delete `~/Library/Application Support/Termtastic/tls/`, run `:server:run`. Confirm `tls/server.p12` + `tls/keystore.pass` (mode 0600) appear and the SHA-256 fingerprint is logged.
- [ ] `curl -k https://127.0.0.1:8082/api/ui-settings` returns 401 (TLS handshake works). `curl http://127.0.0.1:8082/...` fails (no HTTP fallback).
- [ ] Electron auto-bootstrap (fresh DB): launch packaged app, confirm window loads with no approval dialog. SQLite shows exactly one entry under `auth.trusted_devices.v1`.
- [ ] Second localhost client (e.g. Chrome at `https://127.0.0.1:8082` after dismissing cert warning): server approval dialog **does** fire (trusted list no longer empty).
- [ ] Android first connect: add a host pointing at the laptop's LAN IP, connect, accept on server. DataStore JSON now contains a 64-char `pinnedFingerprintHex`. Second connect runs without dialog.
- [ ] Android pin mismatch: `rm -rf` the server's `tls/` dir, restart, reconnect from Android → "cert changed, re-pair?" dialog. Tap Re-pair → server approval fires → fingerprint updates.
- [ ] iOS parity: repeat Android steps.
- [ ] Web: open `https://<lan-ip>:8082`, accept warning once, server approval fires, approve, terminal works. Reload — no warning, no dialog.
- [ ] Headless server (`-Djava.awt.headless=true`): first localhost connect auto-accepts; second device connection logs `Decision.HEADLESS` and is rejected.
- [ ] Migration: existing pre-TLS Android/iOS host entries deserialize without crashing and capture a pin on next connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)