### PR TITLE
Fix: zsh OSC-7 bootstrap skipped ~/.zprofile (dropped Homebrew PATH, froze fzf/vim)

### DIFF
--- a/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ShellInitFiles.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ShellInitFiles.kt
@@ -9,8 +9,12 @@
  * Called by [TerminalSession.create] (in Application.kt) when spawning a
  * new PTY process. The method [ShellInitFiles.configureEnv] injects the
  * appropriate environment variables before the shell starts:
- *  - **zsh**: redirects `ZDOTDIR` to a generated bootstrap `.zshrc` that
- *    sources the user's real config and installs a `chpwd_functions` hook.
+ *  - **zsh**: redirects `ZDOTDIR` to a generated bootstrap dir that forwards
+ *    the user's full login startup chain (`.zshenv`, `.zprofile`, `.zshrc`)
+ *    and installs a `chpwd_functions` hook. Forwarding every phase — not just
+ *    `.zshrc` — matters because zsh resolves all startup files from `ZDOTDIR`,
+ *    so a `.zshrc`-only bootstrap silently skips `~/.zprofile` (where macOS
+ *    users put `brew shellenv`, i.e. the Homebrew `PATH`).
  *  - **bash**: appends an OSC 7 emitter to `PROMPT_COMMAND`.
  *  - **fish**: no action needed (fish emits OSC 7 by default).
  *
@@ -28,9 +32,11 @@ import java.io.File
  * them up. Most distros that ship VTE already do this; macOS bash/zsh do not.
  *
  * Strategy:
- *  - **zsh**: redirect ZDOTDIR to a generated bootstrap dir whose `.zshrc`
- *    sources the user's real `~/.zshrc` (or `${'$'}TERMTASTIC_REAL_ZDOTDIR/.zshrc`)
- *    and then registers a `chpwd_functions` hook.
+ *  - **zsh**: redirect ZDOTDIR to a generated bootstrap dir that forwards each
+ *    phase of the user's real startup chain (`.zshenv` / `.zprofile` →
+ *    `${'$'}{TERMTASTIC_REAL_ZDOTDIR:-${'$'}HOME}`), then in `.zshrc` restores
+ *    `ZDOTDIR`, sources the real `.zshrc`, and registers a `chpwd_functions`
+ *    hook. `.zlogin` is read from the restored real `ZDOTDIR` directly.
  *  - **bash**: append an OSC 7 emitter snippet to PROMPT_COMMAND.
  *  - **fish**: nothing — already emits OSC 7 by default.
  *  - **other**: nothing; the polling fallback in [ProcessCwdReader] still works.
@@ -39,10 +45,84 @@ internal object ShellInitFiles {
 
     private val zshBootstrapDir: File by lazy {
         val dir = File(AppPaths.dataDir(), "shell-init/zsh")
-        dir.mkdirs()
-        File(dir, ".zshrc").writeText(zshRcContents())
+        writeZshBootstrapFiles(dir)
         dir
     }
+
+    /**
+     * Materialise the zsh bootstrap startup files into [dir].
+     *
+     * zsh resolves every user startup file (`.zshenv`, `.zprofile`, `.zshrc`,
+     * `.zlogin`) from `$ZDOTDIR`. Because we redirect `ZDOTDIR` here, the
+     * bootstrap must replay each phase of the user's real startup chain, or
+     * those files are silently skipped. The one that bites on macOS is
+     * `~/.zprofile`: it's where `eval "$(brew shellenv)"` typically lives, so
+     * skipping it drops Homebrew from `PATH` (which in turn makes `vim` resolve
+     * to a stripped system build, etc.). See [zshForwardContents].
+     *
+     * Phase handling:
+     *  - `.zshenv` / `.zprofile` forward to the user's real files while
+     *    `ZDOTDIR` still points here (so the next phase is also found here).
+     *  - `.zshrc` restores `ZDOTDIR`, sources the real `.zshrc`, and installs
+     *    the OSC 7 hook (see [zshRcContents]). Restoring there — not earlier —
+     *    keeps the recursion guard for re-execing startup chains (p10k instant
+     *    prompt, `exec zsh`, …) that historically lived in `.zshrc`.
+     *  - `.zlogin` needs no bootstrap file: by the time zsh reaches it,
+     *    `ZDOTDIR` is restored, so the user's real `.zlogin` is read directly.
+     *
+     * Extracted so tests can generate the bootstrap into a temp dir and drive a
+     * real shell through it.
+     *
+     * @param dir target directory (created if missing).
+     */
+    internal fun writeZshBootstrapFiles(dir: File) {
+        dir.mkdirs()
+        File(dir, ".zshenv").writeText(zshForwardContents(".zshenv"))
+        File(dir, ".zprofile").writeText(zshForwardContents(".zprofile"))
+        File(dir, ".zshrc").writeText(zshRcContents())
+    }
+
+    /**
+     * Bootstrap content for an early startup phase ([fileName], e.g.
+     * `.zshenv` / `.zprofile`) that simply sources the user's real counterpart.
+     *
+     * The real config dir is the original `ZDOTDIR` (stashed as
+     * `TERMTASTIC_REAL_ZDOTDIR` by [configureZsh]) or `${'$'}HOME` when the user
+     * had none. We deliberately do NOT restore `ZDOTDIR` or clear
+     * `TERMTASTIC_REAL_ZDOTDIR` here — later phases (`.zprofile`, `.zshrc`)
+     * still need to be resolved from this bootstrap dir; `.zshrc` does the
+     * restore.
+     *
+     * One subtlety: the canonical way users relocate their zsh config is to
+     * `export ZDOTDIR=…` from `~/.zshenv` (the only file zsh reads from a fixed
+     * location). If we let that take effect, zsh would resolve `.zprofile`,
+     * `.zshrc` and `.zlogin` from the user's new dir and skip our bootstrap
+     * `.zshrc` — silently dropping the OSC 7 hook. So after sourcing the user's
+     * file we re-pin `ZDOTDIR` back to the bootstrap and record the user's new
+     * dir as `TERMTASTIC_REAL_ZDOTDIR`, so `.zshrc` still runs and then
+     * restores to the user's chosen dir.
+     *
+     * @param fileName the startup file to forward (must start with a dot).
+     * @return the bootstrap file contents.
+     */
+    private fun zshForwardContents(fileName: String): String = """
+        # termtastic zsh bootstrap ($fileName) — forward to the user's real
+        # $fileName. ZDOTDIR is redirected to this dir so .zshrc can install an
+        # OSC 7 cwd hook; without forwarding each phase, files like ~/.zprofile
+        # (PATH / `brew shellenv`) would be silently skipped.
+        __termtastic_real_zdotdir="${'$'}{TERMTASTIC_REAL_ZDOTDIR:-${'$'}HOME}"
+        __termtastic_boot_zdotdir="${'$'}ZDOTDIR"
+        [[ -r "${'$'}__termtastic_real_zdotdir/$fileName" ]] && source "${'$'}__termtastic_real_zdotdir/$fileName"
+        # If the user's $fileName repointed ZDOTDIR (config relocation), put it
+        # back to the bootstrap so the remaining phases — including the .zshrc
+        # that installs the OSC 7 hook — still run here; remember their choice so
+        # .zshrc restores to it afterwards.
+        if [[ "${'$'}ZDOTDIR" != "${'$'}__termtastic_boot_zdotdir" ]]; then
+          export TERMTASTIC_REAL_ZDOTDIR="${'$'}ZDOTDIR"
+          export ZDOTDIR="${'$'}__termtastic_boot_zdotdir"
+        fi
+        unset __termtastic_real_zdotdir __termtastic_boot_zdotdir
+    """.trimIndent() + "\n"
 
     /**
      * Configure the environment variables in [env] so the shell at [shellPath]

--- a/server/src/test/kotlin/se/soderbjorn/termtastic/pty/ShellInitFilesTest.kt
+++ b/server/src/test/kotlin/se/soderbjorn/termtastic/pty/ShellInitFilesTest.kt
@@ -1,0 +1,134 @@
+/**
+ * Regression tests for [ShellInitFiles]: the zsh OSC-7 bootstrap redirects
+ * `ZDOTDIR`, and zsh resolves ALL user startup files from `$ZDOTDIR`. If the
+ * bootstrap dir only contains a `.zshrc`, the login-shell files `~/.zshenv`
+ * and `~/.zprofile` are silently skipped — which on macOS drops Homebrew's
+ * `PATH` setup (`eval "$(brew shellenv)"` typically lives in `~/.zprofile`)
+ * and makes `vim` resolve to a stripped system build.
+ *
+ * These drive a real `zsh -l -i` through the generated bootstrap and assert
+ * that (a) every phase of the user's startup chain runs, (b) the OSC-7 hook is
+ * still installed even when the user relocates their config via
+ * `export ZDOTDIR` in `~/.zshenv`, and (c) `ZDOTDIR` ends up at the user's
+ * chosen dir.
+ */
+package se.soderbjorn.termtastic.pty
+
+import org.junit.Assume.assumeTrue
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ShellInitFilesTest {
+
+    private fun zshPath(): String? =
+        listOf("/bin/zsh", "/usr/bin/zsh").firstOrNull { File(it).canExecute() }
+
+    /** Raw stdout of the spawned shell, plus the parsed `TTVARS:` map. */
+    private data class ShellResult(val raw: String, val vars: Map<String, String>)
+
+    /**
+     * Materialises the real bootstrap into a temp dir, then runs `zsh -l -i -c`
+     * with [homeFiles] written into a fake `$HOME` and [extraEnv] applied. The
+     * command prints a `TTVARS:`-prefixed line plus the final `ZDOTDIR`.
+     */
+    private fun runLoginShell(
+        homeFiles: Map<String, String>,
+        extraEnv: Map<String, String> = emptyMap(),
+    ): ShellResult {
+        val zsh = zshPath()!!
+        val fakeHome = createTempDirectory("tt-home").toFile().apply { deleteOnExit() }
+        homeFiles.forEach { (name, body) -> File(fakeHome, name).apply { writeText(body); deleteOnExit() } }
+        val bootstrap = createTempDirectory("tt-bootstrap").toFile().apply { deleteOnExit() }
+        ShellInitFiles.writeZshBootstrapFiles(bootstrap)
+        bootstrap.listFiles()?.forEach { it.deleteOnExit() }
+
+        // The bootstrap .zshrc emits an OSC 7 escape (no trailing newline) at
+        // startup; it lands right before this output, so we slice from a sentinel.
+        val pb = ProcessBuilder(
+            zsh, "-l", "-i", "-c",
+            "print -r -- \"TTVARS:TT_ZSHENV=\$TT_ZSHENV;TT_ZPROFILE=\$TT_ZPROFILE;" +
+                "TT_ZSHRC=\$TT_ZSHRC;TT_ZLOGIN=\$TT_ZLOGIN;ZDOTDIR=\$ZDOTDIR\"",
+        )
+        pb.environment().apply {
+            clear()
+            put("HOME", fakeHome.absolutePath)
+            put("ZDOTDIR", bootstrap.absolutePath)
+            put("TERM", "xterm-256color")
+            put("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+            putAll(extraEnv)
+        }
+        val proc = pb.start()
+        val raw = proc.inputStream.bufferedReader().readText()
+        proc.waitFor()
+        val line = (raw.lineSequence().firstOrNull { it.contains("TTVARS:") } ?: "").substringAfter("TTVARS:")
+        val vars = line.split(";").mapNotNull {
+            val i = it.indexOf('='); if (i <= 0) null else it.substring(0, i) to it.substring(i + 1)
+        }.toMap()
+        return ShellResult(raw, vars)
+    }
+
+    /** True if the spawned shell emitted the OSC 7 cwd report (hook installed). */
+    private fun ShellResult.osc7Emitted() = raw.contains("]7;file://")
+
+    @Test
+    fun bootstrapPreservesTheFullLoginStartupChain() {
+        assumeTrue("zsh not available", zshPath() != null)
+        val r = runLoginShell(
+            mapOf(
+                ".zshenv" to "export TT_ZSHENV=env_ran\n",
+                ".zprofile" to "export TT_ZPROFILE=profile_ran\n",
+                ".zshrc" to "export TT_ZSHRC=rc_ran\n",
+                ".zlogin" to "export TT_ZLOGIN=login_ran\n",
+            ),
+        )
+        assertEquals("env_ran", r.vars["TT_ZSHENV"], "user's ~/.zshenv was skipped")
+        assertEquals("profile_ran", r.vars["TT_ZPROFILE"], "user's ~/.zprofile was skipped")
+        assertEquals("rc_ran", r.vars["TT_ZSHRC"], "user's ~/.zshrc was not sourced")
+        assertEquals("login_ran", r.vars["TT_ZLOGIN"], "user's ~/.zlogin was skipped")
+        assertTrue(r.osc7Emitted(), "OSC 7 cwd hook was not installed")
+    }
+
+    @Test
+    fun hookSurvivesWhenZshenvRelocatesZdotdir() {
+        assumeTrue("zsh not available", zshPath() != null)
+        val custom = createTempDirectory("tt-custom").toFile().apply { deleteOnExit() }
+        File(custom, ".zprofile").apply { writeText("export TT_ZPROFILE=custom_profile\n"); deleteOnExit() }
+        File(custom, ".zshrc").apply { writeText("export TT_ZSHRC=custom_rc\n"); deleteOnExit() }
+        File(custom, ".zlogin").apply { writeText("export TT_ZLOGIN=custom_login\n"); deleteOnExit() }
+
+        val r = runLoginShell(
+            // The canonical config-relocation pattern: ~/.zshenv repoints ZDOTDIR.
+            mapOf(".zshenv" to "export TT_ZSHENV=env_ran\nexport ZDOTDIR=${custom.absolutePath}\n"),
+        )
+        // The user's relocated config must fully load …
+        assertEquals("env_ran", r.vars["TT_ZSHENV"])
+        assertEquals("custom_profile", r.vars["TT_ZPROFILE"], "relocated ~/.zprofile not sourced")
+        assertEquals("custom_rc", r.vars["TT_ZSHRC"], "relocated .zshrc not sourced")
+        assertEquals("custom_login", r.vars["TT_ZLOGIN"], "relocated .zlogin not sourced")
+        // … and ZDOTDIR must end at the user's chosen dir …
+        assertEquals(custom.absolutePath, r.vars["ZDOTDIR"], "ZDOTDIR not restored to user's dir")
+        // … AND the OSC-7 hook must still be installed (the regression).
+        assertTrue(r.osc7Emitted(), "OSC 7 hook lost when ~/.zshenv relocates ZDOTDIR")
+    }
+
+    @Test
+    fun forwardsToEnvironmentZdotdirWhenSet() {
+        assumeTrue("zsh not available", zshPath() != null)
+        val real = createTempDirectory("tt-realzdot").toFile().apply { deleteOnExit() }
+        File(real, ".zprofile").apply { writeText("export TT_ZPROFILE=real_profile\n"); deleteOnExit() }
+        File(real, ".zshrc").apply { writeText("export TT_ZSHRC=real_rc\n"); deleteOnExit() }
+
+        // Mirrors configureZsh: original ZDOTDIR stashed as TERMTASTIC_REAL_ZDOTDIR.
+        val r = runLoginShell(
+            homeFiles = emptyMap(),
+            extraEnv = mapOf("TERMTASTIC_REAL_ZDOTDIR" to real.absolutePath),
+        )
+        assertEquals("real_profile", r.vars["TT_ZPROFILE"], "env ZDOTDIR's .zprofile not sourced")
+        assertEquals("real_rc", r.vars["TT_ZSHRC"], "env ZDOTDIR's .zshrc not sourced")
+        assertEquals(real.absolutePath, r.vars["ZDOTDIR"], "ZDOTDIR not restored to env value")
+        assertTrue(r.osc7Emitted(), "OSC 7 hook not installed with env ZDOTDIR")
+    }
+}


### PR DESCRIPTION
## Symptom

Opening \`vim\` in a pane showed \`YouCompleteMe unavailable: requires Vim compiled with Python (3.8.0+)\`, and triggering fzf (e.g. \`Ctrl-P\` → fzf.vim) **froze the pane** (had to kill it). Consistently in termtastic, never in Terminal/iTerm.

## Root cause

To track cwd via an OSC-7 hook, the server redirects \`ZDOTDIR\` to a generated bootstrap dir (`ShellInitFiles`). But zsh resolves **all** user startup files (\`.zshenv\`, \`.zprofile\`, \`.zshrc\`, \`.zlogin\`) from \`\$ZDOTDIR\`. The bootstrap contained **only** a \`.zshrc\`, so for a login shell (\`zsh -l\`) the \`.zshenv\`/\`.zprofile\` phases looked in the bootstrap dir, found nothing, and the user's real \`~/.zshenv\`/\`~/.zprofile\` were **silently skipped**.

On macOS that drops Homebrew from \`PATH\` (\`eval "\$(brew shellenv)"\` lives in \`~/.zprofile\`), so \`vim\` resolves to the stripped system \`/usr/bin/vim\` (\`-python3\`) instead of the user's Homebrew vim. Hence the YouCompleteMe warning, and — the real problem — fzf.vim's non-python fallback **busy-loops at 100% CPU** (confirmed via thread dump: the server's PTY read loop was idle while \`vim\` spun).

## Fix

The bootstrap now forwards the **full** login chain:
- \`.zshenv\` / \`.zprofile\` source the user's real counterparts (from \`TERMTASTIC_REAL_ZDOTDIR\` or \`\$HOME\`) while \`ZDOTDIR\` still points at the bootstrap.
- \`.zshrc\` restores \`ZDOTDIR\` (keeping the existing re-exec recursion guard), sources the real \`.zshrc\`, and installs the OSC-7 hook.
- \`.zlogin\` is read from the restored real \`ZDOTDIR\`.

The forwarders also **re-pin \`ZDOTDIR\`** after sourcing: if a user relocates their config via \`export ZDOTDIR\` in \`~/.zshenv\` (a common pattern), that would otherwise make zsh read the remaining phases — including the bootstrap \`.zshrc\` that installs the hook — from the user's dir and skip the hook. We put \`ZDOTDIR\` back to the bootstrap and remember the user's choice so \`.zshrc\` restores to it.

## Tests

New \`ShellInitFilesTest\` drives a real \`zsh -l -i\` through the generated bootstrap and asserts:
- the full login chain runs (\`.zshenv\`/\`.zprofile\`/\`.zshrc\`/\`.zlogin\`);
- the OSC-7 hook is emitted **even when \`~/.zshenv\` relocates \`ZDOTDIR\`** (regression guard);
- forwarding works for an env-supplied \`ZDOTDIR\`.

Full server suite: 33/33 green. Also verified live in a dev build (sanitized no-Homebrew server PATH): the spawned login shell now resolves \`vim\` → \`/opt/homebrew/bin/vim\` (\`+python3\`), and the OSC-7 cwd hook still fires.

bash and fish paths are untouched.