### PR TITLE
Mac/Web: Fix scroll jumping a screen after switching into a busy tab

### DIFF
--- a/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/termtastic/TerminalHelpers.kt
@@ -404,6 +404,15 @@ fun markScrollButtonNewOutput(entry: TerminalEntry) {
  * zero-delta no-op inside xterm. Runs independently of [TerminalEntry.autoReflow]
  * because scroll position is orthogonal to PTY sizing.
  *
+ * Restoring `scrollTop` isn't enough on its own: the scroll *area* it moves
+ * within can also be stale. PTY output keeps arriving while a tab is hidden, so
+ * xterm's `Viewport._innerRefresh` runs those writes with the element's
+ * `offsetHeight == 0` and sizes the scroll area one screen short; a same-size
+ * switch never recomputes it, so the `scrollTop` set below would clamp a screen
+ * above the bottom (first wheel-up jumps a screen, and you can't scroll back
+ * down). So we call `syncScrollArea(true)` first to force a re-measure, and the
+ * manual set just backstops it.
+ *
  * Called from the per-pane `ResizeObserver` on each hidden→visible edge (tab
  * activation, where the container gains a non-zero size) and from
  * [renderConfig] after every config push (covers in-place reattaches — e.g.
@@ -419,17 +428,24 @@ fun markScrollButtonNewOutput(entry: TerminalEntry) {
 fun resyncViewportScroll(entry: TerminalEntry) {
     val term = entry.term
     val el = term.asDynamic().element as? HTMLElement ?: return
-    val viewport = el.querySelector(".xterm-viewport") as? HTMLElement ?: return
+    val viewportEl = el.querySelector(".xterm-viewport") as? HTMLElement ?: return
     val core = term.asDynamic()._core
     val cellHeight = (core?._renderService?.dimensions?.css?.cell?.height as? Number)?.toDouble() ?: return
     if (cellHeight <= 0.0) return
+    // Recompute xterm's scroll-area height first, with the now-visible
+    // dimensions: writes to a hidden tab ran Viewport._innerRefresh with
+    // offsetHeight == 0, leaving the area one screen short, and a same-size
+    // switch never fixes it — so the scrollTop below would otherwise clamp a
+    // screen above the bottom. No-op when already in sync.
+    try { core.viewport.syncScrollArea(true) } catch (_: Throwable) {}
     val buffer = term.asDynamic().buffer.active
     val viewportY = (buffer.viewportY as? Number)?.toInt() ?: return
     val target = viewportY.toDouble() * cellHeight
-    // Only touch the DOM when actually misaligned, so a freshly-rendered
-    // pane that is already in sync doesn't churn scrollTop every push.
-    if (kotlin.math.abs(viewport.scrollTop - target) > 0.5) {
-        viewport.scrollTop = target
+    // Backstop the syncScrollArea above (and the pre-`viewport`-handle case):
+    // only touch the DOM when actually misaligned, so an in-sync pane doesn't
+    // churn scrollTop on every push.
+    if (kotlin.math.abs(viewportEl.scrollTop - target) > 0.5) {
+        viewportEl.scrollTop = target
     }
     // Re-assert the pill against the (unchanged) scroll offset, so a reattach
     // that happened to drop the class leaves it consistent with isScrolledUp.


### PR DESCRIPTION
Follow-up to #76 / the tab-switch scroll-desync fix.

## Problem

After switching into a tab by clicking, the terminal is correctly scrolled to the bottom — but the first scroll up jumps the view up by ~a screen, and from there you **can't scroll back down to the bottom line** (e.g. Claude Code's input box). Only the "Jump to bottom" / "New output" pill recovers it. It only shows up on panes running a *busy* program (Claude Code streaming output or redrawing its input box); a quiet shell never triggers it.

## Root cause

The earlier fix (`resyncViewportScroll`) restored the buffer's scroll **position** (`scrollTop`) after a tab reattach, but not the virtual scroll **area** it scrolls within — which can itself be stale.

Termtastic keeps writing PTY output to a pane even while its tab is hidden (the WebSocket never detaches), so a busy program grows the buffer while off-screen. Every such write runs xterm's `Viewport._innerRefresh`, which sizes the scroll area as:

```
rowHeight * bufferLength + (offsetHeight - canvasHeight)
```

A hidden pane reads `offsetHeight == 0`, so the scroll area ends up **exactly one screen (`canvasHeight`) too short**. A grid-changing tab switch masks this (xterm re-syncs on resize on its own — the same "intermittent" behaviour noted in the original desync fix), but a **same-size switch never recomputes it**.

`resyncViewportScroll` then sets `scrollTop = ydisp * cellHeight`, but against the too-short scroll area the browser clamps it one screen above the true bottom. The grid still *renders* at the bottom (xterm draws from `ydisp`), so it looks correct — but the first wheel-up reads the clamped `scrollTop` and snaps `ydisp` up ~a screen, and the DOM can no longer scroll far enough down to reach the bottom line. `scrollToBottom()` (the pill) recovers because it calls `syncScrollArea(immediate)` internally.

## Fix

Call the viewport's `syncScrollArea(true)` **before** touching `scrollTop`, forcing xterm to re-measure the now-visible `offsetHeight` and rewrite both the scroll-area height *and* `scrollTop` using its own logic — a no-op when nothing is stale. The manual `scrollTop` set stays as a fallback (and still covers the original silent-reset case if the internal `viewport` handle is ever unavailable). Verified `_core.viewport` is the direct sibling of the `_core._renderService` access the existing code already relies on.

## Scope

Web/Electron (xterm.js) frontend only — one call plus docs in `TerminalHelpers.kt`. No change to the at-bottom auto-follow path or PTY sizing.

## Testing

- `./gradlew :web:compileKotlinJs` builds cleanly.
- Manual (`scripts/run-electron-dev.sh`): open two tabs, run Claude Code (or any continuously-streaming command) in tab 1, switch to tab 2 while it's producing output, switch back, then scroll up. Before: the view jumps ~a screen and can't scroll down to the input. After: scrolls smoothly and reaches the bottom line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)