### PR TITLE
Mac/Web: Make Shift+Enter insert a newline instead of submitting

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/LayoutBuilder.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/LayoutBuilder.kt
@@ -362,6 +362,35 @@ fun ensureTerminal(paneId: String, sessionId: String): TerminalEntry {
         try { term.focus() } catch (_: Throwable) {}
     })
 
+    // Make Shift+Enter insert a newline instead of submitting. By default
+    // xterm.js emits a carriage return (`\r`) for Enter *and* Shift+Enter, so
+    // a TUI running inside (Claude Code, REPLs, chat-style prompts) can't tell
+    // them apart and treats Shift+Enter as "send". We intercept the keydown
+    // and emit a line feed (`\n`, 0x0A) instead — byte-identical to Ctrl+J,
+    // which such apps map to "insert newline", while a plain shell still reads
+    // it as submit (no regression). We deliberately send a bare `\n` rather
+    // than the CSI-u sequence (`\x1b[13;2u`) that the kitty keyboard protocol
+    // would use: xterm.js doesn't negotiate that protocol, and Claude Code's
+    // CSI-u decoder is unreliable (it can echo the literal escape) — `\n` is
+    // the robust path (it's the same workaround Ghostty users apply via
+    // `shift+enter=text:\n`). Returning `false` suppresses xterm's own `\r`;
+    // `preventDefault` stops the hidden textarea from also inserting a newline
+    // that would be re-sent. Only plain Shift+Enter is remapped — Ctrl/Alt/Meta
+    // combinations fall through to xterm so existing bindings keep working.
+    try {
+        term.attachCustomKeyEventHandler { ev ->
+            if (ev.type == "keydown" && ev.key == "Enter" &&
+                ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey
+            ) {
+                ev.preventDefault()
+                entry.sendInput?.invoke("\n")
+                false
+            } else {
+                true
+            }
+        }
+    } catch (_: Throwable) {}
+
     val observer = ResizeObserver { _, _ ->
         try {
             val visible = entry.container.offsetParent != null

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Xterm.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/Xterm.kt
@@ -14,6 +14,7 @@
 package se.soderbjorn.termtastic
 
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.KeyboardEvent
 
 /**
  * Kotlin external declaration for xterm.js's Terminal class.
@@ -36,4 +37,17 @@ external class Terminal(options: dynamic = definedExternally) {
     fun focus()
     fun paste(data: String)
     fun dispose()
+
+    /**
+     * Registers a custom key event handler that runs *before* xterm.js's own
+     * key processing, letting the host veto or replace the default behaviour.
+     *
+     * Called by [ensureTerminal] in [LayoutBuilder] to remap Shift+Enter to a
+     * line feed (so TUIs read it as "insert newline" rather than "submit").
+     *
+     * @param handler invoked for each `keydown`/`keyup`/`keypress`; return
+     *   `true` to let xterm.js process the event normally, or `false` to
+     *   suppress xterm's handling (e.g. so it does not emit `\r` for Enter).
+     */
+    fun attachCustomKeyEventHandler(handler: (KeyboardEvent) -> Boolean)
 }


### PR DESCRIPTION
Closes #32.

## Problem

Shift+Enter doesn't insert a line break inside Claude Code (and other TUI prompts) — it submits, same as Enter. By default xterm.js emits a carriage return (`\r`, 0x0D) for **both** Enter and Shift+Enter, so the app inside the terminal can't tell them apart.

(Background: "Shift+Enter ≠ Enter" isn't baseline terminal behavior — Terminal.app and Ghostty also send `\r` for both by default. The distinction only exists when an app negotiates the kitty keyboard protocol. So this is an opt-in convenience, not a bug-for-bug match of those terminals.)

## Fix

Intercept the `keydown` for plain Shift+Enter via xterm's `attachCustomKeyEventHandler`, suppress xterm's default `\r`, and emit a line feed (`\n`, 0x0A) instead.

- `\n` is byte-identical to **Ctrl+J**, which Claude Code (and its docs) treat as "insert newline".
- A plain shell / readline still reads `\n` as submit — **identical to Enter, so no regression**. The remap only produces a *visibly* different result in apps that distinguish `\n` from `\r` (Claude Code), which is exactly the target.

### Why `\n` and not the CSI-u sequence

The "modern" encoding for Shift+Enter is the kitty keyboard protocol's `\x1b[13;2u`. We deliberately don't use it:

- xterm.js (5.3.0) doesn't negotiate the kitty protocol, so we'd be emitting CSI-u unconditionally with no opt-in handshake.
- Claude Code's CSI-u decoder is unreliable and can echo the literal `[13;2u` as text (anthropics/claude-code#11192, #27001).

A bare `\n` is the robust path — it's the same workaround Ghostty users apply via `keybind = shift+enter=text:\n`.

Only **plain** Shift+Enter is remapped; Ctrl/Alt/Meta+Enter fall through to xterm so existing bindings keep working.

## Scope

Web/Electron (xterm.js) frontend only. Two files: a one-method binding in `Xterm.kt` and the handler in `ensureTerminal` (`LayoutBuilder.kt`).

## Testing

- `./gradlew :web:compileKotlinJs` builds cleanly.
- Manual (`scripts/run-electron-dev.sh`):
  - **Claude Code**: Shift+Enter inserts a newline (input grows, no submit); Enter submits. ✅ (confirmed)
  - **Plain shell**: `echo hi` + Shift+Enter still runs the command (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
