### PR TITLE
Mac: Add Cmd+1..9 to switch tabs by position

### DIFF
--- a/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/TabSwitchShortcuts.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/termtastic/client/TabSwitchShortcuts.kt
@@ -1,0 +1,39 @@
+/* TabSwitchShortcuts.kt (commonMain)
+ *
+ * Pure mapping logic for the `Cmd+<digit>` tab-switch keyboard
+ * shortcuts (Mac/Electron). Kept platform-agnostic and free of any
+ * DOM / WindowConfig dependency so it can be unit-tested directly; the
+ * web frontend feeds it the live tab count and uses the returned index
+ * to pick the target tab id. See the jsMain `installTabNumberShortcuts`
+ * wiring for the event side of this feature.
+ */
+package se.soderbjorn.termtastic.client
+
+/**
+ * Resolves which tab a `Cmd+<digit>` shortcut should activate.
+ *
+ * Convention (matches Safari / Chrome / iTerm):
+ * - Digits `1`–`8` select the 1st–8th tab by raw position (zero-based
+ *   index `digit - 1`), or nothing if that position doesn't exist.
+ * - Digit `9` always selects the **last** tab, regardless of how many
+ *   tabs there are.
+ *
+ * Called by the jsMain key handler ([installTabNumberShortcuts]) on
+ * every matching keydown; the returned index is looked up against the
+ * live `WindowConfig.tabs` list to obtain the tab id passed to
+ * `WindowCommand.SetActiveTab`.
+ *
+ * @param digit the pressed number key, expected in `1..9`.
+ * @param tabCount the number of tabs currently in the window.
+ * @return the zero-based tab index to activate, or `null` when the
+ *   shortcut should be a no-op (no tabs, out-of-range position, or a
+ *   digit outside `1..9`).
+ */
+fun resolveTabSwitchIndex(digit: Int, tabCount: Int): Int? {
+    if (tabCount <= 0) return null
+    return when (digit) {
+        9 -> tabCount - 1
+        in 1..8 -> (digit - 1).takeIf { it < tabCount }
+        else -> null
+    }
+}

--- a/client/src/jvmTest/kotlin/se/soderbjorn/termtastic/client/TabSwitchShortcutsTest.kt
+++ b/client/src/jvmTest/kotlin/se/soderbjorn/termtastic/client/TabSwitchShortcutsTest.kt
@@ -1,0 +1,47 @@
+/**
+ * Tests for [resolveTabSwitchIndex] — the pure mapping from a
+ * `Cmd+<digit>` keyboard shortcut to the tab index it should activate.
+ *
+ * @see resolveTabSwitchIndex
+ */
+package se.soderbjorn.termtastic.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TabSwitchShortcutsTest {
+
+    @Test
+    fun digitsOneThroughEightMapToZeroBasedIndex() {
+        assertEquals(0, resolveTabSwitchIndex(digit = 1, tabCount = 8))
+        assertEquals(2, resolveTabSwitchIndex(digit = 3, tabCount = 8))
+        assertEquals(7, resolveTabSwitchIndex(digit = 8, tabCount = 8))
+    }
+
+    @Test
+    fun digitNineAlwaysSelectsLastTab() {
+        assertEquals(2, resolveTabSwitchIndex(digit = 9, tabCount = 3))
+        assertEquals(11, resolveTabSwitchIndex(digit = 9, tabCount = 12))
+        assertEquals(0, resolveTabSwitchIndex(digit = 9, tabCount = 1))
+    }
+
+    @Test
+    fun outOfRangePositionalDigitReturnsNull() {
+        assertNull(resolveTabSwitchIndex(digit = 5, tabCount = 3))
+        assertNull(resolveTabSwitchIndex(digit = 8, tabCount = 7))
+    }
+
+    @Test
+    fun noTabsReturnsNull() {
+        assertNull(resolveTabSwitchIndex(digit = 1, tabCount = 0))
+        assertNull(resolveTabSwitchIndex(digit = 9, tabCount = 0))
+    }
+
+    @Test
+    fun digitsOutsideOneThroughNineReturnNull() {
+        assertNull(resolveTabSwitchIndex(digit = 0, tabCount = 5))
+        assertNull(resolveTabSwitchIndex(digit = 10, tabCount = 5))
+        assertNull(resolveTabSwitchIndex(digit = -1, tabCount = 5))
+    }
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TabNumberShortcuts.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TabNumberShortcuts.kt
@@ -1,0 +1,61 @@
+/* TabNumberShortcuts.kt (jsMain)
+ *
+ * Wires the `Cmd+1` … `Cmd+9` keyboard shortcuts that jump straight to
+ * a tab by position. `Cmd+1`–`Cmd+8` activate the 1st–8th tab; `Cmd+9`
+ * activates the last tab (the Safari / Chrome / iTerm convention).
+ *
+ * The pure index mapping lives in commonMain
+ * ([se.soderbjorn.termtastic.client.resolveTabSwitchIndex], unit-tested
+ * there); this file only owns the DOM event side — matching the chord,
+ * resolving it against the live [latestWindowConfig], and firing the
+ * `SetActiveTab` command.
+ *
+ * Installed from [bootViaToolkitShell] and gated to the Electron
+ * desktop client: in a real browser `Cmd+<digit>` is reserved for
+ * switching browser tabs and can't be reliably overridden, so we don't
+ * try to fight it there.
+ */
+package se.soderbjorn.termtastic
+
+import kotlinx.browser.window
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.KeyboardEvent
+import se.soderbjorn.termtastic.client.resolveTabSwitchIndex
+
+/**
+ * Installs the window-level `Cmd+<digit>` tab-switch key handler.
+ *
+ * Listens at the capture phase so the chord is consumed before xterm's
+ * own textarea handler sees it. Only plain `Cmd+<digit>` (no Ctrl / Alt
+ * / Shift) is handled; any other modifier combination is left untouched
+ * so existing chords aren't shadowed. A matching press that resolves to
+ * a real tab fires [WindowCommand.SetActiveTab] via [launchCmd] and
+ * stops further propagation / default handling; a press that maps to no
+ * tab (e.g. `Cmd+5` with three tabs) is left to fall through as a
+ * harmless no-op.
+ *
+ * Called once at boot from [bootViaToolkitShell]; should only be invoked
+ * for the Electron client (see file header).
+ */
+internal fun installTabNumberShortcuts() {
+    val handler: (Event) -> Unit = handler@{ ev ->
+        val k = ev as KeyboardEvent
+        // Plain Cmd only — bail on any other modifier combination.
+        if (!k.metaKey || k.ctrlKey || k.altKey || k.shiftKey) return@handler
+        // Match physical top-row digit keys ("Digit1".."Digit9"), so the
+        // chord is layout-independent and unaffected by what character the
+        // key would otherwise produce.
+        val code = k.code
+        if (code.length != 6 || !code.startsWith("Digit")) return@handler
+        val digit = code.substring(5).toIntOrNull() ?: return@handler
+        if (digit < 1) return@handler
+
+        val config = latestWindowConfig ?: return@handler
+        val index = resolveTabSwitchIndex(digit = digit, tabCount = config.tabs.size) ?: return@handler
+
+        k.preventDefault()
+        k.stopImmediatePropagation()
+        launchCmd(WindowCommand.SetActiveTab(tabId = config.tabs[index].id))
+    }
+    window.addEventListener("keydown", handler, true)
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticHotkeysContent.kt
@@ -25,24 +25,34 @@ internal fun termtasticHotkeysSpec(): HotkeysModalSpec = HotkeysModalSpec(
     groups = listOf(
         HotkeyGroup(
             title = "Windows & tabs",
-            entries = listOf(
-                HotkeyEntry(
+            entries = buildList {
+                add(HotkeyEntry(
                     label = "Previous window",
                     chord = StandardHotkeys.PreviousPane.toChordLabel(),
-                ),
-                HotkeyEntry(
+                ))
+                add(HotkeyEntry(
                     label = "Next window",
                     chord = StandardHotkeys.NextPane.toChordLabel(),
-                ),
-                HotkeyEntry(
+                ))
+                add(HotkeyEntry(
                     label = "Previous tab",
                     chord = StandardHotkeys.PreviousTab.toChordLabel(),
-                ),
-                HotkeyEntry(
+                ))
+                add(HotkeyEntry(
                     label = "Next tab",
                     chord = StandardHotkeys.NextTab.toChordLabel(),
-                ),
-            ),
+                ))
+                // Cmd+1..9 jump straight to a tab by position (Cmd+9 =
+                // last tab). Desktop-only (see installTabNumberShortcuts,
+                // wired in bootViaToolkitShell), so the cheatsheet only
+                // advertises it on the Electron client.
+                if (isElectronClient) {
+                    add(HotkeyEntry(
+                        label = "Switch to tab 1–9 (9 = last)",
+                        chord = listOf("⌘", "1…9"),
+                    ))
+                }
+            },
         ),
         HotkeyGroup(
             title = "Dialogs",

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TermtasticToolkitBootstrap.kt
@@ -648,6 +648,10 @@ fun bootViaToolkitShell(root: HTMLElement) {
     // the toolkit; termtastic only supplies the curated content list.
     val hotkeysModal = ToolkitHotkeysModal().apply { setContent(termtasticHotkeysSpec()) }
     installCheatsheetHotkey(hotkeysModal)
+    // Cmd+1..9 tab switching is desktop-only: in a real browser the OS /
+    // browser owns Cmd+<digit> for switching browser tabs, so we only
+    // arm it for the Electron client. See installTabNumberShortcuts.
+    if (isElectronClient) installTabNumberShortcuts()
     appShellHandle = mountAppShell(
         AppShellSpec(
             rootContainer = root,


### PR DESCRIPTION
## What

Adds **⌘1–⌘9** keyboard shortcuts to jump straight to a tab by position in the Electron desktop app:

- **⌘1–⌘8** activate the 1st–8th tab by raw index in `WindowConfig.tabs`.
- **⌘9** always activates the **last** tab (the Safari / Chrome / iTerm convention).
- Plain ⌘ only — any combination with Ctrl/Alt/Shift is ignored so existing chords aren't shadowed.

## How

- The pure index mapping lives in commonMain: `resolveTabSwitchIndex(digit, tabCount)` (`client/.../TabSwitchShortcuts.kt`), with unit tests.
- `installTabNumberShortcuts()` (`web/.../TabNumberShortcuts.kt`) installs a capture-phase `keydown` handler that matches `⌘+<digit>` via `event.code` (`Digit1`–`Digit9`), resolves it against the live `latestWindowConfig`, and fires `WindowCommand.SetActiveTab`.
- Wired in `bootViaToolkitShell`, gated to `isElectronClient` — a real browser owns `⌘+<digit>` for switching browser tabs, so we don't fight it there.
- Cheatsheet (`⌘/Ctrl+/`) lists the chord on the desktop client.

## Testing

- ✅ `:client:jvmTest` — resolver unit tests (positional mapping, ⌘9→last, out-of-range, empty, invalid digit).
- ✅ `:web:compileKotlinJs` — compiles clean.
- ✅ Manually verified in the Electron demo (`scripts/run-electron-demo.sh`): ⌘1/2/3 switch tabs, ⌘9 jumps to the last tab.

## Note for the maintainer (unrelated pre-existing issue)

`main` currently doesn't compile the web target: commit dd48891 changed `web/.../PaneTypeModal.kt` to reference a `LinkThumbnail` class in `jsMain`, but the file defining it isn't committed (it only exists in the Android module). This PR doesn't touch that — I verified the build locally with a throwaway `LinkThumbnail` shim that is **not** part of this branch. You likely have an uncommitted `LinkThumbnail.kt` to add.