### PR TITLE
Fix terminal scroll desync after tab switch / window refocus (web/Electron)

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/LayoutBuilder.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/LayoutBuilder.kt
@@ -387,6 +387,17 @@ fun ensureTerminal(paneId: String, sessionId: String): TerminalEntry {
                         forceReassert(entry)
                     }
                 }
+                // Hidden→visible edge: the toolkit reattaches the cached pane
+                // element on tab activation, and the browser resets the
+                // `.xterm-viewport` scrollTop to 0 on reattach while xterm
+                // keeps rendering from its internal ydisp (still at the
+                // bottom). Realign the DOM scrollbar with the buffer so the
+                // first scroll isn't interpreted against a stale scrollTop=0
+                // (which jerks the viewport to the top). Runs regardless of
+                // autoReflow — scroll position is independent of PTY sizing.
+                if (!entry.wasContainerVisible) {
+                    resyncViewportScroll(entry)
+                }
                 updateOobOverlay(entry)
             }
             entry.wasContainerVisible = visible

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
@@ -350,6 +350,69 @@ fun markScrollButtonNewOutput(entry: TerminalEntry) {
 }
 
 /**
+ * Realigns the `.xterm-viewport` DOM scroll position with the terminal
+ * buffer's logical scroll offset (`buffer.active.viewportY`, i.e. xterm's
+ * `ydisp`), fixing the desync that follows a detach/reattach of the pane's
+ * DOM.
+ *
+ * Caller context: the toolkit caches each pane's content element by pane id
+ * and *reattaches* the cached element whenever it re-renders — on tab
+ * activation (the previously-hidden tab's panes come back into the tree) and
+ * on every config push (the active tab's panes are reattached in place, e.g.
+ * after a window refocus). The browser resets a scrollable element's
+ * `scrollTop` to 0 whenever it is removed from and re-inserted into the DOM,
+ * but xterm.js renders purely from its internal `ydisp`, so the grid keeps
+ * showing the correct line (usually the latest output at the bottom) while the
+ * native scrollbar silently sits at the top. The two are now out of sync:
+ *
+ *  - the first wheel-up does nothing (`scrollTop` is already 0),
+ *  - the first wheel-down is read against `scrollTop == 0` and jerks the
+ *    viewport to the top of the scrollback, and
+ *  - [updateScrollButton] reads `viewportY == baseY` (not scrolled up) so the
+ *    "New output" pill never appears.
+ *
+ * This restores `scrollTop = viewportY * cellHeight` — the exact value xterm's
+ * own `Viewport._innerRefresh` would write — so the native scrollbar matches
+ * the rendered content again. It works whether the user was at the bottom or
+ * scrolled up into history (it keys off `viewportY`, not "at bottom"), is a
+ * no-op when already aligned, and produces no visible jump: setting `scrollTop`
+ * to precisely `ydisp * cellHeight` makes the resulting `scroll` event a
+ * zero-delta no-op inside xterm. Runs independently of [TerminalEntry.autoReflow]
+ * because scroll position is orthogonal to PTY sizing.
+ *
+ * Called from the per-pane `ResizeObserver` on each hidden→visible edge (tab
+ * activation, where the container gains a non-zero size) and from
+ * [renderConfig] after every config push (covers in-place reattaches — e.g.
+ * window refocus — that keep the same size, so the `ResizeObserver` never
+ * fires). Reads the same `_core._renderService.dimensions.css.cell.height`
+ * path as [safeFit], and degrades to a no-op if those internals are absent.
+ *
+ * @param entry the [TerminalEntry] whose DOM viewport scroll to realign
+ * @see isScrolledUp
+ * @see updateScrollButton
+ * @see fitPreservingScroll
+ */
+fun resyncViewportScroll(entry: TerminalEntry) {
+    val term = entry.term
+    val el = term.asDynamic().element as? HTMLElement ?: return
+    val viewport = el.querySelector(".xterm-viewport") as? HTMLElement ?: return
+    val core = term.asDynamic()._core
+    val cellHeight = (core?._renderService?.dimensions?.css?.cell?.height as? Number)?.toDouble() ?: return
+    if (cellHeight <= 0.0) return
+    val buffer = term.asDynamic().buffer.active
+    val viewportY = (buffer.viewportY as? Number)?.toInt() ?: return
+    val target = viewportY.toDouble() * cellHeight
+    // Only touch the DOM when actually misaligned, so a freshly-rendered
+    // pane that is already in sync doesn't churn scrollTop every push.
+    if (kotlin.math.abs(viewport.scrollTop - target) > 0.5) {
+        viewport.scrollTop = target
+    }
+    // Re-assert the pill against the (unchanged) scroll offset, so a reattach
+    // that happened to drop the class leaves it consistent with isScrolledUp.
+    updateScrollButton(entry)
+}
+
+/**
  * Writes PTY output to the terminal while holding the viewport on the *same
  * content line* when the user has scrolled up (auto-scroll "pause").
  *

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/WindowConnection.kt
@@ -244,6 +244,37 @@ private fun refocusActivePane(config: dynamic) {
     }
 }
 
+/**
+ * Realign the `.xterm-viewport` DOM scrollbar with the buffer's logical
+ * scroll offset for every currently-visible terminal, on the next frame.
+ *
+ * Companion to the per-pane `ResizeObserver` hook (which only fires on a
+ * size change, i.e. the hidden→visible edge of a tab switch). The toolkit
+ * also reattaches the *active* tab's cached pane elements in place on every
+ * config push — e.g. a window refocus that triggers a re-render — and that
+ * reattach resets `scrollTop` to 0 without changing the container size, so
+ * the `ResizeObserver` never fires and the desync would otherwise linger.
+ * Sweeping all visible terminals here closes that gap.
+ *
+ * Deferred to the next frame for the same reason as [refocusActivePane]:
+ * the toolkit's reattach must commit before we read/write `scrollTop`.
+ * Cheap (a handful of panes, each a couple of DOM reads and at most one
+ * `scrollTop` write) and idempotent — [resyncViewportScroll] no-ops when a
+ * pane is already aligned.
+ *
+ * @see resyncViewportScroll
+ * @see refocusActivePane
+ */
+private fun resyncVisibleTerminalsScroll() {
+    kotlinx.browser.window.requestAnimationFrame {
+        for (entry in terminals.values) {
+            if (entry.container.offsetParent != null) {
+                try { resyncViewportScroll(entry) } catch (_: Throwable) {}
+            }
+        }
+    }
+}
+
 fun renderConfig(config: dynamic) {
     // Post-toolkit-migration: the toolkit's `mountAppShell` (driven by
     // `TermtasticTabSource`) owns the entire chrome rebuild — top bar,
@@ -284,6 +315,13 @@ fun renderConfig(config: dynamic) {
     }
     updateAggregateStatus()
     refocusActivePane(config)
+    // Realign every visible terminal's native scrollbar with its buffer after
+    // the toolkit reattaches the active tab's cached pane elements (which
+    // resets scrollTop to 0). Covers in-place reattaches — e.g. window
+    // refocus — that the per-pane ResizeObserver misses because the size
+    // didn't change. The tab-switch case is also covered here, with the
+    // ResizeObserver edge as a faster belt-and-suspenders.
+    resyncVisibleTerminalsScroll()
     // Replay cached session states onto the freshly-rendered chrome so
     // the AppLogo dot and the per-pane / per-tab status dots pick up
     // working/waiting state immediately. Without this the dot stays on


### PR DESCRIPTION
## Problem

Switching to an existing tab (and sometimes after refocusing the window) leaves the terminal *looking* like it's at the latest output, but the scroll state is actually broken:

- the first wheel-up does nothing,
- the first wheel-down jerks the view to the **top** of the scrollback, and
- the floating **"New output"** pill often fails to appear.

It happens quite often, but not on every switch.

## Root cause

Inactive-tab pane content is detached from the DOM and cached by the toolkit, then reattached on activation (and the active tab's panes are reattached in place on every config push — e.g. on window refocus). The browser resets a scrollable element's `scrollTop` to `0` whenever it is removed from and re-inserted into the DOM, but xterm.js renders purely from its internal `ydisp`, which is still at the bottom. So the DOM scrollbar and xterm's logical scroll position desync:

- The grid renders the latest output correctly → *looks* fine.
- The native `.xterm-viewport` scrollbar sits at the top (`scrollTop == 0`).
- First wheel-up is a no-op (already at `0`); first wheel-down is interpreted against `scrollTop == 0` and snaps `ydisp` to the top.
- `isScrolledUp()` reads `viewportY == baseY` (i.e. "not scrolled up"), so the "New output" pill stays hidden.

It's intermittent because a grid-changing resize across the switch makes xterm re-sync `scrollTop` on its own; same-size tab switches (the common case) leave the desync in place — which is also why resizing the window didn't reliably fix it.

## Fix

Add `resyncViewportScroll()`, which restores `scrollTop = viewportY * cellHeight` — the exact value xterm's own `Viewport._innerRefresh` would write. It:

- preserves the user's position whether they were at the bottom or scrolled up into history (it keys off `viewportY`, not "at bottom"),
- is a no-op when already aligned,
- produces no visible jump (setting `scrollTop` to precisely `ydisp * cellHeight` makes the resulting `scroll` event a zero-delta no-op inside xterm),
- runs independently of `autoReflow`, since scroll position is orthogonal to PTY sizing.

Wired into the two reattach triggers:

1. The per-pane `ResizeObserver` hidden→visible edge (tab activation, where the container gains a non-zero size).
2. A `renderConfig` sweep of all visible terminals after every config push — covers in-place reattaches that keep the same size (e.g. window refocus), where the `ResizeObserver` never fires.

The "New output" pill's own logic is unchanged; it simply behaves correctly again once the underlying scroll state is consistent.

## Scope

Web/Electron (xterm.js) frontend only. The Android/iOS native terminal views use a different scroll model and are not affected by this DOM-reattach mechanism.

## Testing

- `./gradlew :web:compileKotlinJs` builds cleanly (only pre-existing warnings).
- Manual via `scripts/run-electron-dev.sh`: reproduced on `main` (tab with scrollback → switch away and back → broken scroll / missing pill), and confirmed it no longer reproduces with this change. The "New output" pill now appears and hides as intended.

## Files changed

- `web/.../TerminalHelpers.kt` — new `resyncViewportScroll()` helper.
- `web/.../LayoutBuilder.kt` — call it on the `ResizeObserver` hidden→visible edge.
- `web/.../WindowConnection.kt` — sweep visible terminals after each config push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
