### PR TITLE
Mac/Web: Keep scroll position pinned when tailing a full-scrollback live feed

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
@@ -354,19 +354,32 @@ fun markScrollButtonNewOutput(entry: TerminalEntry) {
  * content line* when the user has scrolled up (auto-scroll "pause").
  *
  * The pause must keep what the user is reading completely still — not merely
- * stop short of the bottom. The anchor is therefore the absolute top line
- * (`viewportY`), NOT the distance from the bottom: if we held the distance,
- * every appended line would push the read line up by one and the content would
- * drift past the reader every time output arrives.
+ * stop short of the bottom. xterm.js already does this on its own while its
+ * internal `isUserScrolling` flag is set, and it does so correctly in **both**
+ * scrollback regimes (see `BufferService.scroll`):
  *
- * xterm.js's own `BufferService` already holds `ydisp` when its internal
- * `isUserScrolling` flag is set, so normally a write keeps the line still on
- * its own. We re-assert it defensively in the write callback (after the data
- * is parsed): if anything caused the viewport to follow the bottom, scrolling
- * back up to `viewportYBefore` restores the line *and* re-sets
- * `isUserScrolling` (a negative `scrollLines` sets it), so subsequent writes
- * stay pinned. When xterm already held the line, `delta` is 0 and this is a
- * no-op.
+ *  - **Growing** (scrollback not yet full): each appended line increments
+ *    `ybase` but leaves `ydisp` put, so the read line keeps its absolute index
+ *    and stays on screen.
+ *  - **Full** (scrollback at capacity): each appended line trims the oldest
+ *    line off the top, so xterm *decrements* `ydisp` to track that shift and
+ *    keep the read line stationary.
+ *
+ * The subtlety is that the correct anchor differs between the two regimes — the
+ * absolute `viewportY` is stable only while growing; once trimming starts the
+ * absolute index of the read line decreases every write. So we re-assert the
+ * absolute `viewportYBefore` **only while the scrollback is still growing**
+ * (`baseY` increased across the write). There it is both correct and useful: if
+ * a write momentarily followed the bottom, scrolling back up to
+ * `viewportYBefore` restores the line *and* re-sets `isUserScrolling` (a
+ * negative `scrollLines` sets it) so subsequent writes stay pinned; when xterm
+ * already held the line, the delta is 0 and this is a no-op.
+ *
+ * Once the scrollback is **full** (`baseY` unchanged), we must NOT re-assert:
+ * re-anchoring to the now-stale absolute `viewportYBefore` would cancel out
+ * xterm's per-trim `ydisp` decrement and march the viewport up one line per
+ * write — the "tailing a live feed keeps scrolling away" bug. In that regime we
+ * trust xterm's own compensation and leave the scroll position alone.
  *
  * When the user is at the bottom, output is written normally so the terminal
  * keeps auto-following the latest line.
@@ -381,14 +394,21 @@ fun writeHoldingScroll(entry: TerminalEntry, bytes: Uint8Array) {
     if (isScrolledUp(term)) {
         val buffer = term.asDynamic().buffer.active
         val viewportYBefore = (buffer.viewportY as? Number)?.toInt() ?: 0
+        val baseYBefore = (buffer.baseY as? Number)?.toInt() ?: 0
         markScrollButtonNewOutput(entry)
         term.asDynamic().write(bytes) {
             val after = term.asDynamic().buffer.active
             val viewportYAfter = (after.viewportY as? Number)?.toInt() ?: 0
-            // Restore the same top line. delta < 0 (scroll back up) when the
-            // write followed the bottom; that also re-sets isUserScrolling.
-            val delta = viewportYBefore - viewportYAfter
-            if (delta != 0) term.asDynamic().scrollLines(delta)
+            val baseYAfter = (after.baseY as? Number)?.toInt() ?: 0
+            // Only re-anchor while the scrollback is still growing (no trimming
+            // yet, so the absolute viewportYBefore is still the right line).
+            // Once full (baseY unchanged) xterm already decremented ydisp to
+            // hold the line as it trimmed; re-asserting here would undo that and
+            // drift the viewport upward every write.
+            if (baseYAfter > baseYBefore) {
+                val delta = viewportYBefore - viewportYAfter
+                if (delta != 0) term.asDynamic().scrollLines(delta)
+            }
             updateScrollButton(entry)
         }
     } else {


### PR DESCRIPTION
Closes #31.

## Problem

When tailing a live feed (continuously streaming output) and scrolled up to read back, the viewport keeps drifting upward instead of holding still — the line you're reading scrolls away on every write, making it hard to actually read live logs. Terminals like Ghostty hold the rendered view steady once you scroll up; termtastic doesn't.

This is the bug reported in #31 ("After scrolling up, text jumps when new content emitted"). It also explains the note there that it couldn't be reproduced on the maintainer's machine: the drift only begins **once the scrollback buffer fills** (xterm's default 1000 lines) and trimming starts — a short session never fills it, so it never drifts. Anders J, tailing long Claude Code output, fills it in seconds; a quick local test won't.

## Root cause

`writeHoldingScroll` (`web/.../TerminalHelpers.kt`) re-anchors the viewport to the **absolute** top line (`viewportY`) after each write. That's only correct while the scrollback is still growing.

Once the xterm scrollback fills, xterm trims the oldest line on every write and **decrements `ydisp` itself** to keep the viewed line stationary (verified in xterm 5.3.0 `BufferService.scroll`: `isFull ? isUserScrolling && (ydisp = max(ydisp-1,0)) : (ybase++, isUserScrolling || ydisp++)`). The re-anchor to the now-stale absolute `viewportYBefore` cancels that compensation out and pushes the view up one line per write — the drift.

## Fix

Only re-anchor while the scrollback is still **growing** (`baseY` increased across the write → no trimming, so the absolute anchor is still valid and the existing "snap back if a write followed the bottom" behavior is preserved). Once the scrollback is **full** (`baseY` unchanged), trust xterm's own per-trim `ydisp` compensation and leave the scroll position alone.

```kotlin
if (baseYAfter > baseYBefore) {            // still growing — safe to re-anchor
    val delta = viewportYBefore - viewportYAfter
    if (delta != 0) term.scrollLines(delta)
}                                          // full — xterm already holds the line
```

Checked against all four regimes (growing/full × xterm-held/xterm-followed); the new branch is correct in each, and the growing+followed path still re-sets `isUserScrolling` so subsequent writes stay pinned.

## Scope

Web/Electron (xterm.js) frontend only. No change to the at-bottom auto-follow path.

## Testing

- `./gradlew :web:compileKotlinJs` builds cleanly.
- Manual (`scripts/run-electron-dev.sh`): fill the scrollback past 1000 lines, then stream continuously and scroll up —

  ```bash
  for i in $(seq 1 1500); do echo "warmup $i"; done
  i=0; while true; do echo "log line $i  $(date +%T.%N)"; i=$((i+1)); sleep 0.1; done
  ```

  Before: the viewed lines keep creeping upward. After: the view stays put while new output accumulates below and the "New output ↓" pill appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
