### PR TITLE
Add double-click-to-rename for panes (header + sidebar)

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
@@ -8,19 +8,26 @@
  * menu in `termtasticPaneActions` exposes a "Rename pane" item that
  * calls `beginPaneRename`. The toolkit's hover-arm gesture is *not*
  * enabled for pane headers (`PaneHeaderSpec.armRenameOnHover` defaults
- * `false`); the menu item is the sole entry point.
+ * `false`, and the flag isn't exposed through `AppShellSpec`), so
+ * termtastic supplies the double-click trigger itself —
+ * [installPaneTitleDoubleClickRename] routes a dblclick on a pane title
+ * to the same `beginPaneRename`. The kebab item and the double-click are
+ * the two entry points.
  *
- * This file now only carries the tab-label variant, which still owns
- * its own DOM swap because the tab strip isn't yet on the toolkit
- * primitive.
+ * Besides that installer this file carries the tab-label rename variant,
+ * which still owns its own DOM swap because the tab strip isn't yet on
+ * the toolkit primitive.
  *
  * @see startTabRename
+ * @see installPaneTitleDoubleClickRename
  */
 package se.soderbjorn.termtastic
 
 import kotlinx.browser.document
+import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.events.Event
 import org.w3c.dom.events.KeyboardEvent
 
 /**
@@ -76,4 +83,38 @@ fun startTabRename(labelEl: HTMLElement, tabId: String) {
     })
     input.addEventListener("click", { ev -> ev.stopPropagation() })
     input.addEventListener("dblclick", { ev -> ev.stopPropagation() })
+}
+
+/** Guards against double-installation across re-entry. */
+private var paneTitleRenameInstalled = false
+
+/**
+ * Wires double-click on a pane title to start an inline rename, mirroring
+ * the double-click-to-rename gesture on tab labels.
+ *
+ * Called once from [bootViaToolkitShell] after `mountAppShell` (so
+ * [appShellHandle] is set). The toolkit marks each renamable pane title
+ * with `data-dt-pane-rename-target="<paneId>"` and stashes a start-rename
+ * closure on it; we just trigger that closure via the toolkit's public
+ * [se.soderbjorn.darkness.web.shell.AppShellHandle.beginPaneRename].
+ *
+ * A delegated **capture-phase** listener is used so it runs before the
+ * pane's own bubble-phase dblclick (the toolkit's "raise/focus pane" on
+ * `onFloatingFocused`, bound on `.dt-pane`); calling `stopPropagation`
+ * then suppresses that raise, and `preventDefault` suppresses native
+ * text selection — matching the toolkit's own rename gesture. Dblclicks
+ * that aren't on a rename-target element fall through untouched, so
+ * raise-on-dblclick still works everywhere else in the pane.
+ */
+internal fun installPaneTitleDoubleClickRename() {
+    if (paneTitleRenameInstalled) return
+    paneTitleRenameInstalled = true
+    document.asDynamic().addEventListener("dblclick", { ev: Event ->
+        val target = ev.target as? Element ?: return@addEventListener
+        val renameTarget = target.closest("[data-dt-pane-rename-target]") ?: return@addEventListener
+        val paneId = renameTarget.getAttribute("data-dt-pane-rename-target") ?: return@addEventListener
+        ev.stopPropagation()
+        ev.preventDefault()
+        appShellHandle?.beginPaneRename(paneId)
+    }, /* capture = */ true)
 }

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/RenameHandlers.kt
@@ -33,9 +33,9 @@ import org.w3c.dom.events.KeyboardEvent
 /**
  * Starts an inline rename interaction for a tab label.
  *
- * Similar to [startRename] but operates on tab labels in the tab bar. Closes
- * any open tab menus, adds a "renaming" CSS class during editing, and sends
- * [WindowCommand.RenameTab] to the server on commit.
+ * Similar to [startSidebarPaneRename] but operates on tab labels in the tab
+ * bar. Closes any open tab menus, adds a "renaming" CSS class during editing,
+ * and sends [WindowCommand.RenameTab] (not [WindowCommand.Rename]) on commit.
  *
  * @param labelEl the DOM element displaying the current tab label
  * @param tabId the unique tab identifier for the rename command
@@ -117,4 +117,97 @@ internal fun installPaneTitleDoubleClickRename() {
         ev.preventDefault()
         appShellHandle?.beginPaneRename(paneId)
     }, /* capture = */ true)
+}
+
+/** Guards against double-installation across re-entry. */
+private var sidebarPaneRenameInstalled = false
+
+/**
+ * Wires double-click on a sidebar pane-name row to start an inline rename.
+ *
+ * Called once from [bootViaToolkitShell] after `mountAppShell`. The
+ * toolkit's sidebar rows expose no rename hook (unlike the pane header),
+ * so termtastic hand-rolls the inline rename here, mirroring
+ * [startTabRename]. Document-level delegation survives the toolkit's
+ * sidebar rebuilds.
+ *
+ * Only the pane *name* (`.dt-sidebar-row-label`) inside a pane row
+ * (`.dt-sidebar-row[data-pane-id]`) triggers it — clicks on the row's
+ * icon / handle / index badge, and on non-pane rows, fall through so the
+ * row's normal click-to-focus is untouched.
+ */
+internal fun installSidebarPaneDoubleClickRename() {
+    if (sidebarPaneRenameInstalled) return
+    sidebarPaneRenameInstalled = true
+    document.asDynamic().addEventListener("dblclick", { ev: Event ->
+        val target = ev.target as? Element ?: return@addEventListener
+        val labelEl = target.closest(".dt-sidebar-row-label") as? HTMLElement ?: return@addEventListener
+        val row = labelEl.closest(".dt-sidebar-row[data-pane-id]") ?: return@addEventListener
+        val paneId = row.getAttribute("data-pane-id") ?: return@addEventListener
+        ev.stopPropagation()
+        // Suppress the native text-selection a double-click would make on
+        // the label before we swap it for the input (matches the pane-title
+        // rename gesture).
+        ev.preventDefault()
+        startSidebarPaneRename(labelEl, paneId)
+    })
+}
+
+/**
+ * Starts an inline rename interaction for a pane's sidebar name row.
+ *
+ * Close cousin of [startTabRename]: swaps [labelEl] for a focused,
+ * pre-selected `<input>` and commits the new name to the server via
+ * [WindowCommand.Rename] — the same command the pane-header rename and
+ * the kebab "Rename pane" item use. Commit fires on Enter / blur (when
+ * the trimmed value is non-empty and changed); Escape, an empty value,
+ * or no change restores the label in place. On a real commit the input
+ * is left in the DOM; the server's config push rebuilds the sidebar row
+ * with the new name, discarding the transient input.
+ *
+ * @param labelEl the `.dt-sidebar-row-label` span showing the pane name
+ * @param paneId  the pane id, read from the row's `data-pane-id`
+ * @see installSidebarPaneDoubleClickRename
+ */
+internal fun startSidebarPaneRename(labelEl: HTMLElement, paneId: String) {
+    val current = labelEl.textContent ?: ""
+    val parent = labelEl.parentElement ?: return
+    val input = document.createElement("input") as HTMLInputElement
+    input.type = "text"
+    input.className = "tt-sidebar-rename-input"
+    input.value = current
+    input.setAttribute("draggable", "false")
+    parent.replaceChild(input, labelEl)
+    input.focus()
+    input.select()
+
+    var settled = false
+    fun cancel() {
+        if (settled) return
+        settled = true
+        if (input.parentElement === parent) parent.replaceChild(labelEl, input)
+    }
+    fun commit() {
+        if (settled) return
+        settled = true
+        val newTitle = input.value.trim()
+        if (newTitle.isEmpty() || newTitle == current) {
+            if (input.parentElement === parent) parent.replaceChild(labelEl, input)
+            return
+        }
+        launchCmd(WindowCommand.Rename(paneId = paneId, title = newTitle))
+    }
+
+    input.addEventListener("blur", { commit() })
+    input.addEventListener("keydown", { ev ->
+        when ((ev as KeyboardEvent).key) {
+            "Enter" -> { ev.preventDefault(); commit() }
+            "Escape" -> { ev.preventDefault(); cancel() }
+        }
+    })
+    // Keep mouse interactions on the input from reaching the row (its
+    // click-to-focus / drag) while editing.
+    input.addEventListener("mousedown", { ev -> ev.stopPropagation() })
+    input.addEventListener("click", { ev -> ev.stopPropagation() })
+    input.addEventListener("dblclick", { ev -> ev.stopPropagation() })
 }

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
@@ -785,4 +785,10 @@ fun bootViaToolkitShell(root: HTMLElement) {
     // so it survives the toolkit's chrome rebuilds without per-render
     // re-wiring — see [installReformatHoverPopup].
     installReformatHoverPopup()
+
+    // Double-click a pane title to rename it (mirrors tab-label rename).
+    // Document-level delegation, so it survives toolkit chrome rebuilds;
+    // routes to the toolkit's beginPaneRename via appShellHandle (now set
+    // above). See [installPaneTitleDoubleClickRename].
+    installPaneTitleDoubleClickRename()
 }

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
@@ -791,4 +791,9 @@ fun bootViaToolkitShell(root: HTMLElement) {
     // routes to the toolkit's beginPaneRename via appShellHandle (now set
     // above). See [installPaneTitleDoubleClickRename].
     installPaneTitleDoubleClickRename()
+
+    // Double-click a pane's name in the sidebar to rename it. Same
+    // delegation pattern; the sidebar has no toolkit rename hook, so this
+    // hand-rolls the inline input. See [installSidebarPaneDoubleClickRename].
+    installSidebarPaneDoubleClickRename()
 }

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -2652,6 +2652,24 @@ body[data-tt-news-pulse="1"] .tt-news-topbar {
 .dt-sidebar-row-label  { order: 0; }
 .dt-sidebar-row-badge  { order: 1; }
 
+/* Inline rename input that replaces the pane name on sidebar double-click
+   (see RenameHandlers.startSidebarPaneRename). Sits in the label's flex
+   slot and matches the row's type, so the row height/layout stays stable
+   while editing. */
+.tt-sidebar-rename-input {
+    order: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: -1px 0;
+    padding: 0 4px;
+    font: inherit;
+    color: inherit;
+    background: var(--t-surface-alt, rgba(255, 255, 255, 0.08));
+    border: 1px solid var(--t-border, rgba(255, 255, 255, 0.28));
+    border-radius: 4px;
+    outline: none;
+}
+
 /* Vertically align the left-pane tab-header status dot (issue #43) with the
    per-row status dots beneath it. A `.dt-sidebar-row` sits `margin-right: 4px`
    + `padding-right: 12px` = 16px in from the sidebar edge, but the section


### PR DESCRIPTION
## Summary

Adds **double-click-to-rename for panes**, mirroring the existing tab-label double-click rename. A pane is now renamable from three consistent places — the **pane header**, the **kebab "Rename pane"** item, and now the **header title double-click** and the **left sidebar** — all committing the same `WindowCommand.Rename`.

## Details

**Pane header double-click** (`installPaneTitleDoubleClickRename`) — the darkness-toolkit already has the inline-rename machinery but gates its dblclick/hover gestures behind `armRenameOnHover`, which isn't exposed through `AppShellSpec`. So a small document **capture-phase** dblclick listener resolves the toolkit's renamable title (`data-dt-pane-rename-target`) and triggers the toolkit's own input swap via the public `AppShellHandle.beginPaneRename(paneId)`. Capture phase + `stopPropagation`/`preventDefault` suppress the pane's *other* dblclick (raise/focus) and native text selection.

**Sidebar double-click** (`installSidebarPaneDoubleClickRename` + `startSidebarPaneRename`) — the toolkit gives sidebar rows no rename hook, so termtastic hand-rolls the inline rename (close cousin of `startTabRename`): a delegated dblclick on a pane row's `.dt-sidebar-row-label` swaps it for an `<input>`, committing `WindowCommand.Rename(paneId, …)` on Enter/blur and cancelling on Esc/empty/unchanged. New `.tt-sidebar-rename-input` style (uses the theme's `--t-surface-alt`/`--t-border` tokens).

Both use document-level delegation so they survive the toolkit's chrome rebuilds, with install guards against duplicates.

## Notes

- Verified against darkness-toolkit **0.2.5** (the selectors/attrs/APIs used all exist there).
- Empty/unchanged input cancels in place — matches the toolkit's own header-rename gesture exactly.
- An independent code-review pass was run (low risk); its findings were applied (real theme tokens instead of undefined ones, `preventDefault` on the sidebar gesture, a doc-link fix).

## Testing

Verified in `:electron:runDemo` (the demo server handles `WindowCommand.Rename`): double-click a pane header title and a sidebar pane name → inline input → Enter commits / Esc cancels; single-click still just focuses; tab-strip rename and pane raise-on-dblclick elsewhere unaffected.
