### PR TITLE
Fix mangled scrollback replay: sanitize queries, persist width, reset on reconnect

### DIFF
--- a/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/RealPtySocket.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/RealPtySocket.kt
@@ -47,7 +47,7 @@ import se.soderbjorn.lunamux.PtyServerMessage
 /**
  * Live WebSocket connection to `/pty/{sessionId}`. See [PtySocket] for the
  * consumer contract; this class adds the Ktor WebSocket transport, including
- * the server's 64 KB ring-buffer replay as the first frames on [output] and
+ * the server's 128 kB ring-buffer replay as the first frames on [output] and
  * reconnect-with-reset on connection loss.
  */
 class RealPtySocket internal constructor(

--- a/server/src/main/kotlin/se/soderbjorn/lunamux/ServerInitializer.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/ServerInitializer.kt
@@ -48,7 +48,10 @@ class ScrollbackSaver internal constructor(
     /**
      * Iterate over every leaf in the live config and persist its ring buffer
      * snapshot when [force] is `true` or when the leaf's [TerminalSession.bytesWritten]
-     * has advanced since the previous save.
+     * has advanced since the previous save. The session's effective grid size
+     * is sampled alongside the snapshot so a restore can replay the bytes at
+     * the width they were rendered for (raw PTY output only reconstructs
+     * correctly in a same-width grid).
      */
     suspend fun saveAll(force: Boolean) {
         fun collect(leaf: LeafNode, out: MutableList<Pair<String, String>>) {
@@ -68,8 +71,12 @@ class ScrollbackSaver internal constructor(
             val session = TerminalSessions.get(sessionId) ?: continue
             val current = session.bytesWritten()
             if (!force && lastSavedBytes[leafId] == current) continue
+            // Sample the size before the snapshot: a resize racing in between
+            // is at worst off by one resize and gets corrected by the client's
+            // post-restore reassert.
+            val (cols, rows) = session.sizeEvents.value
             val snapshot = session.snapshot()
-            runCatching { repo.saveScrollback(leafId, snapshot) }
+            runCatching { repo.saveScrollback(leafId, snapshot, cols, rows) }
                 .onSuccess { lastSavedBytes[leafId] = current }
                 .onFailure { LoggerFactory.getLogger("ScrollbackPersistence").warn("Failed to save scrollback for $leafId", it) }
         }

--- a/server/src/main/kotlin/se/soderbjorn/lunamux/TerminalSessionManager.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/TerminalSessionManager.kt
@@ -6,7 +6,7 @@
  * `s<n>` ids, and torn down when the last referencing pane closes.
  *
  * [TerminalSession] is a single PTY-backed session: it owns the
- * `PtyProcess`, replays a 64 kB ring buffer to reconnecting clients, runs
+ * `PtyProcess`, replays a 128 kB ring buffer to reconnecting clients, runs
  * a headless [ScreenEmulator] in parallel for AI-state detection, and
  * negotiates a per-PTY winsize as the minimum across all attached
  * clients (tmux-style semantics).
@@ -43,6 +43,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import se.soderbjorn.lunamux.pty.OscScanner
 import se.soderbjorn.lunamux.pty.ProcessCwdReader
+import se.soderbjorn.lunamux.pty.ReplaySanitizer
 import se.soderbjorn.lunamux.pty.ShellInitFiles
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -226,12 +227,27 @@ object TerminalSessions {
      */
     val programTitlesEnabled = MutableStateFlow(false)
 
-    /** Create a fresh session and return its newly minted id (nonce-suffixed
-     *  once [idNonce] is assigned — see its kdoc). */
-    fun create(initialCwd: String? = null, initialScrollback: ByteArray? = null): String {
+    /**
+     * Create a fresh session and return its newly minted id (nonce-suffixed
+     * once [idNonce] is assigned — see its kdoc).
+     *
+     * @param initialCwd starting working directory, or null for the home dir.
+     * @param initialScrollback a persisted scrollback blob to replay to
+     *   attaching clients, or null for a clean session.
+     * @param initialCols grid columns the scrollback was captured at (from
+     *   the persisted record); null falls back to the session default.
+     * @param initialRows grid rows the scrollback was captured at; null falls
+     *   back to the session default.
+     */
+    fun create(
+        initialCwd: String? = null,
+        initialScrollback: ByteArray? = null,
+        initialCols: Int? = null,
+        initialRows: Int? = null,
+    ): String {
         val n = idCounter.incrementAndGet()
         val id = if (idNonce.isEmpty()) "s$n" else "s$n-$idNonce"
-        val session = TerminalSession.create(initialCwd, initialScrollback)
+        val session = TerminalSession.create(initialCwd, initialScrollback, initialCols, initialRows)
         sessions[id] = session
         watchJobs[id] = watchScope.launch {
             launch {
@@ -364,6 +380,8 @@ object TerminalSessions {
 class TerminalSession private constructor(
     private val pty: PtyProcess,
     initialScrollback: ByteArray? = null,
+    initialCols: Int = DEFAULT_COLS,
+    initialRows: Int = DEFAULT_ROWS,
 ) : TermSession {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -398,7 +416,7 @@ class TerminalSession private constructor(
         onTitle = { title -> _programTitle.value = title },
     )
 
-    private val screen = ScreenEmulator(initialCols = 120, initialRows = 32)
+    private val screen = ScreenEmulator(initialCols = initialCols, initialRows = initialRows)
 
     // Ring buffer of recent bytes for reconnect replay.
     private val ringCapacity = 128 * 1024
@@ -414,7 +432,12 @@ class TerminalSession private constructor(
 
     init {
         if (initialScrollback != null && initialScrollback.isNotEmpty()) {
-            appendToRing(initialScrollback)
+            // Blobs persisted by older server versions still contain terminal
+            // query sequences (DSR, DA, OSC color reads, …); strip them once
+            // at ingestion so every future replay of this ring is clean.
+            // Newly persisted blobs are already sanitized (the saver persists
+            // [snapshot], which strips on the way out).
+            appendToRing(ReplaySanitizer.stripQueries(initialScrollback))
             // The restored scrollback may contain DECSET sequences from a
             // full-screen app (vim, htop, …) that died with the old server:
             // mouse tracking, focus reporting, bracketed paste, application
@@ -500,7 +523,7 @@ class TerminalSession private constructor(
     }
 
     private val clientSizes = ConcurrentHashMap<String, SizeVote>()
-    private val _sizeEvents = MutableStateFlow(Pair(120, 32))
+    private val _sizeEvents = MutableStateFlow(Pair(initialCols, initialRows))
     override val sizeEvents: StateFlow<Pair<Int, Int>> = _sizeEvents.asStateFlow()
 
     /** Register the declared terminal size for [clientId] at [priority]. */
@@ -587,7 +610,13 @@ class TerminalSession private constructor(
         false
     }
 
-    /** Return a copy of the ring buffer contents for reconnect replay. */
+    /**
+     * Return a copy of the ring buffer contents for reconnect replay, with
+     * terminal *query* sequences stripped ([ReplaySanitizer.stripQueries]):
+     * replaying a recorded query would make the client terminal answer it
+     * again, injecting the answer into the shell as phantom input. The live
+     * output stream is never filtered — only this replay copy.
+     */
     override fun snapshot(): ByteArray {
         val ringBytes = synchronized(ringLock) {
             if (ringSize == 0) return@synchronized ByteArray(0)
@@ -605,7 +634,7 @@ class TerminalSession private constructor(
         // (ESC[?25l) and no matching show. Append a show to the replay tail;
         // a TUI that genuinely wants the cursor hidden will re-hide it on its
         // next frame.
-        return ringBytes + SHOW_CURSOR_SUFFIX
+        return ReplaySanitizer.stripQueries(ringBytes) + SHOW_CURSOR_SUFFIX
     }
 
     private fun appendToRing(chunk: ByteArray) = synchronized(ringLock) {
@@ -653,7 +682,38 @@ class TerminalSession private constructor(
         private const val MIN_FORCE_COLS = 20
         private const val MIN_FORCE_ROWS = 5
 
-        fun create(initialCwd: String? = null, initialScrollback: ByteArray? = null): TerminalSession {
+        /**
+         * Default grid until a client registers a real size — also the
+         * fallback for restored sessions whose persisted scrollback predates
+         * size recording. Seeds the PTY, the headless [ScreenEmulator] and
+         * [sizeEvents] identically so all three views of the session agree.
+         */
+        private const val DEFAULT_COLS = 120
+        private const val DEFAULT_ROWS = 32
+
+        /**
+         * Spawn the user's shell on a fresh PTY and wrap it in a session.
+         *
+         * Called by [TerminalSessions.create]; [initialCols]/[initialRows]
+         * come from the persisted scrollback record on the restore path so
+         * the replayed bytes reconstruct in a grid of the width they were
+         * rendered for (see `SettingsRepository.ScrollbackRecord`), and are
+         * null everywhere else.
+         *
+         * @param initialCwd starting working directory, or null for home.
+         * @param initialScrollback persisted scrollback to seed the ring, or null.
+         * @param initialCols initial grid columns; null → [DEFAULT_COLS].
+         * @param initialRows initial grid rows; null → [DEFAULT_ROWS].
+         * @return the running session.
+         */
+        fun create(
+            initialCwd: String? = null,
+            initialScrollback: ByteArray? = null,
+            initialCols: Int? = null,
+            initialRows: Int? = null,
+        ): TerminalSession {
+            val cols = initialCols?.takeIf { it > 0 } ?: DEFAULT_COLS
+            val rows = initialRows?.takeIf { it > 0 } ?: DEFAULT_ROWS
             val shell = System.getenv("SHELL") ?: "/bin/bash"
             val home = System.getProperty("user.home")
             val startDir = initialCwd
@@ -670,10 +730,10 @@ class TerminalSession private constructor(
             val pty = PtyProcessBuilder(arrayOf(shell, "-l"))
                 .setDirectory(startDir)
                 .setEnvironment(env)
-                .setInitialColumns(120)
-                .setInitialRows(32)
+                .setInitialColumns(cols)
+                .setInitialRows(rows)
                 .start()
-            return TerminalSession(pty, initialScrollback)
+            return TerminalSession(pty, initialScrollback, cols, rows)
         }
     }
 }

--- a/server/src/main/kotlin/se/soderbjorn/lunamux/WindowState.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/WindowState.kt
@@ -341,8 +341,14 @@ object WindowState {
                 // client is gone), so a persisted agent pane is dropped.
                 is AgentContent -> null
                 is TerminalContent, null -> {
-                    val priorScrollback = runCatching { repo.loadScrollback(leaf.id) }.getOrNull()
-                    val freshSession = TerminalSessions.create(leaf.cwd, priorScrollback)
+                    // Seed the fresh session with the persisted grid size so
+                    // the raw scrollback bytes replay at the width they were
+                    // rendered for; legacy records without a size fall back
+                    // to the session default.
+                    val prior = runCatching { repo.loadScrollback(leaf.id) }.getOrNull()
+                    val freshSession = TerminalSessions.create(
+                        leaf.cwd, prior?.bytes, prior?.cols, prior?.rows,
+                    )
                     leaf.copy(sessionId = freshSession, content = TerminalContent(freshSession))
                 }
             }

--- a/server/src/main/kotlin/se/soderbjorn/lunamux/persistence/SettingsRepository.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/persistence/SettingsRepository.kt
@@ -118,11 +118,23 @@ class SettingsRepository(dbFile: File) {
                 CREATE TABLE IF NOT EXISTS pane_scrollback (
                     leaf_id    TEXT NOT NULL PRIMARY KEY,
                     bytes      BLOB NOT NULL,
-                    updated_at INTEGER NOT NULL
+                    updated_at INTEGER NOT NULL,
+                    cols       INTEGER,
+                    rows       INTEGER
                 )
             """.trimIndent(),
             parameters = 0,
         )
+        // Same no-.sqm story for columns added to an existing table: bring
+        // pre-existing DBs up to the current shape. SQLite has no
+        // ADD COLUMN IF NOT EXISTS, so the "duplicate column name" error on
+        // an already-migrated DB is expected and swallowed.
+        runCatching {
+            driver.execute(null, "ALTER TABLE pane_scrollback ADD COLUMN cols INTEGER", 0)
+        }
+        runCatching {
+            driver.execute(null, "ALTER TABLE pane_scrollback ADD COLUMN rows INTEGER", 0)
+        }
     }
 
     /**
@@ -324,23 +336,58 @@ class SettingsRepository(dbFile: File) {
     }
 
     /**
+     * A persisted scrollback blob plus the terminal grid size it was rendered
+     * at. Raw PTY bytes only reconstruct correctly when replayed into a grid
+     * of the same width they were produced for (a TUI's absolute-cursor
+     * repaints land on the wrong cells otherwise), so the saver records the
+     * session's effective size alongside the bytes and the restore path seeds
+     * the fresh session with it.
+     *
+     * A deliberate plain class, not a data class: the [bytes] payload has no
+     * meaningful equals/hashCode and records are never compared.
+     *
+     * @property bytes the raw ring-buffer bytes as persisted.
+     * @property cols the grid columns at save time, or null on rows written
+     *   by servers that predate size recording.
+     * @property rows the grid rows at save time, or null on legacy rows.
+     * @see loadScrollback
+     * @see saveScrollback
+     */
+    class ScrollbackRecord(val bytes: ByteArray, val cols: Int?, val rows: Int?)
+
+    /**
      * Load the persisted scrollback ring buffer for a pane.
      *
+     * Called by `WindowState.rehydrate` when re-creating a pane's session
+     * after a server restart.
+     *
      * @param leafId the leaf node id whose scrollback to load
-     * @return the raw scrollback bytes, or null if none have been saved
+     * @return the scrollback bytes plus the grid size they were captured at
+     *   (null cols/rows on legacy rows), or null if none have been saved
      */
-    fun loadScrollback(leafId: String): ByteArray? =
-        database.settingsQueries.selectScrollback(leafId).executeAsOneOrNull()
+    fun loadScrollback(leafId: String): ScrollbackRecord? =
+        database.settingsQueries.selectScrollback(leafId).executeAsOneOrNull()?.let {
+            ScrollbackRecord(it.bytes, it.cols?.toInt(), it.rows?.toInt())
+        }
 
     /**
      * Persist the scrollback ring buffer for a pane.
      *
+     * Called by [ScrollbackSaver.saveAll], which samples the session's
+     * effective grid size alongside the snapshot so a later restore can
+     * replay the bytes at the width they were rendered for.
+     *
      * @param leafId the leaf node id to save scrollback for
      * @param bytes the raw ring buffer bytes to persist
+     * @param cols the session's effective grid columns at save time
+     * @param rows the session's effective grid rows at save time
      */
-    suspend fun saveScrollback(leafId: String, bytes: ByteArray) = withContext(Dispatchers.IO) {
-        database.settingsQueries.upsertScrollback(leafId, bytes, System.currentTimeMillis())
-    }
+    suspend fun saveScrollback(leafId: String, bytes: ByteArray, cols: Int?, rows: Int?) =
+        withContext(Dispatchers.IO) {
+            database.settingsQueries.upsertScrollback(
+                leafId, bytes, System.currentTimeMillis(), cols?.toLong(), rows?.toLong(),
+            )
+        }
 
     /**
      * Delete the persisted scrollback for a pane (used during GC of stale leaves).

--- a/server/src/main/kotlin/se/soderbjorn/lunamux/pty/ReplaySanitizer.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/pty/ReplaySanitizer.kt
@@ -1,0 +1,262 @@
+/**
+ * Sanitizer for replayed scrollback: strips terminal *query* escape
+ * sequences from recorded PTY output before it is replayed to a client.
+ *
+ * Programs emit queries (DSR/CPR, DA, XTVERSION, DECRQM, OSC color/clipboard
+ * reads, XTGETTCAP, DECRQSS) as ordinary output on the tty, so they end up in
+ * the session's replay ring buffer verbatim. Replaying them later makes the
+ * client terminal (xterm.js or the native view) *answer* them again — and the
+ * answer is delivered to the shell's stdin as if the user typed it, which is
+ * how fragments like `2cfe2cfe` (pieces of an OSC `rgb:…` color reply) end up
+ * on the prompt after a reconnect or restore.
+ *
+ * [ReplaySanitizer.stripQueries] is called on the replay paths only
+ * ([TerminalSession.snapshot] and the restored-scrollback ingestion in
+ * [TerminalSession]'s init); the live output stream is never filtered, so a
+ * running program's query still reaches the attached client and gets its
+ * answer while the program is actually waiting for one.
+ *
+ * @see se.soderbjorn.lunamux.TerminalSession
+ */
+package se.soderbjorn.lunamux.pty
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * One-shot, pure byte-level filter that removes *complete* terminal query
+ * sequences from a buffer of recorded PTY output.
+ *
+ * Called by [se.soderbjorn.lunamux.TerminalSession] on the two replay choke
+ * points: [se.soderbjorn.lunamux.TermSession.snapshot] (every reconnect /
+ * attach replay, and — because the scrollback saver persists `snapshot()` —
+ * every newly persisted blob) and the constructor path that re-ingests a
+ * blob persisted by an older server version.
+ *
+ * Deliberately *not* a streaming scanner (contrast [OscScanner]): it runs on
+ * a fully materialized ring copy, so it can classify sequences with simple
+ * bounded lookahead and needs no cross-call state.
+ */
+internal object ReplaySanitizer {
+
+    /**
+     * Terminator scan cap for OSC / DCS payloads. A well-formed query payload
+     * is tiny; anything longer (e.g. an inline-image DCS) is not a query, so
+     * past this bound the sequence introducer is copied through verbatim and
+     * scanning resumes inside the payload.
+     */
+    private const val STRING_SEQUENCE_SCAN_CAP = 4096
+
+    /**
+     * Return a copy of [bytes] with every *complete* query sequence removed.
+     *
+     * Two boundary rules keep the filter safe on ring-buffer data:
+     *  - A buffer that *starts* mid-sequence (the ring overwrote the head) is
+     *    passed through untouched — without its `ESC` introducer the tail can
+     *    never be recognized as a query by a client parser, so it is inert.
+     *  - An *incomplete trailing* sequence is preserved verbatim: the live
+     *    stream delivers the remaining bytes right after the replay, and the
+     *    (still running) program that emitted the query is legitimately
+     *    waiting for the answer.
+     *
+     * The operation is idempotent: output never contains a strippable
+     * sequence.
+     *
+     * @param bytes recorded PTY output (raw ring contents or a persisted blob).
+     * @return the input minus complete query sequences; the same content
+     *   byte-for-byte where no queries are present.
+     */
+    fun stripQueries(bytes: ByteArray): ByteArray {
+        if (bytes.isEmpty()) return bytes
+        val out = ByteArrayOutputStream(bytes.size)
+        var i = 0
+        while (i < bytes.size) {
+            val b = bytes[i]
+            if (b != ESC) {
+                out.write(b.toInt())
+                i++
+                continue
+            }
+            if (i + 1 >= bytes.size) {
+                // Lone trailing ESC — incomplete, preserve.
+                out.write(b.toInt())
+                i++
+                continue
+            }
+            when (bytes[i + 1]) {
+                CSI_INTRODUCER -> i = consumeCsi(bytes, i, out)
+                OSC_INTRODUCER -> i = consumeOsc(bytes, i, out)
+                DCS_INTRODUCER -> i = consumeDcs(bytes, i, out)
+                else -> {
+                    // Any other escape (ESC c, ESC 7, ESC >, ESC \ …) is never
+                    // a query: copy the ESC and let the main loop handle the
+                    // rest as ordinary bytes.
+                    out.write(b.toInt())
+                    i++
+                }
+            }
+        }
+        return out.toByteArray()
+    }
+
+    /**
+     * Consume a CSI sequence starting at [start] (`ESC [`), writing it to
+     * [out] unless it classifies as a query. CSI structure per ECMA-48:
+     * parameter bytes `0x30..0x3F`, intermediate bytes `0x20..0x2F`, one
+     * final byte `0x40..0x7E`.
+     *
+     * @return the index of the first byte after the consumed input.
+     */
+    private fun consumeCsi(bytes: ByteArray, start: Int, out: ByteArrayOutputStream): Int {
+        var i = start + 2
+        val paramsStart = i
+        while (i < bytes.size && bytes[i].toInt() in 0x30..0x3F) i++
+        val paramsEnd = i
+        val intermediatesStart = i
+        while (i < bytes.size && bytes[i].toInt() in 0x20..0x2F) i++
+        val intermediatesEnd = i
+        if (i >= bytes.size) return copyThrough(bytes, start, bytes.size, out)
+        val final = bytes[i].toInt()
+        if (final !in 0x40..0x7E) {
+            // Malformed CSI — copy what we scanned and resume after it.
+            return copyThrough(bytes, start, i, out)
+        }
+        val end = i + 1
+        val hasIntermediates = intermediatesEnd > intermediatesStart
+        val singleIntermediate =
+            if (intermediatesEnd - intermediatesStart == 1) bytes[intermediatesStart].toInt() else -1
+        val hasGtPrefix = paramsEnd > paramsStart && bytes[paramsStart] == '>'.code.toByte()
+        val isBareQuestionMark = paramsEnd - paramsStart == 1 &&
+            bytes[paramsStart] == '?'.code.toByte()
+        val isQuery = when (final) {
+            // DSR / CPR / DECXCPR requests (ESC[5n, ESC[6n, ESC[?6n, ESC[?15n …).
+            'n'.code -> !hasIntermediates
+            // DA1/DA2/DA3 (ESC[c, ESC[0c, ESC[>c, ESC[=c). Device-attribute
+            // *responses* travel terminal→host, so a `c` final in PTY output
+            // is always a request.
+            'c'.code -> !hasIntermediates
+            // XTVERSION (ESC[>q / ESC[>0q). DECSCUSR (ESC[4 q) has a space
+            // intermediate and must survive.
+            'q'.code -> !hasIntermediates && hasGtPrefix
+            // DECRQM (ESC[?2004$p / ESC[4$p). DECSCL (ESC[62"p) has a `"`
+            // intermediate and must survive.
+            'p'.code -> singleIntermediate == '$'.code
+            // Kitty keyboard-protocol query is exactly ESC[?u; ESC[u (SCORC)
+            // and the push/pop/set forms must survive.
+            'u'.code -> !hasIntermediates && isBareQuestionMark
+            else -> false
+        }
+        if (!isQuery) copyThrough(bytes, start, end, out)
+        return end
+    }
+
+    /**
+     * Consume an OSC sequence starting at [start] (`ESC ]`), writing it to
+     * [out] unless any `;`-separated payload segment is exactly `?` — the
+     * xterm "report instead of set" convention used by the color queries
+     * (OSC 4/5/10..19) and the clipboard read (OSC 52 with a `?` data field).
+     *
+     * @return the index of the first byte after the consumed input.
+     */
+    private fun consumeOsc(bytes: ByteArray, start: Int, out: ByteArrayOutputStream): Int {
+        val payloadStart = start + 2
+        val terminator = findStringTerminator(bytes, payloadStart)
+            ?: return copyThrough(bytes, start, minOf(start + 2, bytes.size), out)
+        if (terminator.payloadEnd < 0) {
+            // Incomplete at buffer end — preserve verbatim.
+            return copyThrough(bytes, start, bytes.size, out)
+        }
+        val isQuery = hasBareQuestionMarkSegment(bytes, payloadStart, terminator.payloadEnd)
+        if (!isQuery) copyThrough(bytes, start, terminator.end, out)
+        return terminator.end
+    }
+
+    /**
+     * Consume a DCS sequence starting at [start] (`ESC P`). Only the two
+     * query forms are stripped — XTGETTCAP (`ESC P + q … ST`) and DECRQSS
+     * (`ESC P $ q … ST`), where the intermediate immediately follows the
+     * introducer. Everything else (sixel `ESC P Ps ; … q`, etc.) is copied.
+     *
+     * @return the index of the first byte after the consumed input.
+     */
+    private fun consumeDcs(bytes: ByteArray, start: Int, out: ByteArrayOutputStream): Int {
+        if (start + 3 >= bytes.size) {
+            // Too short to classify — incomplete, preserve.
+            return copyThrough(bytes, start, bytes.size, out)
+        }
+        val marker = bytes[start + 2].toInt()
+        val isQueryForm = (marker == '+'.code || marker == '$'.code) &&
+            bytes[start + 3] == 'q'.code.toByte()
+        if (!isQueryForm) {
+            // Not a query DCS: copy the introducer and resume inside the
+            // payload (which is then copied as ordinary bytes).
+            return copyThrough(bytes, start, start + 2, out)
+        }
+        val terminator = findStringTerminator(bytes, start + 4)
+            ?: return copyThrough(bytes, start, start + 2, out)
+        if (terminator.payloadEnd < 0) {
+            // Incomplete at buffer end — preserve verbatim.
+            return copyThrough(bytes, start, bytes.size, out)
+        }
+        return terminator.end
+    }
+
+    /**
+     * Result of scanning for an OSC/DCS string terminator: [payloadEnd] is the
+     * index of the terminator's first byte (or -1 when the buffer ended before
+     * one was found), [end] the index just past the full terminator.
+     */
+    private class Terminator(val payloadEnd: Int, val end: Int)
+
+    /**
+     * Scan forward from [from] for a BEL or ST (`ESC \`) terminator, bounded
+     * by [STRING_SEQUENCE_SCAN_CAP].
+     *
+     * @return the terminator location; a [Terminator] with `payloadEnd = -1`
+     *   when the buffer ends first; or null when the cap is exceeded (caller
+     *   should treat the sequence as opaque non-query content).
+     */
+    private fun findStringTerminator(bytes: ByteArray, from: Int): Terminator? {
+        val cap = minOf(bytes.size, from + STRING_SEQUENCE_SCAN_CAP)
+        var i = from
+        while (i < cap) {
+            when {
+                bytes[i] == BEL -> return Terminator(i, i + 1)
+                bytes[i] == ESC && i + 1 < bytes.size && bytes[i + 1] == '\\'.code.toByte() ->
+                    return Terminator(i, i + 2)
+                // A lone ESC at the very end could be the first half of ST.
+                bytes[i] == ESC && i + 1 >= bytes.size -> return Terminator(-1, bytes.size)
+                else -> i++
+            }
+        }
+        return if (i >= bytes.size) Terminator(-1, bytes.size) else null
+    }
+
+    /**
+     * True when any `;`-separated segment of `bytes[from, until)` is exactly
+     * the single character `?`.
+     */
+    private fun hasBareQuestionMarkSegment(bytes: ByteArray, from: Int, until: Int): Boolean {
+        var segStart = from
+        var i = from
+        while (i <= until) {
+            if (i == until || bytes[i] == ';'.code.toByte()) {
+                if (i - segStart == 1 && bytes[segStart] == '?'.code.toByte()) return true
+                segStart = i + 1
+            }
+            i++
+        }
+        return false
+    }
+
+    /** Copy `bytes[from, until)` into [out] and return [until]. */
+    private fun copyThrough(bytes: ByteArray, from: Int, until: Int, out: ByteArrayOutputStream): Int {
+        out.write(bytes, from, until - from)
+        return until
+    }
+
+    private const val ESC = 0x1B.toByte()
+    private const val BEL = 0x07.toByte()
+    private val CSI_INTRODUCER = '['.code.toByte()
+    private val OSC_INTRODUCER = ']'.code.toByte()
+    private val DCS_INTRODUCER = 'P'.code.toByte()
+}

--- a/server/src/main/sqldelight/se/soderbjorn/lunamux/db/Settings.sq
+++ b/server/src/main/sqldelight/se/soderbjorn/lunamux/db/Settings.sq
@@ -6,7 +6,9 @@ CREATE TABLE IF NOT EXISTS settings (
 CREATE TABLE IF NOT EXISTS pane_scrollback (
     leaf_id    TEXT NOT NULL PRIMARY KEY,
     bytes      BLOB NOT NULL,
-    updated_at INTEGER NOT NULL
+    updated_at INTEGER NOT NULL,
+    cols       INTEGER,
+    rows       INTEGER
 );
 
 selectByKey:
@@ -19,10 +21,10 @@ deleteByKey:
 DELETE FROM settings WHERE key = ?;
 
 selectScrollback:
-SELECT bytes FROM pane_scrollback WHERE leaf_id = ?;
+SELECT bytes, cols, rows FROM pane_scrollback WHERE leaf_id = ?;
 
 upsertScrollback:
-INSERT OR REPLACE INTO pane_scrollback(leaf_id, bytes, updated_at) VALUES (?, ?, ?);
+INSERT OR REPLACE INTO pane_scrollback(leaf_id, bytes, updated_at, cols, rows) VALUES (?, ?, ?, ?, ?);
 
 deleteScrollback:
 DELETE FROM pane_scrollback WHERE leaf_id = ?;

--- a/server/src/test/kotlin/se/soderbjorn/lunamux/persistence/ScrollbackPersistenceTest.kt
+++ b/server/src/test/kotlin/se/soderbjorn/lunamux/persistence/ScrollbackPersistenceTest.kt
@@ -1,0 +1,109 @@
+/**
+ * Tests for the scrollback width-persistence path in [SettingsRepository]:
+ *  - cols/rows round-trip through save/load ([SettingsRepository.ScrollbackRecord]);
+ *  - a legacy database whose `pane_scrollback` table predates the cols/rows
+ *    columns is migrated in place by the idempotent ALTERs in the repository
+ *    init, and its rows load with null size (callers fall back to the
+ *    session default grid);
+ *  - reopening an already-migrated database does not throw.
+ */
+package se.soderbjorn.lunamux.persistence
+
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.sql.DriverManager
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ScrollbackPersistenceTest {
+
+    private fun tempDbFile(): File =
+        File.createTempFile("lunamux-scrollback-test", ".db").apply { deleteOnExit() }
+
+    @Test
+    fun colsAndRowsRoundTrip() = runBlocking {
+        val repo = SettingsRepository(tempDbFile())
+        val bytes = "hello scrollback".toByteArray()
+        repo.saveScrollback("leaf-1", bytes, 187, 45)
+
+        val record = repo.loadScrollback("leaf-1")
+        assertNotNull(record)
+        assertContentEquals(bytes, record.bytes)
+        assertEquals(187, record.cols)
+        assertEquals(45, record.rows)
+    }
+
+    @Test
+    fun nullSizePersistsAsNull() = runBlocking {
+        val repo = SettingsRepository(tempDbFile())
+        repo.saveScrollback("leaf-1", byteArrayOf(1, 2, 3), null, null)
+
+        val record = repo.loadScrollback("leaf-1")
+        assertNotNull(record)
+        assertNull(record.cols)
+        assertNull(record.rows)
+    }
+
+    @Test
+    fun missingLeafLoadsAsNull() {
+        val repo = SettingsRepository(tempDbFile())
+        assertNull(repo.loadScrollback("no-such-leaf"))
+    }
+
+    @Test
+    fun legacyDatabaseIsMigratedAndLoadsWithNullSize() {
+        // Build a database exactly as a pre-size-recording server left it:
+        // user_version=1 (so the SQLDelight create path is skipped) and the
+        // old three-column pane_scrollback shape with a row in it.
+        val dbFile = tempDbFile()
+        DriverManager.getConnection("jdbc:sqlite:${dbFile.absolutePath}").use { conn ->
+            conn.createStatement().use { st ->
+                st.executeUpdate(
+                    "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+                )
+                st.executeUpdate(
+                    """
+                    CREATE TABLE pane_scrollback (
+                        leaf_id    TEXT NOT NULL PRIMARY KEY,
+                        bytes      BLOB NOT NULL,
+                        updated_at INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
+                st.executeUpdate("PRAGMA user_version = 1")
+            }
+            conn.prepareStatement(
+                "INSERT INTO pane_scrollback(leaf_id, bytes, updated_at) VALUES (?, ?, ?)"
+            ).use { ps ->
+                ps.setString(1, "legacy-leaf")
+                ps.setBytes(2, byteArrayOf(42))
+                ps.setLong(3, 12345L)
+                ps.executeUpdate()
+            }
+        }
+
+        val repo = SettingsRepository(dbFile)
+        val record = repo.loadScrollback("legacy-leaf")
+        assertNotNull(record)
+        assertContentEquals(byteArrayOf(42), record.bytes)
+        assertNull(record.cols)
+        assertNull(record.rows)
+    }
+
+    @Test
+    fun reopeningMigratedDatabaseIsIdempotent() = runBlocking {
+        val dbFile = tempDbFile()
+        SettingsRepository(dbFile).saveScrollback("leaf-1", byteArrayOf(7), 100, 30)
+
+        // Second open runs the ALTERs again; the duplicate-column error must
+        // be swallowed and the data must still be there.
+        val reopened = SettingsRepository(dbFile)
+        val record = reopened.loadScrollback("leaf-1")
+        assertNotNull(record)
+        assertEquals(100, record.cols)
+        assertEquals(30, record.rows)
+    }
+}

--- a/server/src/test/kotlin/se/soderbjorn/lunamux/pty/ReplaySanitizerTest.kt
+++ b/server/src/test/kotlin/se/soderbjorn/lunamux/pty/ReplaySanitizerTest.kt
@@ -1,0 +1,177 @@
+/**
+ * Tests for [ReplaySanitizer] — the replay-path filter that strips terminal
+ * *query* escape sequences from recorded PTY output so a replaying client
+ * never answers them into the live shell:
+ *  - every query family is stripped (DSR/CPR, DA1/2/3, XTVERSION, DECRQM,
+ *    kitty keyboard query, OSC `?` reads, XTGETTCAP, DECRQSS);
+ *  - lookalike non-queries survive byte-for-byte (DECSCUSR, DECSCL, OSC
+ *    title/cwd/color *sets*, sixel, DECRST, SGR, plain UTF-8 text);
+ *  - ring-buffer boundary rules hold (truncated head passed through,
+ *    incomplete tail preserved, idempotence, empty input).
+ */
+package se.soderbjorn.lunamux.pty
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class ReplaySanitizerTest {
+
+    private val esc = "\u001b"
+    private val bel = "\u0007"
+    private val st = "\u001b\\"
+
+    private fun strip(s: String): String =
+        ReplaySanitizer.stripQueries(s.toByteArray(Charsets.UTF_8)).toString(Charsets.UTF_8)
+
+    private fun assertStripped(sequence: String) {
+        assertEquals("beforeafter", strip("before${sequence}after"), "expected $sequence to be stripped")
+    }
+
+    private fun assertKept(sequence: String) {
+        val input = "before${sequence}after"
+        assertEquals(input, strip(input), "expected $sequence to survive")
+    }
+
+    // ------------------------------------------------------------ stripped
+
+    @Test
+    fun stripsDeviceStatusReports() {
+        assertStripped("$esc[6n")        // CPR
+        assertStripped("$esc[5n")        // DSR status
+        assertStripped("$esc[?6n")       // DECXCPR
+        assertStripped("$esc[?15n")      // printer status
+        assertStripped("$esc[?25n")      // UDK status
+    }
+
+    @Test
+    fun stripsDeviceAttributeQueries() {
+        assertStripped("$esc[c")         // DA1
+        assertStripped("$esc[0c")        // DA1 explicit
+        assertStripped("$esc[>c")        // DA2
+        assertStripped("$esc[>0c")
+        assertStripped("$esc[=c")        // DA3
+    }
+
+    @Test
+    fun stripsXtversionAndDecrqmAndKittyQuery() {
+        assertStripped("$esc[>q")        // XTVERSION
+        assertStripped("$esc[>0q")
+        assertStripped("$esc[?2004\$p")  // DECRQM (private mode)
+        assertStripped("$esc[4\$p")      // DECRQM (ANSI mode)
+        assertStripped("$esc[?u")        // kitty keyboard query
+    }
+
+    @Test
+    fun stripsOscReadQueries() {
+        assertStripped("$esc]10;?$bel")      // foreground color query
+        assertStripped("$esc]11;?$st")       // background color query, ST-terminated
+        assertStripped("$esc]12;?$bel")      // cursor color query
+        assertStripped("$esc]4;5;?$bel")     // palette entry query
+        assertStripped("$esc]52;c;?$bel")    // clipboard read
+    }
+
+    @Test
+    fun stripsDcsQueries() {
+        assertStripped("${esc}P+q544e$st")   // XTGETTCAP
+        assertStripped("${esc}P\$qm$st")     // DECRQSS
+    }
+
+    @Test
+    fun stripsConsecutiveQueriesCompletely() {
+        assertEquals("ab", strip("a$esc[6n$esc]11;?$bel$esc[>c${esc}P+q6b$st$esc[?u" + "b"))
+    }
+
+    // ---------------------------------------------------------------- kept
+
+    @Test
+    fun keepsCsiLookalikes() {
+        assertKept("$esc[4 q")       // DECSCUSR (space intermediate)
+        assertKept("$esc[62\"p")     // DECSCL (quote intermediate)
+        assertKept("$esc[u")         // SCORC restore cursor
+        assertKept("$esc[>1u")       // kitty push flags
+        assertKept("$esc[?1049l")    // DECRST
+        assertKept("$esc[?2004h")    // DECSET
+        assertKept("$esc[38;5;196m") // SGR
+        assertKept("$esc[2J$esc[H")  // clear + home
+    }
+
+    @Test
+    fun keepsOscSetsAndLabels() {
+        assertKept("$esc]0;my title$bel")            // title set
+        assertKept("$esc]7;file://host/tmp$bel")     // cwd report
+        assertKept("$esc]11;rgb:1e/1e/2e$bel")       // background color SET
+        assertKept("$esc]4;5;rgb:aa/bb/cc$bel")      // palette SET
+        assertKept("$esc]104$bel")                   // color reset
+        assertKept("$esc]8;;https://x.test$bel")     // hyperlink (empty segments)
+    }
+
+    @Test
+    fun keepsNonQueryDcsAndOtherEscapes() {
+        assertKept("${esc}Pq#0;2;0;0;0#0~~\$-$st")   // sixel
+        assertKept("${esc}P0;1q~~$st")               // sixel with params
+        assertKept("${esc}c")                        // RIS
+        assertKept("$esc>")                          // DECKPNM
+        assertKept("${esc}7${esc}8")                 // save/restore cursor
+    }
+
+    @Test
+    fun keepsPlainTextByteForByte() {
+        val mixed = "plain text, UTF-8 →→ äöå 🚀, and\r\nnewlines\ttabs"
+        val bytes = mixed.toByteArray(Charsets.UTF_8)
+        assertContentEquals(bytes, ReplaySanitizer.stripQueries(bytes))
+    }
+
+    @Test
+    fun keepsRestoreModeResetSequences() {
+        // The exact bytes TerminalSession stamps into restored rings — these
+        // must never be stripped or the issue-#91 mode neutralization breaks.
+        val reset = "$esc[?9;1000;1001;1002;1003;1005;1006;1015l$esc[?1004l$esc[?2004l$esc[?1l$esc[?1049l$esc>"
+        assertKept(reset)
+        assertKept("$esc[?25h") // SHOW_CURSOR_SUFFIX
+    }
+
+    // ------------------------------------------------------------ boundary
+
+    @Test
+    fun preservesIncompleteTrailingSequences() {
+        // The live stream will complete these right after the replay; the
+        // emitting program is legitimately waiting for the answer.
+        assertEquals("x$esc[6", strip("x$esc[6"))
+        assertEquals("x$esc[?200", strip("x$esc[?200"))
+        assertEquals("x$esc]11;?", strip("x$esc]11;?"))
+        assertEquals("x${esc}P+q54", strip("x${esc}P+q54"))
+        assertEquals("x$esc", strip("x$esc"))
+    }
+
+    @Test
+    fun passesThroughTruncatedHeadFromRingWrap() {
+        // A ring that overwrote the ESC introducer leaves an inert tail; the
+        // filter must not misparse or mangle it.
+        val truncated = "]11;?${bel}normal text"
+        assertEquals(truncated, strip(truncated))
+        val truncatedCsi = "?2004\$pmore"
+        assertEquals(truncatedCsi, strip(truncatedCsi))
+    }
+
+    @Test
+    fun isIdempotent() {
+        val input = "a$esc[6n$esc]0;t$bel$esc[38;5;1mz$esc]11;?$bel$esc[4 q$esc[6".toByteArray(Charsets.UTF_8)
+        val once = ReplaySanitizer.stripQueries(input)
+        val twice = ReplaySanitizer.stripQueries(once)
+        assertContentEquals(once, twice)
+    }
+
+    @Test
+    fun handlesEmptyInput() {
+        assertContentEquals(ByteArray(0), ReplaySanitizer.stripQueries(ByteArray(0)))
+    }
+
+    @Test
+    fun givesUpOnOversizedStringPayloadsWithoutMangling() {
+        // An OSC payload longer than the scan cap is not a query; the
+        // introducer and payload must pass through untouched.
+        val huge = "$esc]1337;File=inline:" + "A".repeat(8192) + bel
+        assertEquals(huge, strip(huge))
+    }
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/DemoSupport.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/DemoSupport.kt
@@ -233,23 +233,18 @@ internal fun connectDemoPane(entry: TerminalEntry) {
     fun sendInput(data: String) {
         session.inputText(data)
     }
+    // Route input through the [TerminalEntry.sendInput] slot only — the
+    // one-time `onData` handler registered in [ensureTerminal] invokes it, so
+    // registering another `onData` here would double-send every keystroke.
     entry.sendInput = ::sendInput
-    entry.term.onData { data -> sendInput(data) }
 
     // Notify size-aware sessions (the IRC TUI reflows its frame to fill the pane;
     // fixed-frame shell/Claude sessions ignore it) of the terminal's live cell
     // grid — the web demo attaches straight to the DemoSession and never goes
-    // through DemoPtySocket, so this is where the resize has to be forwarded.
-    // Push the current size once now, then on every refit.
-    fun pushResize(cols: Int, rows: Int) {
-        if (cols > 0 && rows > 0) GlobalScope.launch { session.resize(cols, rows) }
-    }
-    pushResize(entry.term.cols, entry.term.rows)
-    entry.term.onResize { size ->
-        val d = size.asDynamic()
-        pushResize((d.cols as? Number)?.toInt() ?: entry.term.cols, (d.rows as? Number)?.toInt() ?: entry.term.rows)
-        updateOobOverlay(entry)
-    }
+    // through DemoPtySocket. Push the current size once now; subsequent refits
+    // are forwarded by the one-time `onResize` handler in [ensureTerminal]
+    // (via [pushDemoSessionResize]).
+    pushDemoSessionResize(entry)
 
     entry.demoJob = GlobalScope.launch {
         session.output().collect { bytes ->

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LayoutBuilder.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LayoutBuilder.kt
@@ -62,12 +62,96 @@ fun attachDragDrop(container: HTMLElement, term: Terminal) {
 }
 
 /**
+ * Debounced automatic PTY size vote carrying [entry]'s current grid.
+ *
+ * Fired by the shared `term.onResize` handler (registered once per xterm
+ * instance in [ensureTerminal]) and by [connectPane]'s open handler. Reads
+ * [TerminalEntry.socket] at call time instead of closing over a specific
+ * connection: xterm.js offers no listener unsubscribe through our bindings,
+ * so a per-connection closure would leave one extra `onResize` listener
+ * behind on every reconnect and multiply each vote. The debounce handle
+ * lives on the entry ([TerminalEntry.pendingResizeTimer]) for the same
+ * reason.
+ *
+ * The grid is sampled synchronously (`term.cols/rows` at call time) so the
+ * vote carries the freshly fitted size even though the send itself is
+ * debounced; the socket is re-read at fire time so a vote scheduled just
+ * before a reconnect lands on the new connection.
+ *
+ * @param entry the terminal whose grid to vote.
+ * @see ensureTerminal
+ * @see forceReassert
+ */
+fun sendResize(entry: TerminalEntry) {
+    if (entry.applyingServerSize) return
+    // Per-pane "stop automatic reflow": when off, never push a resize to
+    // the PTY automatically. This is the single chokepoint every
+    // automatic local refit funnels through (via `term.onResize`), so
+    // gating here freezes the remote PTY size regardless of which
+    // geometry path triggered the local fit. The manual Reformat button
+    // bypasses this by calling `forceReassert`, which sends a
+    // `ForceResize` directly. See [TerminalEntry.autoReflow].
+    if (!entry.autoReflow) return
+    if (!entryOpen(entry)) return
+    val cols = entry.term.cols; val rows = entry.term.rows
+    // While the pane rides a 3D-world plane, this automatic vote lands on the
+    // *same* socket/clientId as the 3D world's explicit vote — fired by
+    // `term.onResize` the instant `setPaneGrid` resizes the grid, and again on
+    // every fresh socket-open re-seed. Vote at the pane's **tier** so it
+    // *reinforces* rather than clobbers: a pane carrying a `grid3d` override
+    // re-votes THREE_D at the same grid (a plain NORMAL Resize here would
+    // silently drop the override to the NORMAL tier — the "counter-voted back"
+    // failure the `isRidingSpikePlane` doc describes), while any other riding
+    // pane, and every 2D pane, votes NORMAL. The circular fit that would ratchet
+    // the grid down is suppressed separately (ResizeObserver / onopen guards), so
+    // `cols`/`rows` here is always PTY-truth, never a fit proposal. Muting the
+    // vote entirely instead would strand a pane that reconnects or re-mounts in
+    // 3D with no size vote at all (blank on world round-trip).
+    // @see setPaneGrid @see isRidingSpikePlane @see SizePriority
+    val priority =
+        if (isRidingSpikePlane(entry) && entry.paneId in spikeGrid3dByPane) SizePriority.THREE_D
+        else SizePriority.NORMAL
+    entry.pendingResizeTimer?.let { window.clearTimeout(it) }
+    entry.pendingResizeTimer = window.setTimeout({
+        entry.pendingResizeTimer = null
+        val socket = entry.socket
+        if (socket != null && entryOpen(entry)) {
+            socket.send(
+                windowJson.encodeToString<PtyControl>(
+                    PtyControl.Resize(cols = cols, rows = rows, priority = priority)
+                )
+            )
+        }
+    }, 50)
+}
+
+/**
+ * Whether [entry]'s current socket exists and is in the OPEN ready state.
+ * Shared guard for [sendResize] and the input path.
+ */
+private fun entryOpen(entry: TerminalEntry): Boolean =
+    entry.socket?.readyState?.toInt() == org.w3c.dom.WebSocket.OPEN.toInt()
+
+/**
  * Establishes a WebSocket connection to the server's PTY endpoint for a terminal pane.
  *
  * Handles bidirectional data flow: user keystrokes are sent as binary data to the
  * server, and PTY output (binary) and control messages (JSON) are received and
  * written to the xterm.js terminal. Automatically reconnects on close (unless the
  * pane has been removed), and shows a device-rejected overlay on auth failure (code 1008).
+ *
+ * The first binary frame of every connection is the server's scrollback
+ * replay: on a reconnect the terminal is reset (RIS) before it is written —
+ * parity with the native client's `RealPtySocket` — so the replay replaces
+ * the previous connection's transcript instead of appending a duplicate
+ * copy, and input is gated while xterm parses it (see
+ * [TerminalEntry.replaying]).
+ *
+ * Note: `term.onData`/`term.onResize` are deliberately NOT registered here —
+ * xterm.js offers no unsubscribe through our bindings, so per-connection
+ * registration would accumulate one listener per reconnect (N reconnects →
+ * every keystroke sent N times). They are registered once per xterm instance
+ * in [ensureTerminal].
  *
  * @param entry the [TerminalEntry] containing the terminal, session ID, and connection state
  * @see ensureTerminal
@@ -89,48 +173,6 @@ fun connectPane(entry: TerminalEntry) {
 
     fun isOpen(): Boolean = socket.readyState.toInt() == org.w3c.dom.WebSocket.OPEN.toInt()
 
-    var pendingResize: Int? = null
-    fun sendResize() {
-        if (entry.applyingServerSize) return
-        // Per-pane "stop automatic reflow": when off, never push a resize to
-        // the PTY automatically. This is the single chokepoint every
-        // automatic local refit funnels through (via `term.onResize`), so
-        // gating here freezes the remote PTY size regardless of which
-        // geometry path triggered the local fit. The manual Reformat button
-        // bypasses this by calling `forceReassert`, which sends a
-        // `ForceResize` directly. See [TerminalEntry.autoReflow].
-        if (!entry.autoReflow) return
-        if (!isOpen()) return
-        val cols = entry.term.cols; val rows = entry.term.rows
-        // While the pane rides a 3D-world plane, this automatic vote lands on the
-        // *same* socket/clientId as the 3D world's explicit vote — fired by
-        // `term.onResize` the instant `setPaneGrid` resizes the grid, and again on
-        // every fresh socket-open re-seed. Vote at the pane's **tier** so it
-        // *reinforces* rather than clobbers: a pane carrying a `grid3d` override
-        // re-votes THREE_D at the same grid (a plain NORMAL Resize here would
-        // silently drop the override to the NORMAL tier — the "counter-voted back"
-        // failure the `isRidingSpikePlane` doc describes), while any other riding
-        // pane, and every 2D pane, votes NORMAL. The circular fit that would ratchet
-        // the grid down is suppressed separately (ResizeObserver / onopen guards), so
-        // `cols`/`rows` here is always PTY-truth, never a fit proposal. Muting the
-        // vote entirely instead would strand a pane that reconnects or re-mounts in
-        // 3D with no size vote at all (blank on world round-trip).
-        // @see setPaneGrid @see isRidingSpikePlane @see SizePriority
-        val priority =
-            if (isRidingSpikePlane(entry) && entry.paneId in spikeGrid3dByPane) SizePriority.THREE_D
-            else SizePriority.NORMAL
-        pendingResize?.let { window.clearTimeout(it) }
-        pendingResize = window.setTimeout({
-            pendingResize = null
-            if (!isOpen()) return@setTimeout
-            socket.send(
-                windowJson.encodeToString<PtyControl>(
-                    PtyControl.Resize(cols = cols, rows = rows, priority = priority)
-                )
-            )
-        }, 50)
-    }
-
     fun sendInput(data: String) {
         if (!isOpen()) return
         val encoder = js("new TextEncoder()")
@@ -138,12 +180,14 @@ fun connectPane(entry: TerminalEntry) {
         socket.send(bytes.buffer as org.khronos.webgl.ArrayBuffer)
     }
 
+    // Reassigned (not accumulated) per connection: the one-time `onData`
+    // handler in [ensureTerminal] routes through this slot, so a reconnect
+    // just swaps which socket keystrokes go to.
     entry.sendInput = ::sendInput
-    entry.term.onData { data -> sendInput(data) }
-    entry.term.onResize { _ -> sendResize(); updateOobOverlay(entry) }
 
     socket.onopen = { _: org.w3c.dom.events.Event ->
         entry.connected = true
+        entry.awaitingSnapshot = true
         connectionState[entry.sessionId] = "connected"
         updateAggregateStatus()
         // Fit to our container and cast a *soft* size vote on every fresh
@@ -184,9 +228,9 @@ fun connectPane(entry: TerminalEntry) {
                 if (!isRidingSpikePlane(entry)) {
                     try { fitPreservingScroll(entry.term, entry.fit) } catch (_: Throwable) {}
                 }
-                sendResize()
+                sendResize(entry)
             } else {
-                window.setTimeout({ sendResize() }, 0)
+                window.setTimeout({ sendResize(entry) }, 0)
             }
         }
     }
@@ -200,10 +244,36 @@ fun connectPane(entry: TerminalEntry) {
         } else {
             val buf = data as org.khronos.webgl.ArrayBuffer
             val bytes = org.khronos.webgl.Uint8Array(buf)
-            // Write while holding the viewport when the user has scrolled up
-            // (pause), and advertising "New output" on the pill. Falls back to
-            // a normal auto-following write at the bottom.
-            writeHoldingScroll(entry, bytes)
+            if (entry.awaitingSnapshot) {
+                // First binary frame of this connection = the server's
+                // scrollback replay (the /pty protocol sends Size → snapshot
+                // → live output, and WebSocket frames are ordered). On a
+                // reconnect the grid still holds the previous connection's
+                // transcript and the replay would append a second full copy,
+                // so reset the terminal first (RIS) — parity with the native
+                // client, which prepends ESC c on reconnect. A first attach
+                // writes into an empty grid and needs no reset. Scroll
+                // holding is irrelevant on both paths (empty or just-reset
+                // grid), hence the direct write.
+                entry.awaitingSnapshot = false
+                if (entry.everConnected) entry.term.write("\u001bc")
+                entry.everConnected = true
+                // Gate keystrokes while xterm parses the replay: a query
+                // sequence in replayed bytes would be answered via onData
+                // and injected into the live shell as phantom input. The
+                // server strips known query families; this closes the
+                // window for anything it doesn't know about.
+                entry.replaying = true
+                entry.term.asDynamic().write(bytes) {
+                    entry.replaying = false
+                    updateScrollButton(entry)
+                }
+            } else {
+                // Write while holding the viewport when the user has scrolled
+                // up (pause), and advertising "New output" on the pill. Falls
+                // back to a normal auto-following write at the bottom.
+                writeHoldingScroll(entry, bytes)
+            }
             if (containsShowCursor(bytes)) {
                 val term = entry.term
                 window.requestAnimationFrame {
@@ -214,6 +284,10 @@ fun connectPane(entry: TerminalEntry) {
     }
     socket.onclose = { event ->
         entry.connected = false
+        // A replay write whose completion callback never fired (socket died
+        // mid-parse, pane torn down) must not leave input gated forever.
+        entry.replaying = false
+        entry.awaitingSnapshot = false
         if (terminals[entry.paneId] === entry) {
             connectionState[entry.sessionId] = "disconnected"
             updateAggregateStatus()
@@ -387,6 +461,27 @@ fun ensureTerminal(paneId: String, sessionId: String): TerminalEntry {
     terminals[paneId] = entry
     connectionState[sessionId] = "connecting"
     updateAggregateStatus()
+
+    // Input/resize handlers are registered exactly ONCE per xterm instance,
+    // here — never in [connectPane]. xterm.js offers no listener unsubscribe
+    // through our bindings, so per-connection registration accumulated one
+    // extra listener per reconnect: after N reconnects every keystroke (and
+    // every resize vote) was delivered to the PTY N times. Both handlers
+    // resolve the *current* connection at call time — `onData` through the
+    // [TerminalEntry.sendInput] slot (reassigned by each connectPane), and
+    // [sendResize] through [TerminalEntry.socket] — so a reconnect swaps the
+    // transport without touching the registrations. The `replaying` gate
+    // drops input while a snapshot replay is being parsed, so terminal-query
+    // answers xterm emits for replayed bytes never reach the live shell (see
+    // [TerminalEntry.replaying]). The resize handler also forwards demo-mode
+    // grid changes ([pushDemoSessionResize], a no-op outside demo mode —
+    // this is the single registration demo panes rely on too).
+    term.onData { data -> if (!entry.replaying) entry.sendInput?.invoke(data) }
+    term.onResize { _ ->
+        sendResize(entry)
+        pushDemoSessionResize(entry)
+        updateOobOverlay(entry)
+    }
 
     // Keep the pill in sync with the user's scroll position, and let it
     // resume auto-follow on click. `onScroll` fires for both user scrolling

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/TerminalHelpers.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/TerminalHelpers.kt
@@ -72,6 +72,23 @@ external class ResizeObserver(callback: (dynamic, dynamic) -> Unit) {
  *   per-pane override (the "this window" toggle, including its config echo).
  *   Defaults to `true` so a pane behaves as "reflow on" until told otherwise.
  *   See [forceReassert] (the manual path, which ignores this flag).
+ * @property everConnected whether this entry has completed at least one
+ *   snapshot replay — gates the reconnect-time terminal reset in
+ *   [connectPane]'s message handler (a first attach writes into an empty
+ *   grid; a reconnect must clear the previous connection's transcript
+ *   first or the replay appends a duplicate copy)
+ * @property awaitingSnapshot true from socket open until the first binary
+ *   frame of that connection arrives — identifies the server's snapshot
+ *   replay frame (the `/pty` protocol sends Size → snapshot → live output,
+ *   and WebSocket frames are ordered)
+ * @property replaying true while xterm.js is parsing a snapshot replay
+ *   frame; the shared `onData` handler drops input during this window so
+ *   any terminal-query answer xterm emits for replayed bytes is not
+ *   injected into the live shell as phantom keystrokes
+ * @property pendingResizeTimer debounce timer handle for [sendResize], or
+ *   null when no vote is pending (lives on the entry, not in a
+ *   per-connection closure, so the handler can be registered once per
+ *   xterm instance)
  */
 class TerminalEntry(
     val paneId: String,
@@ -92,6 +109,10 @@ class TerminalEntry(
     var wasContainerVisible: Boolean = false,
     var demoJob: kotlinx.coroutines.Job? = null,
     var autoReflow: Boolean = true,
+    var everConnected: Boolean = false,
+    var awaitingSnapshot: Boolean = false,
+    var replaying: Boolean = false,
+    var pendingResizeTimer: Int? = null,
 )
 
 /**


### PR DESCRIPTION
## Problem

Scrollback replay (reconnect and cross-restart restore) had four compounding defects:

1. **Query-reply injection** — recorded PTY output keeps terminal *query* sequences (DSR/CPR `ESC[6n`, DA, OSC 10/11/12 color reads, XTGETTCAP, DECRQSS…). On replay, xterm.js answers them again and the answers are delivered to the live shell as phantom keystrokes — this is the mystery `2cfe2cfe`-style garbage on the prompt (fragments of `rgb:…` color replies).
2. **Width-blind restore** — `pane_scrollback` stored no cols/rows, so restored raw bytes replayed into the default 120×32 grid and then reflowed to the real pane. TUI absolute-cursor repaints landed on the wrong cells → ghost frames, duplicated tables, permanent hard-wrap scars.
3. **Reconnect duplication (web)** — every reconnect re-replayed the full snapshot into an un-reset grid, appending a second copy of the transcript (the native client already prepends `ESC c`).
4. **Handler leak (web)** — `term.onData`/`term.onResize` were re-registered per connection with no unsubscribe, so after N reconnects every keystroke/resize vote was sent N times (multiplying the injected garbage too).

## Fix

- **New `ReplaySanitizer`** (server): one-shot byte filter that strips *complete* query sequences on the replay paths only — `snapshot()` (covers attach replay + persistence, since the saver persists `snapshot()`) and restored-blob ingestion in the session init (cleans blobs written by older versions). The live output stream is untouched, so a running program's query still reaches the client and gets its answer. Lookalikes survive (DECSCUSR `ESC[4 q`, DECSCL, sixel DCS, OSC sets, DECRST/DECSET, SGR); incomplete trailing sequences are preserved because the live stream completes them for a program that is genuinely waiting.
- **Width persistence**: `pane_scrollback` gains nullable `cols`/`rows` (idempotent `ALTER`s migrate existing DBs, same no-`.sqm` pattern as the table's own bootstrap). The saver samples `sizeEvents` with each snapshot; the restore path seeds the fresh session's PTY, headless emulator and `sizeEvents` with the persisted size — the existing Size-then-snapshot protocol then makes clients render the replay at native width before one clean reflow to the live pane. Legacy rows fall back to 120×32 (exact current behavior).
- **Web reconnect reset**: the first binary frame of a connection is the snapshot (protocol sends Size → snapshot → live output); on reconnects the terminal is RIS-reset before writing it — parity with `RealPtySocket`. Input is gated while the replay parses, as belt-and-braces against query families the sanitizer doesn't know.
- **One-time handlers**: `onData`/`onResize` now register once per xterm instance in `ensureTerminal` and resolve the current socket at call time (`TerminalEntry.sendInput` slot / `entry.socket`); demo mode routes through the same single registration.

## Verification

- `:server:test`: 175 tests pass, including 16 new `ReplaySanitizer` cases (all query families, lookalike survivals, ring-boundary rules, idempotence) and 5 new persistence/migration cases (legacy 3-column DB migrates in place and loads with null size).
- End-to-end against a live server with a WebSocket probe: live output still carries raw queries (pass-through intact); reconnect snapshot keeps content but is query-free; after graceful restart the DB holds the blob at 87×41 and the restored session announces 87×41 **before** the replay.
- Also verified the column migration in place on a pre-existing dev database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)