### PR TITLE
Mac: New tab/terminal, directional pane nav, and Quake show/hide shortcuts

### DIFF
--- a/docs/superpowers/specs/2026-06-22-directional-pane-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-22-directional-pane-navigation-design.md
@@ -61,10 +61,12 @@ pane in direction" from the live on-screen rectangles:
 
 - Candidate panes: `document.querySelectorAll(".dt-pane")` (only the
   active tab's panes are in the DOM). Each carries `data-pane-id`.
+  Minimized panes are already absent (rendered as dock items).
 - Current pane: `.dt-pane.dt-pane-focused`, falling back to the active
   tab's `focusedPaneId`, then the first `.dt-pane`.
-- Skip zero-size rects (hidden / `display:none`, e.g. siblings of a
-  maximized pane).
+- Skip only genuinely zero-size rects (defensive, e.g. a pane
+  mid-collapse-animation). NB: a sibling *covered* by a maximized pane
+  keeps its full rect and remains a valid target — see Focus dispatch.
 
 ### Pure selection function (testable, DOM-free)
 
@@ -88,14 +90,21 @@ pickPaneInDirection(rects: List<Rect>, currentIndex: Int,
 
 ## Focus dispatch
 
-On a chosen target pane id, send the same pair a sidebar click uses:
+On a chosen target pane id, send **`SetFocusedPane` only**:
 
 ```
 SetFocusedPane(tabId = activeTabId, paneId = target)
-RaisePane(paneId = target)
 ```
 
 `activeTabId` from `latestWindowConfig?.activeTabId`. No-op if null.
+
+We deliberately do **not** send `RaisePane`. The toolkit's own
+Ctrl+Alt+Left/Right pane cycle (which this replaces) was focus-only and
+never re-stacked z-order — only an explicit pane *click* raises. Matching
+that avoids churning the persisted layout z-order on every keystroke. If
+the target is covered by a maximized sibling, the server's
+`setFocusedPane` clears that sibling's maximize flag, so the focused pane
+becomes visible (mirroring the cycle's auto-unmaximize) without a raise.
 
 ## Gating & cheatsheet
 

--- a/docs/superpowers/specs/2026-06-22-directional-pane-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-22-directional-pane-navigation-design.md
@@ -1,0 +1,138 @@
+# Directional pane navigation (vim-style) — design
+
+**Date:** 2026-06-22
+**Scope:** Mac/Electron app (web frontend, `web/src/jsMain`)
+**Status:** Approved
+
+## Goal
+
+Let the user move keyboard focus between panes in the active tab by
+*direction* (left / down / up / right), vim-style, instead of the
+toolkit's current linear *cycle*.
+
+## Bindings
+
+Directional pane focus, four directions, two key families that behave
+identically:
+
+| Keys            | Action                  |
+| --------------- | ----------------------- |
+| `⌃⌥H` / `⌃⌥←`  | Focus pane to the left  |
+| `⌃⌥J` / `⌃⌥↓`  | Focus pane below        |
+| `⌃⌥K` / `⌃⌥↑`  | Focus pane above        |
+| `⌃⌥L` / `⌃⌥→`  | Focus pane to the right |
+
+- Match condition: `ctrlKey && altKey && !metaKey && !shiftKey` and
+  `event.code ∈ { KeyH, KeyJ, KeyK, KeyL, ArrowLeft, ArrowDown,
+  ArrowUp, ArrowRight }`.
+- **`event.code`, not `event.key`** — on macOS Option mutates
+  `event.key` (⌥H → "˙"); `code` is layout/modifier independent.
+- The toolkit already binds `⌃⌥←/→` to a horizontal pane *cycle* and
+  `⌃⌥⇧←/→` to a tab cycle. We **replace** the pane cycle with
+  directional movement on the same keys; `⌃⌥↑/↓` were unbound and
+  become directional. The tab cycle (`⌃⌥⇧←/→`) is untouched because our
+  `!shiftKey` guard lets it fall through.
+
+## Override mechanism
+
+The toolkit's `HotkeyRegistry` attaches its dispatcher to **`window` in
+capture phase** (lazily, on its first `register()` during
+`mountAppShell`). On a match it calls `preventDefault()` +
+`stopPropagation()` — *not* `stopImmediatePropagation()`.
+
+To win cleanly:
+
+1. Install our `window` capture-phase `keydown` listener **before**
+   `bootViaToolkitShell()` runs, so ours is earlier in window's
+   same-target listener list.
+2. On a handled chord, call `preventDefault()` +
+   **`stopImmediatePropagation()`** so the toolkit's later
+   same-target listener never runs.
+
+Result: the handled chords reach only our handler; everything else
+(including `⌃⌥⇧`-arrow tab cycle and plain terminal input) passes
+through untouched.
+
+## Geometry — source of truth is the DOM
+
+Pane geometry is toolkit-owned (persisted in `LAYOUT_STATE`); the
+server `WindowConfig` coordinates can be stale. So we compute "nearest
+pane in direction" from the live on-screen rectangles:
+
+- Candidate panes: `document.querySelectorAll(".dt-pane")` (only the
+  active tab's panes are in the DOM). Each carries `data-pane-id`.
+- Current pane: `.dt-pane.dt-pane-focused`, falling back to the active
+  tab's `focusedPaneId`, then the first `.dt-pane`.
+- Skip zero-size rects (hidden / `display:none`, e.g. siblings of a
+  maximized pane).
+
+### Pure selection function (testable, DOM-free)
+
+```
+enum Direction { LEFT, DOWN, UP, RIGHT }
+data class Rect(left, top, right, bottom)   // center = mid of each axis
+
+pickPaneInDirection(rects: List<Rect>, currentIndex: Int,
+                    dir: Direction, wrap: Boolean): Int?
+```
+
+- **In-direction pass:** candidates strictly in `dir` of the current
+  pane's center. Score = `primaryAxisDistance + 2 * perpendicularOffset`
+  (favors the pane directly in line, then nearest). Pick min score.
+- **Wrap pass** (only if no in-direction candidate and `wrap = true`):
+  jump to the farthest pane on the opposite edge, best-aligned on the
+  perpendicular axis. e.g. RIGHT-wrap → smallest center-x, tie-break by
+  nearest center-y.
+- Returns `null` for: < 2 panes, no current pane, or no distinct
+  target (no-op).
+
+## Focus dispatch
+
+On a chosen target pane id, send the same pair a sidebar click uses:
+
+```
+SetFocusedPane(tabId = activeTabId, paneId = target)
+RaisePane(paneId = target)
+```
+
+`activeTabId` from `latestWindowConfig?.activeTabId`. No-op if null.
+
+## Gating & cheatsheet
+
+- Installed only when `isElectronClient` (the Mac app), matching the
+  ⌘T/⌘D precedent.
+- Cheatsheet (`⌘/`): in the app, the two "Previous/Next window" cycle
+  rows are replaced by four "Focus pane …" rows showing the **arrow**
+  chords (`⌃⌥←/↓/↑/→`). The equivalent `⌃⌥HJKL` vim bindings also work
+  but are intentionally omitted from the cheatsheet as a power-user
+  feature. In the plain browser build (no override installed) the
+  original cycle rows remain. Tab-cycle rows stay in both.
+
+## Files
+
+- **New** `web/src/jsMain/.../PaneNavigation.kt` — `Direction`, `Rect`,
+  pure `pickPaneInDirection`, DOM glue, `installDirectionalPaneNav()`.
+- `web/src/jsMain/.../main.kt` — call `installDirectionalPaneNav()`
+  immediately before `bootViaToolkitShell(appEl)`, gated on
+  `isElectronClient`.
+- `web/src/jsMain/.../TermtasticHotkeysContent.kt` — directional rows +
+  footer note.
+
+## Out of scope
+
+Cross-tab movement (stays within the active tab); pane resize/move;
+removing the toolkit's now-shadowed cycle bindings (we suppress them at
+dispatch instead).
+
+## Known caveat
+
+`⌃⌥`+arrows overlap macOS **VoiceOver** navigation when VoiceOver is
+on. Pre-existing (the toolkit already used `⌃⌥`-arrows); not addressed.
+
+## Testing
+
+The web module has no test source set; adding a karma harness is
+disproportionate here. `pickPaneInDirection` is kept pure for future
+testability, but verification is manual in the running app
+(`:electron:runDemo`): split panes into a grid and confirm each
+direction + wrap behaves, including over a focused terminal.

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronExternals.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronExternals.kt
@@ -81,9 +81,11 @@ external class BrowserWindow(options: dynamic = definedExternally) {
     fun isDestroyed(): Boolean
     fun isMinimized(): Boolean
     fun isVisible(): Boolean
+    fun isFocused(): Boolean
     fun isFullScreen(): Boolean
     fun restore()
     fun show()
+    fun hide()
     fun focus()
     fun destroy()
     fun loadURL(url: String, options: dynamic = definedExternally): Promise<Unit>

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
@@ -631,6 +631,25 @@ private fun showNewTab() {
     target.webContents.send("new-tab")
 }
 
+/**
+ * Opens a new terminal pane in the active tab in response to the
+ * "File → New Terminal" menu item (⌘D). Mirrors [showNewTab]: focus (and
+ * if needed reveal) the target window, then send the `new-terminal` IPC
+ * the renderer listens for. The renderer resolves the active tab + cwd and
+ * dispatches [se.soderbjorn.termtastic.WindowCommand.AddPaneToTab] — the
+ * same command the pane bar's "+" → Terminal action uses.
+ */
+private fun showNewTerminal() {
+    val focused = BrowserWindow.getFocusedWindow()
+    val mw = mainWindow
+    val target: BrowserWindow = focused
+        ?: (if (mw != null && !mw.isDestroyed()) mw else null)
+        ?: return
+    if (!target.isVisible()) target.show()
+    target.focus()
+    target.webContents.send("new-terminal")
+}
+
 // ── Application menu ─────────────────────────────────────────────────
 
 private fun buildAppMenu() {
@@ -684,9 +703,15 @@ private fun buildAppMenu() {
     newTabItem.label = "New Tab"
     newTabItem.accelerator = "CommandOrControl+T"
     newTabItem.click = { showNewTab() }
+    // "New Terminal" (⌘D) adds a terminal pane to the active tab — the pane
+    // equivalent of "New Tab". Sits directly below it in the File menu.
+    val newTerminalItem: dynamic = js("({})")
+    newTerminalItem.label = "New Terminal"
+    newTerminalItem.accelerator = "CommandOrControl+D"
+    newTerminalItem.click = { showNewTerminal() }
     val fileMenu: dynamic = js("({})")
     fileMenu.label = "File"
-    fileMenu.submenu = arrayOf<dynamic>(newTabItem)
+    fileMenu.submenu = arrayOf<dynamic>(newTabItem, newTerminalItem)
     template.add(fileMenu)
 
     template.add(js("({label:'Edit', submenu:[{role:'undo'},{role:'redo'},{type:'separator'},{role:'cut'},{role:'copy'},{role:'paste'},{role:'selectAll'}]})"))

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
@@ -28,8 +28,18 @@ import kotlin.js.Promise
 /** Production server port — mirrors shared `Constants.SERVER_TLS_PORT`. */
 private const val PROD_PORT = 8443
 
-/** Global hotkey accelerator that summons the app from any context. */
+/**
+ * Global hotkey accelerator that toggles the app from any context
+ * (Quake/iTerm-style show-hide). @see toggleQuakeWindow
+ */
 private const val SUMMON_ACCELERATOR = "Control+Alt+Command+Space"
+
+/**
+ * Second global toggle accelerator — the conventional Quake/iTerm
+ * hotkey-window key. Being global, it shadows Ctrl+` in every other app
+ * while termtastic runs. @see toggleQuakeWindow
+ */
+private const val QUAKE_ACCELERATOR = "Control+`"
 
 private val URL_OVERRIDE: String? = (process.env.TERMTASTIC_URL as? String)?.takeIf { it.isNotEmpty() }
 // Server is HTTPS-only with a self-signed cert generated on first boot
@@ -882,6 +892,27 @@ private fun showAndFocus() {
     }
 }
 
+/**
+ * Quake / iTerm-style show-hide toggle for the main window, wired to both
+ * global hotkeys ([SUMMON_ACCELERATOR] and [QUAKE_ACCELERATOR]). When the
+ * window is already frontmost (visible, focused, and not minimized) it
+ * hides; otherwise it is restored/shown/focused via [showAndFocus]. A
+ * destroyed (or never-created) window is recreated.
+ *
+ * @see registerGlobalShortcut
+ */
+private fun toggleQuakeWindow() {
+    val w = mainWindow
+    if (w == null || w.isDestroyed()) {
+        createWindow(); return
+    }
+    if (w.isVisible() && w.isFocused() && !w.isMinimized()) {
+        w.hide()
+    } else {
+        showAndFocus()
+    }
+}
+
 private fun showUnreachable(errorDescription: String, hint: String?) {
     val hintHtml = hint?.let { "<p>$it</p>" }
         ?: "<p>Start the server with:</p><p><code>./gradlew :server:run</code></p>"
@@ -969,9 +1000,17 @@ private fun ensureServerThenCreateWindow(): Promise<Unit> = Promise { resolve, _
 }
 
 private fun registerGlobalShortcut() {
-    val ok = globalShortcut.register(SUMMON_ACCELERATOR) { showAndFocus() }
+    // Both global hotkeys toggle the window (Quake-style): the original
+    // summon chord and the conventional Ctrl+` hotkey-window key. Each is
+    // registered independently so one failing (e.g. another app already
+    // grabbed it) doesn't block the other.
+    val ok = globalShortcut.register(SUMMON_ACCELERATOR) { toggleQuakeWindow() }
     if (!ok) {
         console.warn("Failed to register global shortcut: $SUMMON_ACCELERATOR")
+    }
+    val quakeOk = globalShortcut.register(QUAKE_ACCELERATOR) { toggleQuakeWindow() }
+    if (!quakeOk) {
+        console.warn("Failed to register global shortcut: $QUAKE_ACCELERATOR")
     }
 }
 

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/termtastic/electron/ElectronMain.kt
@@ -610,6 +610,27 @@ private fun showSettings() {
     target.webContents.send("show-settings")
 }
 
+// ── New tab dispatch ─────────────────────────────────────────────────
+
+/**
+ * Opens a new tab in response to the "File → New Tab" menu item (⌘T).
+ * Mirrors [showSettings]: focus (and if needed reveal) the target window,
+ * then send the `new-tab` IPC the renderer listens for. The renderer
+ * dispatches [se.soderbjorn.termtastic.WindowCommand.AddTab] — the same
+ * command the "+" tab-strip button uses — so the shortcut and the button
+ * behave identically.
+ */
+private fun showNewTab() {
+    val focused = BrowserWindow.getFocusedWindow()
+    val mw = mainWindow
+    val target: BrowserWindow = focused
+        ?: (if (mw != null && !mw.isDestroyed()) mw else null)
+        ?: return
+    if (!target.isVisible()) target.show()
+    target.focus()
+    target.webContents.send("new-tab")
+}
+
 // ── Application menu ─────────────────────────────────────────────────
 
 private fun buildAppMenu() {
@@ -654,6 +675,19 @@ private fun buildAppMenu() {
         appMenu.submenu = appSubmenu
         template.add(appMenu)
     }
+
+    // File menu → "New Tab" (⌘T / Ctrl+T). Opens a new, focused tab via the
+    // `new-tab` IPC; sits in the conventional File-menu slot (after the app
+    // menu on macOS, first otherwise) so the shortcut is discoverable in the
+    // menu bar — not just a hidden chord.
+    val newTabItem: dynamic = js("({})")
+    newTabItem.label = "New Tab"
+    newTabItem.accelerator = "CommandOrControl+T"
+    newTabItem.click = { showNewTab() }
+    val fileMenu: dynamic = js("({})")
+    fileMenu.label = "File"
+    fileMenu.submenu = arrayOf<dynamic>(newTabItem)
+    template.add(fileMenu)
 
     template.add(js("({label:'Edit', submenu:[{role:'undo'},{role:'redo'},{type:'separator'},{role:'cut'},{role:'copy'},{role:'paste'},{role:'selectAll'}]})"))
     template.add(js("({label:'View', submenu:[{role:'reload'},{role:'forceReload'},{role:'toggleDevTools'},{type:'separator'},{role:'resetZoom'},{role:'zoomIn'},{role:'zoomOut'},{type:'separator'},{role:'togglefullscreen'}]})"))

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -220,6 +220,23 @@ contextBridge.exposeInMainWorld("electronApi", {
   },
 
   /**
+   * Subscribes to the "new terminal" event sent by the main process when the
+   * user picks "File → New Terminal" (⌘D) from the macOS menu. The renderer
+   * adds a terminal pane to the active tab.
+   *
+   * Only the channel name is forwarded; the IPC event object itself is not
+   * leaked into the renderer for context-isolation safety.
+   *
+   * @param {() => void} handler - Called with no arguments on each event.
+   * @returns {() => void} Unsubscribe function that detaches the listener.
+   */
+  onNewTerminal: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("new-terminal", wrapped);
+    return () => ipcRenderer.removeListener("new-terminal", wrapped);
+  },
+
+  /**
    * Subscribes to the "debug set pane state" event sent by the main
    * process when the user picks "Pane state: Working/Waiting/Clear"
    * from the macOS Debug submenu. The handler receives the requested

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -202,6 +202,24 @@ contextBridge.exposeInMainWorld("electronApi", {
   },
 
   /**
+   * Subscribes to the "new tab" event sent by the main process when the user
+   * picks "File → New Tab" (⌘T) from the macOS menu. The renderer dispatches
+   * the focused-add window command so the server opens a tab and switches to
+   * it.
+   *
+   * Only the channel name is forwarded; the IPC event object itself is not
+   * leaked into the renderer for context-isolation safety.
+   *
+   * @param {() => void} handler - Called with no arguments on each event.
+   * @returns {() => void} Unsubscribe function that detaches the listener.
+   */
+  onNewTab: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("new-tab", wrapped);
+    return () => ipcRenderer.removeListener("new-tab", wrapped);
+  },
+
+  /**
    * Subscribes to the "debug set pane state" event sent by the main
    * process when the user picks "Pane state: Working/Waiting/Clear"
    * from the macOS Debug submenu. The handler receives the requested

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/PaneNavigation.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/PaneNavigation.kt
@@ -1,0 +1,207 @@
+/* PaneNavigation.kt (jsMain)
+ *
+ * Directional (vim-style) pane focus for the Mac/Electron app. Binds
+ * Ctrl+Option+H/J/K/L and Ctrl+Option+arrow keys to move keyboard focus
+ * to the pane left / below / above / right of the currently focused pane
+ * in the active tab, with wrap-around at the edges.
+ *
+ * Replaces the darkness-toolkit's linear pane *cycle* (which lives on the
+ * same Ctrl+Alt+Left/Right chord): we install a `window` capture-phase
+ * keydown listener BEFORE `bootViaToolkitShell()` registers the toolkit's
+ * own window-capture dispatcher, and call `stopImmediatePropagation()` on
+ * the chords we handle so the toolkit's later same-target listener never
+ * runs for them. The toolkit's tab cycle (Ctrl+Alt+Shift+arrows) is left
+ * alone — our `!shiftKey` guard lets it fall through.
+ *
+ * Pane geometry is toolkit-owned (the server config coordinates can be
+ * stale), so the spatial logic reads the live on-screen rectangles of the
+ * `.dt-pane` elements instead. See
+ * docs/superpowers/specs/2026-06-22-directional-pane-navigation-design.md.
+ */
+package se.soderbjorn.termtastic
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import kotlin.math.abs
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.KeyboardEvent
+
+/** The four directions pane focus can move. */
+internal enum class PaneDirection { LEFT, DOWN, UP, RIGHT }
+
+/**
+ * A pane's on-screen bounding box (viewport pixels). Only the geometry the
+ * directional math needs; decoupled from the DOM so [pickPaneInDirection]
+ * stays pure and testable.
+ */
+internal data class PaneRect(
+    val left: Double,
+    val top: Double,
+    val right: Double,
+    val bottom: Double,
+) {
+    val centerX: Double get() = (left + right) / 2.0
+    val centerY: Double get() = (top + bottom) / 2.0
+}
+
+/**
+ * Pure spatial selection: from the pane at [currentIndex], return the
+ * index of the pane to move focus to in [dir], or `null` for a no-op.
+ *
+ * Two passes:
+ *  1. **In-direction** — panes strictly in [dir] of the current pane's
+ *     center, scored by `axisDistance + 2*perpendicularOffset` so a pane
+ *     directly in line beats an equally-near but offset one. Closest wins.
+ *  2. **Wrap** (only when no in-direction candidate and [wrap] is true) —
+ *     jump to the farthest pane on the opposite edge, tie-broken by the
+ *     nearest perpendicular alignment (so wrapping right from the top row
+ *     lands on the top-left pane, not the bottom-left).
+ *
+ * Returns `null` when there are fewer than two panes or [currentIndex] is
+ * out of range. Called by [navigatePane].
+ *
+ * @param rects every visible pane's box, in DOM order.
+ * @param currentIndex index of the focused pane within [rects].
+ * @param dir direction to move.
+ * @param wrap whether to wrap around at the edges.
+ * @return target index, or `null` for no movement.
+ */
+internal fun pickPaneInDirection(
+    rects: List<PaneRect>,
+    currentIndex: Int,
+    dir: PaneDirection,
+    wrap: Boolean = true,
+): Int? {
+    if (rects.size < 2 || currentIndex !in rects.indices) return null
+    val cur = rects[currentIndex]
+
+    fun inDirection(r: PaneRect): Boolean = when (dir) {
+        PaneDirection.LEFT -> r.centerX < cur.centerX
+        PaneDirection.RIGHT -> r.centerX > cur.centerX
+        PaneDirection.UP -> r.centerY < cur.centerY
+        PaneDirection.DOWN -> r.centerY > cur.centerY
+    }
+    fun primaryDist(r: PaneRect): Double = when (dir) {
+        PaneDirection.LEFT, PaneDirection.RIGHT -> abs(r.centerX - cur.centerX)
+        PaneDirection.UP, PaneDirection.DOWN -> abs(r.centerY - cur.centerY)
+    }
+    fun perpDist(r: PaneRect): Double = when (dir) {
+        PaneDirection.LEFT, PaneDirection.RIGHT -> abs(r.centerY - cur.centerY)
+        PaneDirection.UP, PaneDirection.DOWN -> abs(r.centerX - cur.centerX)
+    }
+
+    val inDir = rects.indices.filter { it != currentIndex && inDirection(rects[it]) }
+    if (inDir.isNotEmpty()) {
+        return inDir.minByOrNull { primaryDist(rects[it]) + 2.0 * perpDist(rects[it]) }
+    }
+    if (!wrap) return null
+
+    // Wrap: the opposite-edge extreme dominates (weighted far above any
+    // perpendicular offset), with perpendicular alignment as the tiebreak.
+    val others = rects.indices.filter { it != currentIndex }
+    return others.minByOrNull { idx ->
+        val r = rects[idx]
+        val extreme = when (dir) {
+            PaneDirection.RIGHT -> r.centerX       // wrap to leftmost
+            PaneDirection.LEFT -> -r.centerX       // wrap to rightmost
+            PaneDirection.DOWN -> r.centerY        // wrap to topmost
+            PaneDirection.UP -> -r.centerY         // wrap to bottommost
+        }
+        extreme * 1_000_000.0 + perpDist(r)
+    }
+}
+
+/**
+ * Collects the active tab's pane wrappers (`.dt-pane`) that are actually
+ * visible — zero-size rects (e.g. siblings hidden behind a maximized
+ * pane) are dropped so they aren't navigation targets. Only the active
+ * tab's panes are in the DOM, so no tab filtering is needed.
+ */
+private fun visiblePaneElements(): List<HTMLElement> {
+    val nodes = document.querySelectorAll(".dt-pane")
+    val out = ArrayList<HTMLElement>()
+    for (i in 0 until nodes.length) {
+        val el = nodes.item(i) as? HTMLElement ?: continue
+        val r = el.getBoundingClientRect()
+        if ((r.right - r.left) > 0.0 && (r.bottom - r.top) > 0.0) out.add(el)
+    }
+    return out
+}
+
+/**
+ * Resolves the focused pane's index among [els]: the `.dt-pane-focused`
+ * element if present, else the active tab's persisted `focusedPaneId`,
+ * else the first pane.
+ */
+private fun focusedIndex(els: List<HTMLElement>, tabId: String): Int {
+    val byClass = els.indexOfFirst { it.classList.contains("dt-pane-focused") }
+    if (byClass >= 0) return byClass
+    val saved = savedFocusedPaneId(tabId)
+    val byAttr = if (saved != null) els.indexOfFirst { it.getAttribute("data-pane-id") == saved } else -1
+    return if (byAttr >= 0) byAttr else 0
+}
+
+/**
+ * Moves keyboard focus to the pane in [dir], dispatching the same command
+ * pair a sidebar click uses (focus + raise to front). No-op when there is
+ * no active tab, fewer than two visible panes, or no distinct target.
+ *
+ * Called by the keydown listener installed in [installDirectionalPaneNav].
+ */
+private fun navigatePane(dir: PaneDirection) {
+    val tabId = latestWindowConfig?.activeTabId ?: return
+    val els = visiblePaneElements()
+    if (els.size < 2) return
+    val rects = els.map {
+        val r = it.getBoundingClientRect()
+        PaneRect(left = r.left, top = r.top, right = r.right, bottom = r.bottom)
+    }
+    val targetIdx = pickPaneInDirection(rects, focusedIndex(els, tabId), dir, wrap = true) ?: return
+    val targetId = els[targetIdx].getAttribute("data-pane-id") ?: return
+    launchCmd(WindowCommand.SetFocusedPane(tabId = tabId, paneId = targetId))
+    launchCmd(WindowCommand.RaisePane(paneId = targetId))
+}
+
+/**
+ * Maps a physical key [code] to a [PaneDirection]. We key off
+ * `KeyboardEvent.code` (not `.key`) because macOS Option mutates `.key`
+ * (⌥H → "˙") while `.code` stays layout/modifier independent.
+ */
+private fun directionForCode(code: String): PaneDirection? = when (code) {
+    "KeyH", "ArrowLeft" -> PaneDirection.LEFT
+    "KeyJ", "ArrowDown" -> PaneDirection.DOWN
+    "KeyK", "ArrowUp" -> PaneDirection.UP
+    "KeyL", "ArrowRight" -> PaneDirection.RIGHT
+    else -> null
+}
+
+/** Guards against double-installation across hot reloads / re-entry. */
+private var paneNavInstalled = false
+
+/**
+ * Installs the directional pane-navigation keydown listener.
+ *
+ * MUST be called from [start] BEFORE [bootViaToolkitShell] so this
+ * `window` capture-phase listener is registered ahead of the toolkit's
+ * own window-capture hotkey dispatcher; combined with
+ * `stopImmediatePropagation()` on handled chords, that lets us preempt
+ * the toolkit's pane-cycle binding on Ctrl+Alt+Left/Right. Gated to the
+ * Electron/Mac app at the call site.
+ *
+ * Handles only `Ctrl+Alt+(H/J/K/L | arrow)` with neither Meta nor Shift;
+ * everything else (plain terminal input, the Ctrl+Alt+Shift tab cycle)
+ * passes through untouched.
+ */
+internal fun installDirectionalPaneNav() {
+    if (paneNavInstalled) return
+    paneNavInstalled = true
+    window.asDynamic().addEventListener("keydown", { ev: Event ->
+        val e = ev as? KeyboardEvent ?: return@addEventListener
+        if (!e.ctrlKey || !e.altKey || e.metaKey || e.shiftKey) return@addEventListener
+        val dir = directionForCode(e.code) ?: return@addEventListener
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        navigatePane(dir)
+    }, true)
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/PaneNavigation.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/PaneNavigation.kt
@@ -113,10 +113,13 @@ internal fun pickPaneInDirection(
 }
 
 /**
- * Collects the active tab's pane wrappers (`.dt-pane`) that are actually
- * visible — zero-size rects (e.g. siblings hidden behind a maximized
- * pane) are dropped so they aren't navigation targets. Only the active
- * tab's panes are in the DOM, so no tab filtering is needed.
+ * Collects the active tab's pane wrappers (`.dt-pane`). Only the active
+ * tab's panes are in the DOM, so no tab filtering is needed. Minimized
+ * panes are already absent (the toolkit renders them as dock items, not
+ * `.dt-pane`). Zero-size rects are dropped defensively so a pane that is
+ * mid-collapse-animation can't become a target. Note a sibling *covered*
+ * by a maximized pane keeps its full rect here and IS a valid target —
+ * focusing it un-maximizes the cover server-side (see [navigatePane]).
  */
 private fun visiblePaneElements(): List<HTMLElement> {
     val nodes = document.querySelectorAll(".dt-pane")
@@ -131,8 +134,10 @@ private fun visiblePaneElements(): List<HTMLElement> {
 
 /**
  * Resolves the focused pane's index among [els]: the `.dt-pane-focused`
- * element if present, else the active tab's persisted `focusedPaneId`,
- * else the first pane.
+ * element if present, else the active tab's persisted `focusedPaneId`. If
+ * neither resolves (focus is on non-pane chrome, or the snapshot lags the
+ * DOM), it returns 0 as a hard last-resort anchor so the next directional
+ * press still does something predictable rather than no-op'ing.
  */
 private fun focusedIndex(els: List<HTMLElement>, tabId: String): Int {
     val byClass = els.indexOfFirst { it.classList.contains("dt-pane-focused") }
@@ -143,9 +148,18 @@ private fun focusedIndex(els: List<HTMLElement>, tabId: String): Int {
 }
 
 /**
- * Moves keyboard focus to the pane in [dir], dispatching the same command
- * pair a sidebar click uses (focus + raise to front). No-op when there is
- * no active tab, fewer than two visible panes, or no distinct target.
+ * Moves keyboard focus to the pane in [dir]. No-op when there is no active
+ * tab, fewer than two visible panes, or no distinct target.
+ *
+ * Sends `SetFocusedPane` only — deliberately NOT `RaisePane`. This matches
+ * the darkness-toolkit's own pane-cycle hotkeys (the Ctrl+Alt+Left/Right
+ * binding this replaces), which changed focus without re-stacking z-order;
+ * only an explicit pane *click* (sidebar `onPaneSelect`) raises. It also
+ * means focus echoes don't churn the persisted layout z-order on every
+ * keystroke. If the target is currently covered by a *maximized* sibling,
+ * the server's [se.soderbjorn.termtastic.WindowCommand.SetFocusedPane]
+ * handler clears that sibling's maximize flag, so the newly-focused pane
+ * becomes visible (again matching the cycle's auto-unmaximize).
  *
  * Called by the keydown listener installed in [installDirectionalPaneNav].
  */
@@ -160,7 +174,6 @@ private fun navigatePane(dir: PaneDirection) {
     val targetIdx = pickPaneInDirection(rects, focusedIndex(els, tabId), dir, wrap = true) ?: return
     val targetId = els[targetIdx].getAttribute("data-pane-id") ?: return
     launchCmd(WindowCommand.SetFocusedPane(tabId = tabId, paneId = targetId))
-    launchCmd(WindowCommand.RaisePane(paneId = targetId))
 }
 
 /**
@@ -201,6 +214,13 @@ internal fun installDirectionalPaneNav() {
         if (!e.ctrlKey || !e.altKey || e.metaKey || e.shiftKey) return@addEventListener
         val dir = directionForCode(e.code) ?: return@addEventListener
         e.preventDefault()
+        // stopImmediatePropagation (not just stopPropagation) blocks every
+        // OTHER window-capture keydown listener for this chord — that is how
+        // we preempt the toolkit's pane-cycle dispatcher. Load-bearing
+        // caveat: because we registered first, ANY window keydown listener
+        // added later (toolkit or termtastic) will never see Ctrl+Alt+
+        // (H/J/K/L|arrows). Nothing else needs them today; if that changes,
+        // narrow this swallow.
         e.stopImmediatePropagation()
         navigatePane(dir)
     }, true)

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
@@ -43,19 +43,36 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
                             chord = listOf(if (isMacUserAgent()) "⌘" else "Ctrl", "D"),
                         ),
                     )
+                    // In the app, Ctrl+Option+arrows move focus by DIRECTION —
+                    // see PaneNavigation.kt. These override the toolkit's
+                    // Previous/Next-window cycle on the same chord, so the
+                    // directional bindings are listed here in place of the
+                    // cycle. The equivalent Ctrl+Option+H/J/K/L vim bindings
+                    // also work but are intentionally left out of the
+                    // cheatsheet as a power-user feature.
+                    val ctrl = if (isMacUserAgent()) "⌃" else "Ctrl"
+                    val opt = if (isMacUserAgent()) "⌥" else "Alt"
+                    add(HotkeyEntry(label = "Focus pane left", chord = listOf(ctrl, opt, "←")))
+                    add(HotkeyEntry(label = "Focus pane down", chord = listOf(ctrl, opt, "↓")))
+                    add(HotkeyEntry(label = "Focus pane up", chord = listOf(ctrl, opt, "↑")))
+                    add(HotkeyEntry(label = "Focus pane right", chord = listOf(ctrl, opt, "→")))
+                } else {
+                    // Plain browser build: the toolkit's linear pane cycle is
+                    // still active (the directional override is app-only), so
+                    // show it.
+                    add(
+                        HotkeyEntry(
+                            label = "Previous window",
+                            chord = StandardHotkeys.PreviousPane.toChordLabel(),
+                        ),
+                    )
+                    add(
+                        HotkeyEntry(
+                            label = "Next window",
+                            chord = StandardHotkeys.NextPane.toChordLabel(),
+                        ),
+                    )
                 }
-                add(
-                    HotkeyEntry(
-                        label = "Previous window",
-                        chord = StandardHotkeys.PreviousPane.toChordLabel(),
-                    ),
-                )
-                add(
-                    HotkeyEntry(
-                        label = "Next window",
-                        chord = StandardHotkeys.NextPane.toChordLabel(),
-                    ),
-                )
                 add(
                     HotkeyEntry(
                         label = "Previous tab",

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
@@ -37,6 +37,12 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
                             chord = listOf(if (isMacUserAgent()) "⌘" else "Ctrl", "T"),
                         ),
                     )
+                    add(
+                        HotkeyEntry(
+                            label = "New terminal",
+                            chord = listOf(if (isMacUserAgent()) "⌘" else "Ctrl", "D"),
+                        ),
+                    )
                 }
                 add(
                     HotkeyEntry(

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
@@ -96,7 +96,7 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
         ),
         HotkeyGroup(
             title = "App",
-            entries = listOf(
+            entries = listOfNotNull(
                 HotkeyEntry(
                     label = "Show this hotkeys cheatsheet",
                     chord = run {
@@ -109,6 +109,18 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
                         listOf(if (isMac) "⌘" else "Ctrl", "/")
                     },
                 ),
+                // Global Quake-style show/hide toggle — registered by the
+                // Electron main process (ElectronMain.QUAKE_ACCELERATOR), so it
+                // exists only in the bundled app (also bound to
+                // Ctrl+Alt+Cmd+Space). Listed for discoverability.
+                if (isElectronClient) {
+                    HotkeyEntry(
+                        label = "Show / hide Termtastic",
+                        chord = listOf(if (isMacUserAgent()) "⌃" else "Ctrl", "`"),
+                    )
+                } else {
+                    null
+                },
             ),
         ),
     ),

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
@@ -25,24 +25,44 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
     groups = listOf(
         HotkeyGroup(
             title = "Windows & tabs",
-            entries = listOf(
-                HotkeyEntry(
-                    label = "Previous window",
-                    chord = StandardHotkeys.PreviousPane.toChordLabel(),
-                ),
-                HotkeyEntry(
-                    label = "Next window",
-                    chord = StandardHotkeys.NextPane.toChordLabel(),
-                ),
-                HotkeyEntry(
-                    label = "Previous tab",
-                    chord = StandardHotkeys.PreviousTab.toChordLabel(),
-                ),
-                HotkeyEntry(
-                    label = "Next tab",
-                    chord = StandardHotkeys.NextTab.toChordLabel(),
-                ),
-            ),
+            entries = buildList {
+                // "New tab" (⌘T) is wired through the Electron app menu only
+                // (see ElectronMain.buildAppMenu / main.kt onNewTab), so it is
+                // listed solely when running inside the bundled app — a plain
+                // browser tab has no such binding (⌘T is the browser's own).
+                if (isElectronClient) {
+                    add(
+                        HotkeyEntry(
+                            label = "New tab",
+                            chord = listOf(if (isMacUserAgent()) "⌘" else "Ctrl", "T"),
+                        ),
+                    )
+                }
+                add(
+                    HotkeyEntry(
+                        label = "Previous window",
+                        chord = StandardHotkeys.PreviousPane.toChordLabel(),
+                    ),
+                )
+                add(
+                    HotkeyEntry(
+                        label = "Next window",
+                        chord = StandardHotkeys.NextPane.toChordLabel(),
+                    ),
+                )
+                add(
+                    HotkeyEntry(
+                        label = "Previous tab",
+                        chord = StandardHotkeys.PreviousTab.toChordLabel(),
+                    ),
+                )
+                add(
+                    HotkeyEntry(
+                        label = "Next tab",
+                        chord = StandardHotkeys.NextTab.toChordLabel(),
+                    ),
+                )
+            },
         ),
         HotkeyGroup(
             title = "Dialogs",
@@ -71,3 +91,16 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
     ),
     footerNote = "Window and tab chords work even when a terminal is focused.",
 )
+
+/**
+ * True when the running browser/Electron user-agent looks like macOS (or
+ * iOS). Used to pick the ⌘ vs Ctrl glyph for the "New tab" cheatsheet
+ * entry. Mirrors the inline check the "App" group uses for the cheatsheet
+ * chord itself.
+ */
+private fun isMacUserAgent(): Boolean {
+    val ua = js(
+        "(typeof navigator !== 'undefined' && navigator.userAgent) || ''",
+    ) as String
+    return ua.contains("Mac") || ua.contains("iPhone") || ua.contains("iPad")
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
@@ -313,6 +313,16 @@ private fun start() {
         // (showBottomBar = false). The bespoke chrome that
         // used to live here is gone — see TERMTASTIC-TOOLKIT-MIGRATION.md
         // for the migration boundary and the regressions documented there.
+        // Directional (vim-style) pane focus: Ctrl+Option+H/J/K/L and
+        // Ctrl+Option+arrows move focus between panes by direction. Must be
+        // installed BEFORE bootViaToolkitShell so its window capture-phase
+        // listener is registered ahead of the toolkit's own hotkey
+        // dispatcher (it overrides the toolkit's pane cycle). Gated to the
+        // Mac/Electron app, like the ⌘T/⌘D shortcuts.
+        if (isElectronClient) {
+            installDirectionalPaneNav()
+        }
+
         val appEl = document.getElementById("app") as HTMLElement
         bootViaToolkitShell(appEl)
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
@@ -541,6 +541,20 @@ private fun start() {
         electronApi.onNewTab({ launchCmd(WindowCommand.AddTab) })
     }
 
+    // macOS app menu → "File → New Terminal" (⌘D) adds a terminal pane to the
+    // active tab. Forwarded from the Electron main process via the
+    // `new-terminal` IPC; resolves the active tab + its cwd from the live
+    // config snapshot and fires the same AddPaneToTab the pane bar's
+    // "+" → Terminal action uses. No-op if there is no active tab yet.
+    if (electronApi?.onNewTerminal != null) {
+        electronApi.onNewTerminal({
+            val tabId = latestWindowConfig?.activeTabId
+            if (tabId != null) {
+                launchCmd(WindowCommand.AddPaneToTab(tabId = tabId, cwd = cwdForNewPaneIn(tabId)))
+            }
+        })
+    }
+
     // macOS Debug menu → per-pane state override (Working / Waiting /
     // Clear). Forwarded from the Electron main process via the
     // `debug-set-pane-state` IPC; the renderer-side helper looks up

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/main.kt
@@ -533,6 +533,14 @@ private fun start() {
         electronApi.onShowSettings({ openAppSettingsSidebar() })
     }
 
+    // macOS app menu → "File → New Tab" (⌘T) adds a tab. Forwarded from the
+    // Electron main process via the `new-tab` IPC; fires the same AddTab
+    // command the "+" tab-strip button uses, so the shortcut and the button
+    // behave identically.
+    if (electronApi?.onNewTab != null) {
+        electronApi.onNewTab({ launchCmd(WindowCommand.AddTab) })
+    }
+
     // macOS Debug menu → per-pane state override (Working / Waiting /
     // Clear). Forwarded from the Electron main process via the
     // `debug-set-pane-state` IPC; the renderer-side helper looks up


### PR DESCRIPTION
## Summary

Adds a set of keyboard shortcuts to the **Mac/Electron app**, aimed at agent-development workflows:

| Shortcut | Action |
| --- | --- |
| **⌘T** | New tab |
| **⌘D** | New terminal pane (in the active tab) |
| **⌃⌥← / ↓ / ↑ / →** (and **⌃⌥H/J/K/L**) | Move pane focus by direction (vim-style), with wrap-around |
| **Ctrl+`** (and Ctrl+Alt+Cmd+Space) | Quake/iTerm-style global show/hide toggle |

## Details

**⌘T / ⌘D** — native **File** menu items in the Electron main process → `new-tab` / `new-terminal` IPC → preload bridge → renderer dispatches the same `WindowCommand.AddTab` / `AddPaneToTab` the `+` buttons use. Purely additive; no protocol/server changes. Both are also surfaced in the ⌘/ cheatsheet.

**Directional pane navigation** (`web/.../PaneNavigation.kt`) — replaces the darkness-toolkit's linear pane *cycle* (which was on the same ⌃⌥-arrow chord) with true directional movement. A `window` capture-phase keydown listener is installed *before* the toolkit shell so it preempts the toolkit's dispatcher (`stopImmediatePropagation`); it matches on `event.code` (Option mutates `event.key` on macOS) and requires exactly Ctrl+Option, so the toolkit's ⌃⌥⇧-arrow **tab** cycle is untouched. The spatial pick reads live `.dt-pane` DOM rects (pane geometry is toolkit-owned, so the server config is unreliable for this). It sends **`SetFocusedPane` only** — matching the cycle it replaces, which was focus-only (no z-order re-stacking). HJKL works but is intentionally left out of the cheatsheet as a power-user binding.

**Quake toggle** (`electron-main/.../ElectronMain.kt`) — the existing global summon (Ctrl+Alt+Cmd+Space) now *toggles* (hides when frontmost) instead of only showing, and **Ctrl+`** is added as a second global hotkey with the same `toggleQuakeWindow()` behavior.

## Caveats worth a reviewer's eye

- **`Ctrl+\`` is a *global* shortcut** — while termtastic runs it shadows Ctrl+` in every app (e.g. VS Code's integrated-terminal toggle). This is inherent to a Quake hotkey window and was a deliberate choice.
- Global hotkeys remain **dev-gated** (`registered only when !IS_DEV_LAUNCH`), so they activate only in packaged builds, not dev/demo launches.
- ⌃⌥-arrows overlap macOS **VoiceOver** navigation when VoiceOver is on (pre-existing; the toolkit already used ⌃⌥-arrows).

## Testing

- ⌘T, ⌘D, directional pane nav (incl. wrap + over a focused terminal): verified in `:electron:runDemo`.
- Quake toggle: verified in a packaged build (the dev launches don't register global hotkeys).
- All modules compile.

## Notes

- Design spec under `docs/superpowers/specs/`.
- An independent code-review pass was run on the branch; its findings were addressed (notably: directional nav switched to focus-only to match the prior cycle, and corrected docs around maximized-pane handling).
