### PR TITLE
Honor program-set terminal titles (OSC 0/2) in pane names

### DIFF
--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/Constants.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/Constants.kt
@@ -1,6 +1,7 @@
 /**
- * Shared network constants used by both the Ktor server and all client targets
- * (Electron, Android, iOS) to agree on connection endpoints.
+ * Shared constants used by both the Ktor server and all client targets
+ * (Electron, Android, iOS) to agree on connection endpoints and on
+ * cross-module UI-settings keys.
  */
 package se.soderbjorn.termtastic
 
@@ -17,3 +18,12 @@ package se.soderbjorn.termtastic
  * connect never triggers a `certificate-error`.
  */
 const val SERVER_TLS_PORT = 8443
+
+/**
+ * UI-settings key (in `/api/ui-settings`) for the opt-in "use program-set
+ * terminal titles" toggle. Defined in the shared module because the key is a
+ * cross-module contract: the web client's App Settings sidebar writes it
+ * (`AppSettingsContent.kt`) and the server reads it live to gate applying
+ * OSC 0/2 program titles to panes (see `TerminalSessions.programTitlesEnabled`).
+ */
+const val TERMINAL_PROGRAM_TITLE_KEY = "terminalProgramTitle"

--- a/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
+++ b/clientServer/src/commonMain/kotlin/se/soderbjorn/termtastic/WindowConfig.kt
@@ -156,13 +156,21 @@ data class LeafNode(
     val sessionId: String,
     /**
      * Display title shown in the pane header. Always equals
-     * `customName ?: prettifyPath(cwd) ?: defaultLabel` — kept denormalized so
-     * the websocket payload doesn't have to compute it client-side and so
-     * persisted blobs round-trip without recomputation.
+     * `customName ?: programTitle ?: prettifyPath(cwd) ?: defaultLabel` — kept
+     * denormalized so the websocket payload doesn't have to compute it
+     * client-side and so persisted blobs round-trip without recomputation.
      */
     val title: String,
     /** User-set name. `null` means "fall back to the cwd-based title". */
     val customName: String? = null,
+    /**
+     * Title set by the program running in the terminal via the standard OSC 0/2
+     * escape sequence (e.g. Claude Code's live task summary), sanitized
+     * server-side. Ranks below [customName] and above the cwd-based title —
+     * see `computeLeafTitle`. `null` when no program has set one (or the
+     * feature is off); persisted like [cwd] so restored layouts keep it.
+     */
+    val programTitle: String? = null,
     /** Last known shell working directory, learned from OSC 7 / proc polling. */
     val cwd: String? = null,
     /**

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/Application.kt
@@ -37,7 +37,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import org.slf4j.LoggerFactory
 import se.soderbjorn.termtastic.persistence.AppPaths
 import se.soderbjorn.termtastic.persistence.SettingsRepository
@@ -55,6 +61,23 @@ private const val PING_PERIOD_MS = 20_000L
 private const val PING_TIMEOUT_MS = 40_000L
 
 /**
+ * Read the "use program-set terminal titles" opt-in flag
+ * ([TERMINAL_PROGRAM_TITLE_KEY]) out of a UI-settings snapshot, tolerating
+ * both JSON-boolean and stringified-"true" shapes (writes can land either
+ * way — see `snapshotBoolean` in the web client). Called by [main] when
+ * mapping [SettingsRepository.uiSettings] into the live
+ * [TerminalSessions.programTitlesEnabled] flag flow.
+ *
+ * @receiver a UI-settings snapshot from [SettingsRepository.uiSettings].
+ * @return `true` when the user has enabled program-set titles.
+ */
+internal fun JsonObject.terminalProgramTitleEnabled(): Boolean {
+    val el = this[TERMINAL_PROGRAM_TITLE_KEY] as? JsonPrimitive ?: return false
+    el.booleanOrNull?.let { return it }
+    return el.isString && el.content == "true"
+}
+
+/**
  * Application entry point. Initialises the persistence layer, restores the
  * window layout, starts background coroutines, launches the Claude usage
  * monitor, and starts the Netty HTTP/WebSocket server.
@@ -67,6 +90,23 @@ fun main() {
     WindowState.initialize(repo)
 
     val persistenceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Opt-in program-set terminal titles (OSC 0/2). Mirror the toggle into
+    // TerminalSessions' stable flag flow: per-session watchers re-collect on
+    // enable (so the current title applies immediately, no restart), and an
+    // off value sweeps every stored program title so panes revert to
+    // cwd-based names (including scrubbing titles persisted from an earlier
+    // enabled run when the app starts disabled).
+    persistenceScope.launch {
+        repo.uiSettings
+            .map { it.terminalProgramTitleEnabled() }
+            .distinctUntilChanged()
+            .collect { enabled ->
+                TerminalSessions.programTitlesEnabled.value = enabled
+                if (!enabled) WindowState.clearProgramTitles()
+            }
+    }
+
     installWindowConfigPersister(persistenceScope, repo)
     val scrollbackSaver = installScrollbackSaver(persistenceScope, repo)
     val sessionStates = installSessionStatePoller(persistenceScope)

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/PaneManager.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/PaneManager.kt
@@ -94,7 +94,7 @@ internal object PaneManager {
         var changed = false
         fun renameLeaf(leaf: LeafNode): LeafNode {
             if (leaf.id != paneId) return leaf
-            val newTitle = computeLeafTitle(newCustomName, leaf.cwd, leaf.title)
+            val newTitle = computeLeafTitle(newCustomName, leaf.programTitle, leaf.cwd, leaf.title)
             if (leaf.customName == newCustomName && leaf.title == newTitle) return leaf
             changed = true
             return leaf.copy(customName = newCustomName, title = newTitle)
@@ -120,13 +120,85 @@ internal object PaneManager {
         fun maybeUpdate(leaf: LeafNode): LeafNode {
             if (leaf.sessionId != sessionId || leaf.cwd == cwd) return leaf
             changed = true
-            val newTitle = computeLeafTitle(leaf.customName, cwd, leaf.title)
-            return leaf.copy(cwd = cwd, title = newTitle)
+            val updated = leaf.copy(cwd = cwd)
+            return updated.copy(title = computeLeafTitle(updated))
         }
         val newCfg = cfg.copy(
             tabs = cfg.tabs.map { tab ->
                 tab.copy(
                     panes = tab.panes.map { p -> p.copy(leaf = maybeUpdate(p.leaf)) },
+                )
+            }
+        )
+        return if (changed) newCfg else null
+    }
+
+    /**
+     * Apply a program-set terminal title (OSC 0/2) to the pane(s) backed by
+     * [sessionId].
+     *
+     * A sibling of [updatePaneCwd]: called by [WindowState.applyProgramTitle]
+     * when the program running in a terminal sets its title (e.g. Claude
+     * Code's task summary, or ssh/vim). The sanitized title is stored on
+     * [LeafNode.programTitle] and the denormalized [LeafNode.title] is
+     * recomputed via [computeLeafTitle], which keeps a user's
+     * [LeafNode.customName] winning — the pane's visible title never changes
+     * when it was manually renamed, though the program title is still recorded
+     * in case the manual name is later cleared.
+     *
+     * An empty/unusable [rawTitle] clears [LeafNode.programTitle] (the
+     * standard way for a program to reset the title), falling back to the
+     * cwd-based title.
+     *
+     * @param cfg the current window config snapshot.
+     * @param sessionId the PTY session id whose pane should be titled.
+     * @param rawTitle the raw OSC payload; sanitized via [sanitizeProgramTitle].
+     * @return the new config, or `null` when no leaf matched or nothing changed.
+     * @see computeLeafTitle
+     * @see updatePaneCwd
+     */
+    fun applyProgramTitle(cfg: WindowConfig, sessionId: String, rawTitle: String): WindowConfig? {
+        if (sessionId.isEmpty()) return null
+        val sanitized = sanitizeProgramTitle(rawTitle)
+        var changed = false
+        fun maybeTitle(leaf: LeafNode): LeafNode {
+            if (leaf.sessionId != sessionId || leaf.programTitle == sanitized) return leaf
+            changed = true
+            val updated = leaf.copy(programTitle = sanitized)
+            return updated.copy(title = computeLeafTitle(updated))
+        }
+        val newCfg = cfg.copy(
+            tabs = cfg.tabs.map { tab ->
+                tab.copy(
+                    panes = tab.panes.map { p -> p.copy(leaf = maybeTitle(p.leaf)) },
+                )
+            }
+        )
+        return if (changed) newCfg else null
+    }
+
+    /**
+     * Drop every stored [LeafNode.programTitle] and recompute the affected
+     * titles. Called by [WindowState.clearProgramTitles] when the user turns
+     * the "use program-set terminal titles" setting off, so panes revert to
+     * their cwd-based names instead of keeping stale program titles around
+     * (they are persisted, so they would otherwise survive restarts too).
+     *
+     * @param cfg the current window config snapshot.
+     * @return the new config, or `null` when no leaf had a program title.
+     */
+    fun clearProgramTitles(cfg: WindowConfig): WindowConfig? {
+        var changed = false
+        fun maybeClear(leaf: LeafNode): LeafNode {
+            if (leaf.programTitle == null) return leaf
+            changed = true
+            val updated = leaf.copy(programTitle = null)
+            return updated.copy(title = computeLeafTitle(updated))
+        }
+        val newCfg = cfg.copy(
+            tabs = cfg.tabs.map { tab ->
+                tab.copy(
+                    panes = tab.panes.map { p -> p.copy(leaf = maybeClear(p.leaf)) },
                 )
             }
         )

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/PathFormatting.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/PathFormatting.kt
@@ -25,14 +25,93 @@ internal fun prettifyPath(path: String): String {
 
 /**
  * Resolve the display title for a pane:
- *  1. user-set [customName] wins;
- *  2. else the prettified [cwd];
- *  3. else [fallback] (typically the auto-generated "Session N" label).
+ *  1. user-set [customName] wins (a manual rename is never overridden);
+ *  2. else the program-set [programTitle] (OSC 0/2, see `applyProgramTitle`);
+ *  3. else the prettified [cwd];
+ *  4. else [fallback] (typically the auto-generated "Session N" label).
+ *
+ * Called by [PaneManager]'s title-affecting mutations and [WindowState] pane
+ * creation.
+ *
+ * @param customName the user's manual name, or `null`.
+ * @param programTitle the sanitized program-set title, or `null`.
+ * @param cwd the last known working directory, or `null`.
+ * @param fallback the last-resort label when nothing else is set.
+ * @return the resolved display title.
  */
-internal fun computeLeafTitle(customName: String?, cwd: String?, fallback: String): String =
+internal fun computeLeafTitle(
+    customName: String?,
+    programTitle: String?,
+    cwd: String?,
+    fallback: String,
+): String =
     customName?.takeIf { it.isNotBlank() }
+        ?: programTitle?.takeIf { it.isNotBlank() }
         ?: cwd?.takeIf { it.isNotBlank() }?.let(::prettifyPath)
         ?: fallback
+
+/**
+ * Recompute the display title for an existing [leaf] from its own naming
+ * fields. Convenience overload used by [PaneManager]'s mutation helpers: after
+ * changing one of `customName` / `programTitle` / `cwd` on a copied leaf, call
+ * this to derive the matching [LeafNode.title] without threading every title
+ * input through by hand.
+ *
+ * @param leaf the (already-updated) leaf whose title to compute.
+ * @param fallback the last-resort label; defaults to the leaf's current title,
+ *   which preserves the previously-resolved name when nothing else is set.
+ * @return the resolved display title.
+ */
+internal fun computeLeafTitle(leaf: LeafNode, fallback: String = leaf.title): String =
+    computeLeafTitle(leaf.customName, leaf.programTitle, leaf.cwd, fallback)
+
+/**
+ * Normalize a raw program-set terminal title (OSC 0/2 payload) into a clean,
+ * bounded pane title. Called by [PaneManager.applyProgramTitle] before the
+ * title is stored on [LeafNode.programTitle].
+ *
+ * The input is untrusted (any program in the PTY — including a remote host
+ * over ssh — can emit it) and the result is persisted and broadcast to every
+ * client, so this strips control characters (C0, C1, and invisible Unicode
+ * format characters such as bidi overrides), box-drawing characters, and
+ * HTML-significant characters (defense-in-depth; the toolkit renders titles
+ * via `textContent`), collapses whitespace, and caps the length without
+ * splitting a surrogate pair. Everything else is kept verbatim, matching how
+ * other terminals display program titles.
+ *
+ * @param raw the untrusted OSC title payload.
+ * @return a cleaned title, or `null` when nothing usable remains (an empty
+ *   title is the standard way for a program to reset the title).
+ */
+internal fun sanitizeProgramTitle(raw: String): String? {
+    val firstLine = raw.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() } ?: return null
+    var s = firstLine
+        .replace(BOX_AND_CONTROL, " ")
+        .replace(HTML_UNSAFE, "")
+        .trim()
+    s = s.split(WHITESPACE).filter { it.isNotBlank() }.joinToString(" ")
+    if (s.length > MAX_TITLE_CHARS) {
+        var cut = MAX_TITLE_CHARS
+        // Don't split a surrogate pair — a dangling high surrogate would
+        // serialize as U+FFFD on the wire and in the persisted blob.
+        if (s[cut - 1].isHighSurrogate()) cut--
+        s = s.take(cut).trim()
+    }
+    return s.ifEmpty { null }
+}
+
+/** Length cap for program-set titles — long enough for a task summary, short enough for a tab. */
+private const val MAX_TITLE_CHARS = 80
+private val WHITESPACE = Regex("""\s+""")
+/**
+ * Characters replaced with a space: C0 controls (`\p{Cntrl}`), C1 controls
+ * (not covered by the POSIX class), invisible Unicode format characters
+ * (`\p{Cf}` — zero-widths, bidi overrides that could visually spoof a title),
+ * and box-drawing glyphs.
+ */
+private val BOX_AND_CONTROL = Regex("""[\p{Cntrl}\p{Cf}\u0080-\u009F─-╿]+""")
+/** HTML-significant chars stripped so a program-controlled title can't inject markup. */
+private val HTML_UNSAFE = Regex("""[<>&"'`\\]""")
 
 /**
  * Returns a deep copy of this config with every [LeafNode.sessionId] blanked.

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/TerminalSessionManager.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/TerminalSessionManager.kt
@@ -13,7 +13,7 @@
  *
  * @see WindowState
  * @see ScreenEmulator
- * @see Osc7Scanner
+ * @see OscScanner
  * @see ProcessCwdReader
  */
 package se.soderbjorn.termtastic
@@ -33,12 +33,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import se.soderbjorn.termtastic.pty.Osc7Scanner
+import se.soderbjorn.termtastic.pty.OscScanner
 import se.soderbjorn.termtastic.pty.ProcessCwdReader
 import se.soderbjorn.termtastic.pty.ShellInitFiles
 import java.io.File
@@ -50,12 +53,14 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Registry of process-wide PTYs. Each created session also gets a watcher
  * coroutine that listens for cwd changes coming out of [TerminalSession.cwd]
- * and forwards them (debounced) into [WindowState.updatePaneCwd]. The
- * 750 ms debounce coalesces `cd` bursts before they ever touch the
- * WindowConfig flow; the existing 2 s persistence debouncer in `main()`
+ * and forwards them (debounced) into [WindowState.updatePaneCwd], and — while
+ * the opt-in [programTitlesEnabled] flag is on — does the same for program-set
+ * titles ([TerminalSession.programTitle] → [WindowState.applyProgramTitle]).
+ * The 750 ms debounce coalesces `cd` / title bursts before they ever touch
+ * the WindowConfig flow; the existing 2 s persistence debouncer in `main()`
  * then coalesces *those* updates into one SQLite write.
  */
-@OptIn(FlowPreview::class)
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 object TerminalSessions {
     private val sessions = ConcurrentHashMap<String, TerminalSession>()
     private val watchJobs = ConcurrentHashMap<String, Job>()
@@ -95,6 +100,20 @@ object TerminalSessions {
     private val nullStreak = ConcurrentHashMap<String, Int>()
     private const val STATE_GRACE_POLLS = 3  // 3 polls × 3 s = 9 s grace
 
+    /**
+     * Live opt-in flag for the "use program-set terminal titles" feature (the
+     * [TERMINAL_PROGRAM_TITLE_KEY] UI setting). `main()`'s settings collector
+     * writes toggle flips into this — deliberately a stable [MutableStateFlow]
+     * that is mutated, never replaced: sessions (and their title watchers)
+     * are created during `WindowState.initialize`, *before* `main()` finishes
+     * wiring, and a watcher bound to a swapped-out flow instance would miss
+     * every later flip. Each watcher re-collects on an off→on flip, so a pane
+     * picks up the program's *current* title immediately — no restart, and no
+     * waiting for the next title change; `main()` additionally sweeps stored
+     * titles on an on→off flip.
+     */
+    val programTitlesEnabled = MutableStateFlow(false)
+
     /** Create a fresh session and return its newly minted id (nonce-suffixed
      *  once [idNonce] is assigned — see its kdoc). */
     fun create(initialCwd: String? = null, initialScrollback: ByteArray? = null): String {
@@ -103,11 +122,27 @@ object TerminalSessions {
         val session = TerminalSession.create(initialCwd, initialScrollback)
         sessions[id] = session
         watchJobs[id] = watchScope.launch {
-            session.cwd
-                .filterNotNull()
-                .debounce(750.milliseconds)
-                .distinctUntilChanged()
-                .collect { newCwd -> WindowState.updatePaneCwd(id, newCwd) }
+            launch {
+                session.cwd
+                    .filterNotNull()
+                    .debounce(750.milliseconds)
+                    .distinctUntilChanged()
+                    .collect { newCwd -> WindowState.updatePaneCwd(id, newCwd) }
+            }
+            // Program-set titles (OSC 0/2), debounced like cwd changes. The
+            // opt-in gate is the *outer* flow: while off nothing is collected
+            // (free), and on enable flatMapLatest re-collects the title
+            // StateFlow, which replays the current title so the pane is named
+            // right away. An empty title flows through so a program clearing
+            // its title falls the pane back to the cwd-based name.
+            launch {
+                programTitlesEnabled
+                    .flatMapLatest { enabled ->
+                        if (enabled) session.programTitle.filterNotNull().debounce(750.milliseconds)
+                        else emptyFlow()
+                    }
+                    .collect { newTitle -> WindowState.applyProgramTitle(id, newTitle) }
+            }
         }
         return id
     }
@@ -202,7 +237,23 @@ class TerminalSession private constructor(
     private val _cwd = MutableStateFlow<String?>(null)
     val cwd: StateFlow<String?> = _cwd.asStateFlow()
 
-    private val osc7 = Osc7Scanner { path -> _cwd.value = path }
+    private val _programTitle = MutableStateFlow<String?>(null)
+
+    /**
+     * Most recent program-set terminal title (OSC 0/2) we've observed for this
+     * pane, raw and unsanitized — parsed by the same inline [OscScanner] that
+     * handles OSC 7. `null` until a program first sets a title; an empty
+     * string means the program cleared its title. Collected (debounced, and
+     * only while the opt-in flag is on) by the watcher in
+     * [TerminalSessions.create], which forwards it to
+     * [WindowState.applyProgramTitle].
+     */
+    val programTitle: StateFlow<String?> = _programTitle.asStateFlow()
+
+    private val osc = OscScanner(
+        onCwd = { path -> _cwd.value = path },
+        onTitle = { title -> _programTitle.value = title },
+    )
 
     private val screen = ScreenEmulator(initialCols = 120, initialRows = 32)
 
@@ -249,7 +300,7 @@ class TerminalSession private constructor(
                 break
             }
             if (n <= 0) break
-            osc7.feed(buf, n)
+            osc.feed(buf, n)
             screen.feed(buf, n)
             val chunk = buf.copyOf(n)
             appendToRing(chunk)

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/WindowState.kt
@@ -590,6 +590,38 @@ object WindowState {
     }
 
     /**
+     * Apply a program-set terminal title (OSC 0/2) to the pane backed by
+     * [sessionId]. Called by the title watcher in `TerminalSessions.create`
+     * when the program running in a terminal sets (or clears) its title.
+     * Mutating `_config` re-broadcasts the layout to every client and triggers
+     * the debounced SQLite persist, exactly like [updatePaneCwd]. A user's
+     * manual name always wins (see [computeLeafTitle]).
+     *
+     * @param sessionId the PTY session id whose pane should be titled.
+     * @param rawTitle the raw OSC title payload (sanitized downstream).
+     * @see PaneManager.applyProgramTitle
+     */
+    fun applyProgramTitle(sessionId: String, rawTitle: String) = synchronized(this) {
+        val cfg = _config.value
+        val newCfg = PaneManager.applyProgramTitle(cfg, sessionId, rawTitle) ?: return@synchronized
+        _config.value = newCfg
+    }
+
+    /**
+     * Drop every stored program title and revert the affected panes to their
+     * cwd-based names. Called from `main()` when the "use program-set terminal
+     * titles" setting turns off (including at startup while the feature is
+     * disabled, which scrubs any titles persisted from an earlier enabled run).
+     *
+     * @see PaneManager.clearProgramTitles
+     */
+    fun clearProgramTitles() = synchronized(this) {
+        val cfg = _config.value
+        val newCfg = PaneManager.clearProgramTitles(cfg) ?: return@synchronized
+        _config.value = newCfg
+    }
+
+    /**
      * Update the position and size of [paneId]. The user has overridden
      * preset-driven geometry, so the affected tab's `layoutPreset` is
      * cleared (transitions to Custom mode) — subsequent pane add/remove
@@ -714,7 +746,7 @@ object WindowState {
             id = newNodeId(),
             sessionId = sessionId,
             cwd = effectiveCwd,
-            title = computeLeafTitle(null, effectiveCwd, fallbackTitle),
+            title = computeLeafTitle(null, null, effectiveCwd, fallbackTitle),
             content = TerminalContent(sessionId),
         )
         val (ox, oy) = PaneManager.randomSnappedOrigin()
@@ -747,7 +779,7 @@ object WindowState {
             id = newNodeId(),
             sessionId = "",
             cwd = effectiveCwd,
-            title = computeLeafTitle(null, effectiveCwd, "Files"),
+            title = computeLeafTitle(null, null, effectiveCwd, "Files"),
             content = FileBrowserContent(),
         )
         val (ox, oy) = PaneManager.randomSnappedOrigin()
@@ -777,7 +809,7 @@ object WindowState {
             id = newNodeId(),
             sessionId = "",
             cwd = effectiveCwd,
-            title = computeLeafTitle(null, effectiveCwd, "Git"),
+            title = computeLeafTitle(null, null, effectiveCwd, "Git"),
             content = GitContent(),
         )
         val (ox, oy) = PaneManager.randomSnappedOrigin()

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/pty/OscScanner.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/pty/OscScanner.kt
@@ -1,15 +1,22 @@
 /**
- * OSC 7 (current working directory) escape sequence scanner.
+ * OSC (Operating System Command) escape sequence scanner.
  *
- * This file contains [Osc7Scanner], a streaming state-machine parser that
- * watches raw PTY byte output for OSC 7 escape sequences
- * (`ESC ] 7 ; file://<host>/<path> ST`) and invokes a callback with the
- * decoded path each time one is found for the local host.
+ * This file contains [OscScanner], a streaming state-machine parser that
+ * watches raw PTY byte output for the OSC sequences Termtastic consumes:
+ *  - **OSC 7** (`ESC ] 7 ; file://<host>/<path> ST`) — current-working-
+ *    directory reports; the decoded path is delivered via a callback each
+ *    time one is found for the local host.
+ *  - **OSC 0 / OSC 2** (`ESC ] 0;<title> ST` / `ESC ] 2;<title> ST`) — the
+ *    standard window-title sequence any program can emit (e.g. Claude Code's
+ *    live task summary); the raw title is delivered via an optional second
+ *    callback. OSC 1 (icon name only) is deliberately ignored.
  *
  * Each [TerminalSession] creates one scanner instance, feeding it from the
- * PTY read loop. The callback updates the session's [TerminalSession.cwd]
+ * PTY read loop. The cwd callback updates the session's [TerminalSession.cwd]
  * StateFlow, which [WindowState.updatePaneCwd] uses to keep the pane title
- * and file-browser root directory in sync.
+ * and file-browser root directory in sync; the title callback feeds
+ * [TerminalSession.programTitle], consumed (opt-in) by
+ * [WindowState.applyProgramTitle] the same way.
  *
  * @see ShellInitFiles
  * @see ProcessCwdReader
@@ -22,8 +29,10 @@ import java.net.InetAddress
 
 /**
  * Streaming parser that watches a PTY byte stream for OSC 7 cwd reports
- * (`ESC ] 7 ; file://<host>/<urlencoded-path> ST` where ST is `BEL` or `ESC \`)
- * and invokes [onCwd] each time it sees one for the local host.
+ * (`ESC ] 7 ; file://<host>/<urlencoded-path> ST` where ST is `BEL` or `ESC \`),
+ * invoking [onCwd] each time it sees one for the local host, and for OSC 0/2
+ * window-title sequences, invoking [onTitle] with the raw UTF-8 title text
+ * (which may be empty — the standard way for a program to clear its title).
  *
  * Designed to be fed in arbitrary chunks: the state machine carries any partial
  * sequence across [feed] calls so a sequence that straddles a buffer boundary
@@ -32,18 +41,31 @@ import java.net.InetAddress
  * Bytes are NOT removed from the stream — terminal emulators render OSC
  * sequences invisibly anyway, and stripping them would break other consumers
  * (e.g. iTerm2 integration scrolling, font escapes) sharing the same OSC range.
+ *
+ * @property onCwd invoked with the decoded local path of each OSC 7 report.
+ * @property onTitle invoked with the raw title of each OSC 0/2 sequence;
+ *   `null` (the default) skips title reporting.
  */
-internal class Osc7Scanner(private val onCwd: (String) -> Unit) {
+internal class OscScanner(
+    private val onCwd: (String) -> Unit,
+    private val onTitle: ((String) -> Unit)? = null,
+) {
 
     private enum class State { IDLE, ESC, OSC, OSC_ESC }
 
     private var state = State.IDLE
-    private val buf = StringBuilder()
+
+    // Plain array + length index (not a ByteArrayOutputStream) — this runs on
+    // the PTY read loop for every byte of an in-flight OSC sequence, and BAOS
+    // methods are synchronized.
+    private val buf = ByteArray(MAX_BUF)
+    private var bufLen = 0
 
     /**
      * Feed [len] bytes from [chunk] into the state machine. Any complete
-     * OSC 7 sequences found will trigger the [onCwd] callback with the
-     * decoded path. Partial sequences are carried across calls.
+     * OSC 7 sequence found triggers the [onCwd] callback with the decoded
+     * path; any complete OSC 0/2 sequence triggers [onTitle] with the title.
+     * Partial sequences are carried across calls.
      *
      * @param chunk raw PTY output bytes
      * @param len number of valid bytes in [chunk] (defaults to `chunk.size`)
@@ -55,7 +77,7 @@ internal class Osc7Scanner(private val onCwd: (String) -> Unit) {
             when (state) {
                 State.IDLE -> if (b == 0x1B) state = State.ESC
                 State.ESC -> when (b) {
-                    0x5D /* ] */ -> { state = State.OSC; buf.setLength(0) }
+                    0x5D /* ] */ -> { state = State.OSC; bufLen = 0 }
                     0x1B -> Unit // stay in ESC
                     else -> state = State.IDLE
                 }
@@ -63,19 +85,19 @@ internal class Osc7Scanner(private val onCwd: (String) -> Unit) {
                     0x07 /* BEL */ -> { finishOsc(); state = State.IDLE }
                     0x1B -> state = State.OSC_ESC
                     else -> {
-                        if (buf.length < MAX_BUF) {
-                            buf.append(b.toChar())
+                        if (bufLen < MAX_BUF) {
+                            buf[bufLen++] = b.toByte()
                         } else {
                             // Runaway sequence — abort and resync.
-                            buf.setLength(0)
+                            bufLen = 0
                             state = State.IDLE
                         }
                     }
                 }
                 State.OSC_ESC -> when (b) {
                     0x5C /* \ */ -> { finishOsc(); state = State.IDLE }
-                    0x1B -> { buf.setLength(0); state = State.ESC }
-                    else -> { buf.setLength(0); state = State.IDLE }
+                    0x1B -> { bufLen = 0; state = State.ESC }
+                    else -> { bufLen = 0; state = State.IDLE }
                 }
             }
             i++
@@ -84,16 +106,29 @@ internal class Osc7Scanner(private val onCwd: (String) -> Unit) {
 
     /**
      * Called when the state machine sees a complete OSC sequence (terminated
-     * by BEL or ST). Checks if it is an OSC 7 with a `file://` URL for
-     * the local host, and if so invokes [onCwd] with the decoded path.
+     * by BEL or ST) and dispatches it: OSC 7 with a `file://` URL for the
+     * local host → [onCwd] with the decoded path; OSC 0/2 → [onTitle] with
+     * the UTF-8 title text (possibly empty = "clear the title"). The command
+     * prefix is checked on the raw bytes so uninteresting sequences (fonts,
+     * clipboard, iTerm2 integration, …) cost no decode or allocation.
      */
     private fun finishOsc() {
-        val payload = buf.toString()
-        buf.setLength(0)
-        if (!payload.startsWith("7;")) return
-        val (host, path) = parseFileUrl(payload.substring(2)) ?: return
-        if (host.isNotEmpty() && host != "localhost" && host != localHostname) return
-        if (path.isNotEmpty()) onCwd(path)
+        val len = bufLen
+        bufLen = 0
+        if (len < 2 || buf[1] != SEMICOLON) return
+        when (buf[0].toInt()) {
+            // The file URL is percent-encoded ASCII, so the byte-faithful
+            // ISO-8859-1 view is exact; percentDecode reassembles UTF-8 from
+            // the raw bytes.
+            '7'.code -> {
+                val (host, path) = parseFileUrl(String(buf, 2, len - 2, Charsets.ISO_8859_1)) ?: return
+                if (host.isNotEmpty() && host != "localhost" && host != localHostname) return
+                if (path.isNotEmpty()) onCwd(path)
+            }
+            // OSC 0 (icon + window title) and OSC 2 (window title); title
+            // text is real UTF-8. OSC 1 (icon only) falls through, ignored.
+            '0'.code, '2'.code -> onTitle?.invoke(String(buf, 2, len - 2, Charsets.UTF_8))
+        }
     }
 
     /**
@@ -140,6 +175,7 @@ internal class Osc7Scanner(private val onCwd: (String) -> Unit) {
 
     companion object {
         private const val MAX_BUF = 4096
+        private const val SEMICOLON = ';'.code.toByte()
 
         private val localHostname: String by lazy {
             runCatching { InetAddress.getLocalHost().hostName }.getOrNull().orEmpty()

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ProcessCwdReader.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ProcessCwdReader.kt
@@ -15,7 +15,7 @@
  *  - macOS: runs `lsof -a -p <pid> -d cwd -Fn`.
  *  - Windows: not supported (returns null); ConPTY shells typically handle OSC 7.
  *
- * @see Osc7Scanner
+ * @see OscScanner
  * @see ShellInitFiles
  * @see TerminalSession
  */

--- a/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ShellInitFiles.kt
+++ b/server/src/main/kotlin/se/soderbjorn/termtastic/pty/ShellInitFiles.kt
@@ -3,7 +3,7 @@
  *
  * This file contains [ShellInitFiles], which configures shell environments
  * so that interactive shells emit OSC 7 escape sequences reporting their
- * current working directory. This enables [Osc7Scanner] to instantly detect
+ * current working directory. This enables [OscScanner] to instantly detect
  * directory changes without polling.
  *
  * Called by [TerminalSession.create] (in Application.kt) when spawning a
@@ -18,7 +18,7 @@
  *  - **bash**: appends an OSC 7 emitter to `PROMPT_COMMAND`.
  *  - **fish**: no action needed (fish emits OSC 7 by default).
  *
- * @see Osc7Scanner
+ * @see OscScanner
  * @see ProcessCwdReader
  * @see AppPaths
  */
@@ -28,7 +28,7 @@ import se.soderbjorn.termtastic.persistence.AppPaths
 import java.io.File
 
 /**
- * Makes interactive shells emit OSC 7 cwd reports so [Osc7Scanner] can pick
+ * Makes interactive shells emit OSC 7 cwd reports so [OscScanner] can pick
  * them up. Most distros that ship VTE already do this; macOS bash/zsh do not.
  *
  * Strategy:

--- a/server/src/test/kotlin/se/soderbjorn/termtastic/ProgramTitleTest.kt
+++ b/server/src/test/kotlin/se/soderbjorn/termtastic/ProgramTitleTest.kt
@@ -1,0 +1,288 @@
+/**
+ * Tests for the program-set terminal title feature (OSC 0/2 → pane title):
+ *  - [sanitizeProgramTitle] — untrusted-payload cleaning;
+ *  - [computeLeafTitle] — title precedence (manual rename > program title >
+ *    cwd > fallback);
+ *  - [PaneManager.applyProgramTitle] — applying/clearing a title on the
+ *    pane(s) backed by a session, without ever overriding a manual rename;
+ *  - [OscScanner] — OSC 0/2 title extraction from a raw byte stream,
+ *    including sequences split across feed() calls, UTF-8 titles, and
+ *    non-interference with the OSC 7 cwd path.
+ */
+package se.soderbjorn.termtastic
+
+import se.soderbjorn.termtastic.pty.OscScanner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
+
+class ProgramTitleTest {
+
+    // ---------------------------------------------------------------- helpers
+
+    private fun leaf(
+        id: String = "p1",
+        sessionId: String = "s1",
+        title: String = "fallback",
+        customName: String? = null,
+        programTitle: String? = null,
+        cwd: String? = null,
+    ) = LeafNode(
+        id = id,
+        sessionId = sessionId,
+        title = title,
+        customName = customName,
+        programTitle = programTitle,
+        cwd = cwd,
+        content = TerminalContent(sessionId),
+    )
+
+    private fun cfg(vararg leaves: LeafNode) = WindowConfig(
+        tabs = listOf(
+            TabConfig(
+                id = "t1",
+                title = "Tab 1",
+                panes = leaves.map { l ->
+                    Pane(leaf = l, x = 0.0, y = 0.0, width = 0.5, height = 0.5, z = 1L)
+                },
+            )
+        ),
+    )
+
+    private fun WindowConfig.leafById(id: String): LeafNode =
+        tabs.flatMap { it.panes }.map { it.leaf }.first { it.id == id }
+
+    // --------------------------------------------------- sanitizeProgramTitle
+
+    @Test
+    fun sanitize_keeps_a_normal_title_verbatim() {
+        assertEquals("Fix Login Bug", sanitizeProgramTitle("Fix Login Bug"))
+    }
+
+    @Test
+    fun sanitize_strips_html_significant_characters() {
+        assertEquals("scriptalert(x)/script", sanitizeProgramTitle("""<script>alert("x")</script>"""))
+    }
+
+    @Test
+    fun sanitize_replaces_control_characters_and_collapses_whitespace() {
+        assertEquals("a b c", sanitizeProgramTitle("a\u0007b\t\t c"))
+    }
+
+    @Test
+    fun sanitize_uses_first_nonempty_line_only() {
+        assertEquals("first", sanitizeProgramTitle("\n  first\nsecond"))
+    }
+
+    @Test
+    fun sanitize_caps_length() {
+        val long = "x".repeat(300)
+        assertEquals(80, sanitizeProgramTitle(long)!!.length)
+    }
+
+    @Test
+    fun sanitize_never_splits_a_surrogate_pair_at_the_cap() {
+        // 79 ASCII chars, then an astral emoji whose high surrogate is the
+        // 80th UTF-16 unit — a naive take(80) would keep a lone surrogate.
+        val result = sanitizeProgramTitle("x".repeat(79) + "😀")!!
+        assertEquals("x".repeat(79), result)
+    }
+
+    @Test
+    fun sanitize_strips_c1_controls_and_bidi_overrides() {
+        // U+009B (8-bit CSI) and U+202E (RTL override) are invisible /
+        // spoofing-capable and must not survive into a broadcast title.
+        assertEquals("a b", sanitizeProgramTitle("a\u009Bb"))
+        assertEquals("gpj .exe", sanitizeProgramTitle("gpj\u202E.exe"))
+    }
+
+    @Test
+    fun sanitize_returns_null_for_empty_or_blank() {
+        assertNull(sanitizeProgramTitle(""))
+        assertNull(sanitizeProgramTitle("   "))
+        assertNull(sanitizeProgramTitle("\u0007\u0008"))
+    }
+
+    // ------------------------------------------------------- computeLeafTitle
+
+    @Test
+    fun custom_name_beats_program_title_and_cwd() {
+        assertEquals(
+            "my name",
+            computeLeafTitle("my name", "Fix Login Bug", "/tmp/project", "fb"),
+        )
+    }
+
+    @Test
+    fun program_title_beats_cwd() {
+        assertEquals(
+            "Fix Login Bug",
+            computeLeafTitle(null, "Fix Login Bug", "/tmp/project", "fb"),
+        )
+    }
+
+    @Test
+    fun cwd_beats_fallback_and_blank_program_title_is_ignored() {
+        assertEquals("/tmp/project", computeLeafTitle(null, null, "/tmp/project", "fb"))
+        assertEquals("/tmp/project", computeLeafTitle(null, "  ", "/tmp/project", "fb"))
+        assertEquals("fb", computeLeafTitle(null, null, null, "fb"))
+    }
+
+    @Test
+    fun leaf_overload_reads_the_leaf_fields() {
+        val l = leaf(programTitle = "Fix Login Bug", cwd = "/tmp/project")
+        assertEquals("Fix Login Bug", computeLeafTitle(l))
+    }
+
+    // ---------------------------------------- PaneManager.applyProgramTitle
+
+    @Test
+    fun apply_sets_program_title_and_recomputes_title() {
+        val out = PaneManager.applyProgramTitle(cfg(leaf(cwd = "/tmp/project")), "s1", "Fix Login Bug")
+        assertNotNull(out)
+        val l = out.leafById("p1")
+        assertEquals("Fix Login Bug", l.programTitle)
+        assertEquals("Fix Login Bug", l.title)
+    }
+
+    @Test
+    fun apply_never_changes_the_visible_title_of_a_manually_renamed_pane() {
+        val out = PaneManager.applyProgramTitle(
+            cfg(leaf(customName = "my name", title = "my name", cwd = "/tmp/project")),
+            "s1",
+            "Fix Login Bug",
+        )
+        assertNotNull(out)
+        val l = out.leafById("p1")
+        // Recorded, so it resurfaces if the manual name is later cleared…
+        assertEquals("Fix Login Bug", l.programTitle)
+        // …but the visible title stays the user's.
+        assertEquals("my name", l.title)
+    }
+
+    @Test
+    fun clearing_the_manual_name_falls_back_to_the_program_title() {
+        val named = PaneManager.applyProgramTitle(
+            cfg(leaf(customName = "my name", title = "my name", cwd = "/tmp/project")),
+            "s1",
+            "Fix Login Bug",
+        )!!
+        val cleared = PaneManager.renamePane(named, "p1", "")
+        assertNotNull(cleared)
+        assertEquals("Fix Login Bug", cleared.leafById("p1").title)
+    }
+
+    @Test
+    fun empty_title_clears_back_to_the_cwd_title() {
+        val titled = PaneManager.applyProgramTitle(cfg(leaf(cwd = "/tmp/project")), "s1", "Fix Login Bug")!!
+        val out = PaneManager.applyProgramTitle(titled, "s1", "")
+        assertNotNull(out)
+        val l = out.leafById("p1")
+        assertNull(l.programTitle)
+        assertEquals("/tmp/project", l.title)
+    }
+
+    @Test
+    fun apply_is_a_noop_for_unknown_session_or_unchanged_title() {
+        val base = cfg(leaf(cwd = "/tmp/project"))
+        assertNull(PaneManager.applyProgramTitle(base, "s999", "Fix Login Bug"))
+        val titled = PaneManager.applyProgramTitle(base, "s1", "Fix Login Bug")!!
+        assertNull(PaneManager.applyProgramTitle(titled, "s1", "Fix Login Bug"))
+    }
+
+    @Test
+    fun apply_titles_every_pane_linked_to_the_session() {
+        val out = PaneManager.applyProgramTitle(
+            cfg(leaf(id = "p1", cwd = "/tmp/a"), leaf(id = "p2", cwd = "/tmp/b")),
+            "s1",
+            "Fix Login Bug",
+        )
+        assertNotNull(out)
+        assertEquals("Fix Login Bug", out.leafById("p1").title)
+        assertEquals("Fix Login Bug", out.leafById("p2").title)
+    }
+
+    @Test
+    fun clear_sweep_reverts_all_program_titles_to_cwd_names() {
+        val titled = PaneManager.applyProgramTitle(
+            cfg(
+                leaf(id = "p1", sessionId = "s1", cwd = "/tmp/a"),
+                leaf(id = "p2", sessionId = "s2", customName = "my name", title = "my name", cwd = "/tmp/b"),
+            ),
+            "s1",
+            "Fix Login Bug",
+        )!!
+        val cleared = PaneManager.clearProgramTitles(titled)
+        assertNotNull(cleared)
+        assertEquals("/tmp/a", cleared.leafById("p1").title)
+        assertNull(cleared.leafById("p1").programTitle)
+        // Untouched panes keep their state; nothing-to-clear is a no-op.
+        assertEquals("my name", cleared.leafById("p2").title)
+        assertNull(PaneManager.clearProgramTitles(cleared))
+    }
+
+    // ------------------------------------------------ OscScanner title capture
+
+    private fun scannerCapturing(
+        titles: MutableList<String>,
+        cwds: MutableList<String> = mutableListOf(),
+    ) = OscScanner(onCwd = { cwds.add(it) }, onTitle = { titles.add(it) })
+
+    private fun OscScanner.feedText(text: String) = feed(text.toByteArray(Charsets.UTF_8))
+
+    @Test
+    fun osc0_sets_the_title() {
+        val titles = mutableListOf<String>()
+        scannerCapturing(titles).feedText("\u001B]0;Fix Login Bug\u0007")
+        assertEquals(listOf("Fix Login Bug"), titles)
+    }
+
+    @Test
+    fun osc2_with_st_terminator_sets_the_title() {
+        val titles = mutableListOf<String>()
+        scannerCapturing(titles).feedText("\u001B]2;Hello World\u001B\\")
+        assertEquals(listOf("Hello World"), titles)
+    }
+
+    @Test
+    fun utf8_title_decodes_correctly() {
+        val titles = mutableListOf<String>()
+        scannerCapturing(titles).feedText("\u001B]0;✳ Fixa åäö\u0007")
+        assertEquals(listOf("✳ Fixa åäö"), titles)
+    }
+
+    @Test
+    fun empty_title_fires_with_empty_string() {
+        val titles = mutableListOf<String>()
+        scannerCapturing(titles).feedText("\u001B]0;\u0007")
+        assertEquals(listOf(""), titles)
+    }
+
+    @Test
+    fun sequence_split_across_feeds_still_fires() {
+        val titles = mutableListOf<String>()
+        val scanner = scannerCapturing(titles)
+        scanner.feedText("\u001B]0;Fix Lo")
+        scanner.feedText("gin Bug\u0007")
+        assertEquals(listOf("Fix Login Bug"), titles)
+    }
+
+    @Test
+    fun osc7_still_reports_cwd_and_does_not_fire_title() {
+        val titles = mutableListOf<String>()
+        val cwds = mutableListOf<String>()
+        scannerCapturing(titles, cwds).feedText("\u001B]7;file://localhost/tmp/pro%20ject\u0007")
+        assertEquals(listOf("/tmp/pro ject"), cwds)
+        assertEquals(emptyList(), titles)
+    }
+
+    @Test
+    fun osc1_icon_name_and_plain_output_fire_nothing() {
+        val titles = mutableListOf<String>()
+        val scanner = scannerCapturing(titles)
+        scanner.feedText("\u001B]1;icon only\u0007")
+        scanner.feedText("just some regular output\r\nmore\r\n")
+        assertEquals(emptyList(), titles)
+    }
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/AppSettingsContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/AppSettingsContent.kt
@@ -25,16 +25,19 @@
  *         when running inside the bundled Electron app ([isElectronClient])
  *         — the dialog opens on the server's desktop, which a remote
  *         browser can't see.
- *  2. An **Experimental features** section with two persisted boolean
- *     toggles:
+ *  2. An **Experimental features** section with persisted boolean toggles:
  *       - **Enable file browser** — when off, hides the File Browser
  *         entry from the topbar "New pane" hover dropdown.
  *       - **Enable Git change view** — same for the Git entry.
+ *       - **Use program-set terminal titles** — opt-in: panes take the
+ *         title the running program sets via OSC 0/2 (consumed
+ *         server-side); this row carries an explanatory description line.
  *
- * The flags persist server-side under two new top-level keys in
+ * The flags persist server-side under top-level keys in
  * `/api/ui-settings`:
  *   - `experimentalFileBrowser` (Boolean, default false)
  *   - `experimentalGitView` (Boolean, default false)
+ *   - `terminalProgramTitle` (Boolean, default false)
  *
  * Reads consult [toolkitSettingsSnapshot] (already mirrored from the
  * server's payload via [updateToolkitSettingsSnapshot]); writes
@@ -46,6 +49,7 @@
  * @see buildAppSettingsContent
  * @see isExperimentalFileBrowserEnabled
  * @see isExperimentalGitViewEnabled
+ * @see isTerminalProgramTitleEnabled
  */
 package se.soderbjorn.termtastic
 
@@ -66,6 +70,10 @@ private const val KEY_EXPERIMENTAL_FILE_BROWSER = "experimentalFileBrowser"
 
 /** Persistence key for the experimental Git-view flag. */
 private const val KEY_EXPERIMENTAL_GIT_VIEW = "experimentalGitView"
+
+// The opt-in "use program-set terminal titles" flag persists under
+// TERMINAL_PROGRAM_TITLE_KEY from the shared clientServer module — the server
+// reads the same constant, so the contract is compiler-enforced.
 
 /**
  * Tooltip/`title` of the toolkit's topbar Theme Manager (palette) button.
@@ -147,6 +155,18 @@ fun isExperimentalFileBrowserEnabled(): Boolean =
  */
 fun isExperimentalGitViewEnabled(): Boolean =
     snapshotBoolean(KEY_EXPERIMENTAL_GIT_VIEW)
+
+/**
+ * Whether panes should take the title the running program sets (OSC 0/2).
+ * Read only to seed the toggle's initial state in
+ * [buildExperimentalSection]; the actual feature logic lives server-side
+ * (the title watcher reads the same persisted key).
+ *
+ * @return `true` when the user has opted in.
+ * @see TERMINAL_PROGRAM_TITLE_KEY
+ */
+fun isTerminalProgramTitleEnabled(): Boolean =
+    snapshotBoolean(TERMINAL_PROGRAM_TITLE_KEY)
 
 /**
  * Mirror a single boolean key into [toolkitSettingsSnapshot] without
@@ -370,6 +390,20 @@ private fun buildExperimentalSection(): HTMLElement {
             putJsonBoolean(KEY_EXPERIMENTAL_GIT_VIEW, v)
         },
     ))
+    section.appendChild(buildToggleRow(
+        labelText = "Use program-set terminal titles",
+        initialValue = isTerminalProgramTitleEnabled(),
+        onChange = { v ->
+            updateSnapshotBoolean(TERMINAL_PROGRAM_TITLE_KEY, v)
+            putJsonBoolean(TERMINAL_PROGRAM_TITLE_KEY, v)
+        },
+        descriptionText = "Lets programs running in a terminal name its tab, using " +
+            "the standard title sequence that terminals like iTerm2 honor. With " +
+            "Claude Code this means the tab shows a short summary of what you " +
+            "asked it to do instead of the folder name. Terminals you've renamed " +
+            "yourself are never changed, and turning this off returns tabs to " +
+            "their folder names.",
+    ))
 
     return section
 }
@@ -388,16 +422,19 @@ private fun buildExperimentalSection(): HTMLElement {
  * highlighted rectangle moves immediately, regardless of how long the
  * async server round-trip in [onChange] takes.
  *
- * @param labelText    the visible label text shown above the buttons.
- * @param initialValue which option ("On" = true) starts selected.
- * @param onChange     invoked with the new value every time the user
+ * @param labelText       the visible label text shown above the buttons.
+ * @param initialValue    which option ("On" = true) starts selected.
+ * @param onChange        invoked with the new value every time the user
  *   picks a different option.
+ * @param descriptionText optional muted help text rendered under the label to
+ *   explain what the setting does; omitted (`null`) renders no description.
  * @return the freshly-built row element.
  */
 private fun buildToggleRow(
     labelText: String,
     initialValue: Boolean,
     onChange: (Boolean) -> Unit,
+    descriptionText: String? = null,
 ): HTMLElement {
     val row = document.createElement("div") as HTMLElement
     row.className = "termtastic-app-settings-toggle-row"
@@ -406,6 +443,13 @@ private fun buildToggleRow(
     labelEl.className = "termtastic-app-settings-toggle-label"
     labelEl.textContent = labelText
     row.appendChild(labelEl)
+
+    if (descriptionText != null) {
+        val descEl = document.createElement("div") as HTMLElement
+        descEl.className = "termtastic-app-settings-toggle-desc"
+        descEl.textContent = descriptionText
+        row.appendChild(descEl)
+    }
 
     val btnRow = document.createElement("div") as HTMLElement
     btnRow.className = "dt-settings-button-row"

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -2218,6 +2218,14 @@ body.appearance-light .git-graphical-connector {
     color: inherit;
 }
 
+/* Muted help text under a toggle label, explaining what the setting does. */
+.termtastic-app-settings-toggle-desc {
+    font-size: 11.5px;
+    line-height: 1.4;
+    color: inherit;
+    opacity: 0.65;
+}
+
 /* Light-mode tweaks. */
 body.appearance-light .termtastic-app-settings-nav-button {
     background: transparent;


### PR DESCRIPTION
## Summary

Opt-in support for the standard **OSC 0/2 window-title escape sequence**: when a program running in a terminal sets its title, the pane/tab shows it — the same behavior iTerm2, Terminal.app, and ghostty ship by default. Off by default under **App Settings → Experimental features → "Use program-set terminal titles"**.

Title precedence is **manual rename › program title › cwd › fallback**: a pane you renamed yourself is never touched, and turning the toggle off reverts every tab to its folder name.

## Why

Claude Code sets the terminal title to a live summary of the current task (on by default in the CLI). With this toggle enabled, a tab running Claude Code reads like **"Fix login bug"** instead of the working directory — with zero agent-specific integration. The same mechanism covers ssh, vim, and anything else that sets titles.

## How it works

Nearly all the plumbing existed already — titles ride the same pipeline as cwd updates:

- **Capture** — the OSC 7 cwd scanner (`Osc7Scanner`) is generalized to `OscScanner` (git rename, history preserved). It additionally parses `ESC ]0;title ST` / `ESC ]2;title ST` into a per-session `programTitle` StateFlow; OSC 1 (icon-only) is ignored, and sequences split across PTY reads still parse.
- **Gate** — the toggle is a live flow; each session's watcher collects titles through `flatMapLatest(enabled)`. While off, the pipeline is inert. On enable, the program's *current* title applies immediately (StateFlow replay) — no restart, no waiting for the next title change. On disable, stored titles are swept so tabs revert to folder names.
- **Store + resolve** — `LeafNode.programTitle`, persisted like `cwd`; `computeLeafTitle` implements the precedence, and an empty title (the standard "reset") clears back to the cwd name. No client or protocol changes on any platform (`ignoreUnknownKeys` keeps old clients compatible).
- **Sanitize** — titles are untrusted (any program can emit them, including remote hosts over ssh) and are persisted + broadcast to every client. `sanitizeProgramTitle` strips C0/C1 controls, invisible format characters (bidi overrides, zero-widths), box-drawing and HTML-significant characters (defense-in-depth — tab/pane labels render via `textContent` throughout the toolkit), and caps length surrogate-safely.

## Approaches tried and discarded

Two agent-integration designs were prototyped first: screen-scraping the agent's TUI for the user's prompt, and Claude Code hook registration (a loopback HTTP endpoint + a shell wrapper function + a headless `claude -p` call to summarize the prompt into a label). Both worked, but each was ~1.5k lines of externally-coupled, agent-specific machinery with real robustness and privacy questions — prompt text leaving the machine, TUI-format fragility, per-CLI coupling. Plain OSC title support is half the size (+734/−66, of which 288 lines are tests), has none of that surface, and covers every title-setting program instead of one agent.

## Testing

- `ProgramTitleTest` (26 unit tests): sanitizer (HTML/control/C1/bidi stripping, surrogate-safe cap, empty→null), title precedence, apply/clear semantics (manual-rename immunity, multi-pane sessions, no-op paths), the disable sweep, and scanner capture (OSC 0/2, BEL and ST terminators, UTF-8 titles, split sequences, OSC 7 non-interference).
- **End-to-end against a running server**, driven exactly like a client over the `/window` + `/pty/{id}` WebSockets and the settings REST endpoint — 10/10 checks: off → OSC ignored; enable → current title applies immediately; manual rename wins while the program title is recorded underneath; clearing the manual name reveals it; empty title reverts to the cwd name; `<script>`-style titles arrive sanitized; disable → every tab reverts; OSC stays ignored after disable.
  - One design note surfaced by the e2e: sessions restored at startup bind their title watchers before `main()` finishes wiring, so the enable flag is a stable `MutableStateFlow` that `main()` *mutates* — never a replaced reference, which would leave restored sessions deaf to the toggle.

## Open questions

- Is the 750 ms debounce (matching the cwd watcher) the right coalescing for title churn?
- Worth making this default-on eventually, given it's standard terminal behavior elsewhere?

*Demo video in the comments.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
