### PR TITLE
Electron auto-updater + local metadata-safe release/publish

### DIFF
--- a/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/newsupdates/NewsUpdatesBackingViewModel.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/newsupdates/NewsUpdatesBackingViewModel.kt
@@ -123,10 +123,11 @@ fun createNewsUpdatesBackingViewModel(
  *   comparison baseline against the manifest's `latestVersionCode`.
  * @param currentVersionName the running build's human-readable version, logged
  *   for context (not used in the comparison).
- * @param enableUpdateCheck when false, the `versions.json` update comparison is
- *   skipped entirely (news still flows normally). Used by the desktop/Electron
- *   build, where electron-updater owns in-app updates and this manifest would
- *   otherwise double-notify. Defaults to true, so Android/iOS are unchanged.
+ * @param enableUpdateCheck when false, `versions.json` is not fetched and its
+ *   update comparison is skipped entirely (news still flows normally). Used by the
+ *   desktop/Electron build, where electron-updater owns in-app updates and this
+ *   manifest would otherwise double-notify. Defaults to true, so Android/iOS are
+ *   unchanged.
  * @param scope coroutine scope the check loop runs in; defaults to a background
  *   [SupervisorJob] scope so a failed check never tears down siblings.
  * @param manifestUrl the version manifest URL; overridable for testing.
@@ -288,7 +289,10 @@ class NewsUpdatesBackingViewModel(
             "NewsUpdates: checking $manifestUrl + $newsUrl for platform=$platformId " +
                 "code=$currentVersionCode name=$currentVersionName",
         )
-        val versions = fetchVersionManifest()
+        // Desktop disables the versions.json update path (electron-updater owns
+        // updates there), so skip the fetch entirely rather than spend a request on
+        // a manifest we'd ignore. News is always fetched.
+        val versions = if (enableUpdateCheck) fetchVersionManifest() else null
         val news = fetchNewsManifest()
         if (versions == null && news == null) {
             // Silent no-op on total failure: no state change, no timestamp advance.
@@ -381,11 +385,9 @@ class NewsUpdatesBackingViewModel(
 
     /** Apply a fetched version manifest to the emitted [State]. */
     private fun applyVersionManifest(manifest: VersionManifest) {
-        // Update checks disabled (desktop/Electron, where electron-updater owns
-        // in-app updates): never advertise a versions.json update. Leaves
-        // updateAvailable at its default false so the bell/screen show no
-        // version-update section; news is unaffected (applyNewsManifest is separate).
-        if (!enableUpdateCheck) return
+        // Only ever reached when enableUpdateCheck is true: when false, checkNow
+        // skips fetchVersionManifest and restoreAll has no cached manifest to apply,
+        // so a desktop build never advertises a versions.json update.
         if (manifest.schemaVersion > VersionManifest.SUPPORTED_SCHEMA_VERSION) {
             println("NewsUpdates: version schemaVersion=${manifest.schemaVersion} unsupported; no update")
             latestUpdateVersionCode = null

--- a/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/newsupdates/NewsUpdatesBackingViewModel.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/newsupdates/NewsUpdatesBackingViewModel.kt
@@ -123,6 +123,10 @@ fun createNewsUpdatesBackingViewModel(
  *   comparison baseline against the manifest's `latestVersionCode`.
  * @param currentVersionName the running build's human-readable version, logged
  *   for context (not used in the comparison).
+ * @param enableUpdateCheck when false, the `versions.json` update comparison is
+ *   skipped entirely (news still flows normally). Used by the desktop/Electron
+ *   build, where electron-updater owns in-app updates and this manifest would
+ *   otherwise double-notify. Defaults to true, so Android/iOS are unchanged.
  * @param scope coroutine scope the check loop runs in; defaults to a background
  *   [SupervisorJob] scope so a failed check never tears down siblings.
  * @param manifestUrl the version manifest URL; overridable for testing.
@@ -137,6 +141,7 @@ class NewsUpdatesBackingViewModel(
     private val platformId: String,
     private val currentVersionCode: Long,
     private val currentVersionName: String,
+    private val enableUpdateCheck: Boolean = true,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     private val manifestUrl: String = DEFAULT_MANIFEST_URL,
     private val newsUrl: String = DEFAULT_NEWS_URL,
@@ -376,6 +381,11 @@ class NewsUpdatesBackingViewModel(
 
     /** Apply a fetched version manifest to the emitted [State]. */
     private fun applyVersionManifest(manifest: VersionManifest) {
+        // Update checks disabled (desktop/Electron, where electron-updater owns
+        // in-app updates): never advertise a versions.json update. Leaves
+        // updateAvailable at its default false so the bell/screen show no
+        // version-update section; news is unaffected (applyNewsManifest is separate).
+        if (!enableUpdateCheck) return
         if (manifest.schemaVersion > VersionManifest.SUPPORTED_SCHEMA_VERSION) {
             println("NewsUpdates: version schemaVersion=${manifest.schemaVersion} unsupported; no update")
             latestUpdateVersionCode = null

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
@@ -71,6 +71,70 @@ object UpdateChannels {
 private var updaterListenersBound = false
 
 /**
+ * Supplier of the live main window, stored by [initAutoUpdater] so
+ * [sendUpdateEvent] can reach the current renderer from anywhere in this file
+ * (not just the listener closures). Resolved at send time, so a window rebuild
+ * never severs event delivery.
+ */
+private var updaterWindowSupplier: (() -> BrowserWindow?)? = null
+
+/**
+ * Whether an update has been fully downloaded and is ready to install. Set by
+ * the `update-downloaded` event; cleared again by `update-available` (a newly
+ * discovered version invalidates the previous download, and the renderer's
+ * banner drops back to "Download" at the same moment, keeping both sides in
+ * agreement).
+ *
+ * Guards the `update:quit-and-install` IPC handler in [main]: without it, a
+ * renderer whose state got ahead of reality could shut the bundled server down
+ * for an install that [AutoUpdaterApi.quitAndInstall] will refuse, stranding a
+ * running app with a dead server.
+ */
+private var updateDownloaded = false
+
+/**
+ * Whether a downloaded update is ready to install right now.
+ *
+ * Called by the `update:quit-and-install` IPC handler in [main] before it
+ * commits to the pre-install teardown (quit-gate bypass + server shutdown).
+ *
+ * @return `true` once `update-downloaded` has fired for the currently-known
+ *   version, `false` before any download or after a newer version was found.
+ */
+fun isUpdateDownloaded(): Boolean = updateDownloaded
+
+/**
+ * Sends one update lifecycle event to the current renderer, dropping it when
+ * no live window exists. Shared by the [initAutoUpdater] listeners and the
+ * out-of-band error paths ([reportUpdateError]).
+ *
+ * @param channel one of the main → renderer [UpdateChannels].
+ * @param payload the plain-object payload for the channel, or `null`.
+ */
+private fun sendUpdateEvent(channel: String, payload: dynamic = null) {
+    val w = updaterWindowSupplier?.invoke() ?: return
+    if (!w.isDestroyed()) w.webContents.send(channel, payload)
+}
+
+/**
+ * Surfaces an update failure to the renderer's banner on the standard
+ * [UpdateChannels.ERROR] channel, exactly like electron-updater's own `error`
+ * event.
+ *
+ * Called by the `update:quit-and-install` IPC handler in [main] when it
+ * refuses an install (no downloaded update) and by [quitAndInstallUpdate]'s
+ * failure path — cases that never pass through the autoUpdater singleton and
+ * so would otherwise fail invisibly.
+ *
+ * @param message human-readable failure text, shown verbatim in the banner.
+ */
+fun reportUpdateError(message: String) {
+    val payload = js("({})")
+    payload.message = message
+    sendUpdateEvent(UpdateChannels.ERROR, payload)
+}
+
+/**
  * Configures [autoUpdater] and binds its lifecycle listeners once, forwarding
  * each event to the current renderer.
  *
@@ -93,24 +157,23 @@ fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
     // (electron-updater's default would auto-apply a pending download on quit).
     autoUpdater.autoInstallOnAppQuit = false
 
+    updaterWindowSupplier = currentWindow
     if (updaterListenersBound) return
     updaterListenersBound = true
 
-    fun send(channel: String, payload: dynamic = null) {
-        val w = currentWindow() ?: return
-        if (!w.isDestroyed()) w.webContents.send(channel, payload)
-    }
-
-    autoUpdater.on("checking-for-update") { send(UpdateChannels.CHECKING) }
+    autoUpdater.on("checking-for-update") { sendUpdateEvent(UpdateChannels.CHECKING) }
 
     autoUpdater.on("update-available") { info ->
+        // A newly discovered version invalidates any previously downloaded one
+        // (the renderer's banner falls back to "Download" on this same event).
+        updateDownloaded = false
         val payload = js("({})")
         payload.version = info?.version
         payload.releaseNotesUrl = releaseNotesUrl(info?.version as? String)
-        send(UpdateChannels.AVAILABLE, payload)
+        sendUpdateEvent(UpdateChannels.AVAILABLE, payload)
     }
 
-    autoUpdater.on("update-not-available") { send(UpdateChannels.NOT_AVAILABLE) }
+    autoUpdater.on("update-not-available") { sendUpdateEvent(UpdateChannels.NOT_AVAILABLE) }
 
     autoUpdater.on("download-progress") { progress ->
         val payload = js("({})")
@@ -118,20 +181,21 @@ fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
         payload.transferred = progress?.transferred
         payload.total = progress?.total
         payload.bytesPerSecond = progress?.bytesPerSecond
-        send(UpdateChannels.PROGRESS, payload)
+        sendUpdateEvent(UpdateChannels.PROGRESS, payload)
     }
 
     autoUpdater.on("update-downloaded") { info ->
+        updateDownloaded = true
         val payload = js("({})")
         payload.version = info?.version
         payload.releaseNotesUrl = releaseNotesUrl(info?.version as? String)
-        send(UpdateChannels.DOWNLOADED, payload)
+        sendUpdateEvent(UpdateChannels.DOWNLOADED, payload)
     }
 
     autoUpdater.on("error") { err ->
         val payload = js("({})")
         payload.message = (err?.message as? String) ?: "Update failed"
-        send(UpdateChannels.ERROR, payload)
+        sendUpdateEvent(UpdateChannels.ERROR, payload)
     }
 }
 
@@ -175,11 +239,25 @@ fun downloadUpdate() {
  * already-confirmed quit). Deferred via [setImmediate] so the IPC reply is
  * delivered before the app tears down.
  *
+ * If [AutoUpdaterApi.quitAndInstall] throws (e.g. no update is actually
+ * downloaded), the failure is surfaced to the renderer's banner via
+ * [reportUpdateError] and [onFailure] runs — without the try/catch the throw
+ * would be an uncaught main-process exception (Electron's error dialog) in an
+ * app whose server was just shut down.
+ *
+ * @param onFailure invoked when the install could not start and the app keeps
+ *   running; the caller uses it to undo its pre-install teardown (re-arming
+ *   the quit-confirmation gate).
  * @see AutoUpdaterApi.quitAndInstall
  */
-fun quitAndInstallUpdate() {
+fun quitAndInstallUpdate(onFailure: () -> Unit) {
     setImmediate {
-        autoUpdater.quitAndInstall()
+        try {
+            autoUpdater.quitAndInstall()
+        } catch (t: Throwable) {
+            reportUpdateError(t.message ?: "Installing the update failed")
+            onFailure()
+        }
     }
 }
 

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
@@ -1,0 +1,178 @@
+/* AutoUpdater.kt
+ * In-app auto-update lifecycle for the Lunamux Electron main process.
+ *
+ * A Kotlin/JS port of the acolite `app/updater.ts` pattern: it configures
+ * electron-updater's [autoUpdater] singleton (declared in
+ * [ElectronUpdaterExternals.kt]), relays each update lifecycle event to the
+ * renderer over IPC, and exposes the three control entry points
+ * ([checkForUpdates], [downloadUpdate], [quitAndInstallUpdate]) that the
+ * renderer's Updates panel drives.
+ *
+ * The renderer half lives in `web/.../AutoUpdaterPanel.kt`; the IPC channel
+ * names shared across main ↔ preload ↔ renderer are defined once in
+ * [UpdateChannels]. Wiring (IPC handler registration, the startup check, and
+ * the "Check for Updates…" menu item) is in [main] / `buildAppMenu`.
+ */
+package se.soderbjorn.lunamux.electron
+
+/**
+ * IPC channel names for the auto-update feature, shared conceptually with
+ * `electron/preload.js` and the renderer (`web/.../AutoUpdaterPanel.kt`),
+ * which use the same string literals. Grouped here so the main-process side
+ * has a single source of truth.
+ *
+ * The `update:*` command channels flow renderer → main (via `ipcRenderer.invoke`
+ * ⇄ `ipcMain.handle`); the remaining channels flow main → renderer (via
+ * `webContents.send` ⇄ `ipcRenderer.on`). [SHOW_PANEL] is a main → renderer
+ * signal that asks the renderer to open the Updates panel (fired by the
+ * "Check for Updates…" menu item).
+ */
+object UpdateChannels {
+    // ── renderer → main (commands) ──────────────────────────────────
+    /** Ask the main process to check the provider for a newer version. */
+    const val CHECK = "update:check"
+
+    /** Ask the main process to download the available update. */
+    const val DOWNLOAD = "update:download"
+
+    /** Ask the main process to quit, install the update, and relaunch. */
+    const val QUIT_AND_INSTALL = "update:quit-and-install"
+
+    // ── main → renderer (lifecycle events) ──────────────────────────
+    /** A check has started. */
+    const val CHECKING = "update:checking"
+
+    /** A newer version is available (payload: `{ version }`). */
+    const val AVAILABLE = "update:available"
+
+    /** No newer version is available. */
+    const val NOT_AVAILABLE = "update:not-available"
+
+    /** Download progress (payload: `{ percent, transferred, total, bytesPerSecond }`). */
+    const val PROGRESS = "update:progress"
+
+    /** The update has finished downloading and is ready to install (payload: `{ version }`). */
+    const val DOWNLOADED = "update:downloaded"
+
+    /** An update operation failed (payload: `{ message }`). */
+    const val ERROR = "update:error"
+
+    // ── main → renderer (navigation) ────────────────────────────────
+    /** Ask the renderer to open the Updates panel (from the Help menu item). */
+    const val SHOW_PANEL = "show-updates-panel"
+}
+
+/**
+ * Guards one-time listener binding in [initAutoUpdater]. electron-updater's
+ * `autoUpdater` is a process-wide singleton, so its lifecycle listeners must
+ * be attached exactly once regardless of how many times a BrowserWindow is
+ * (re)created.
+ */
+private var updaterListenersBound = false
+
+/**
+ * Configures [autoUpdater] and binds its lifecycle listeners once, forwarding
+ * each event to the current renderer.
+ *
+ * Called once from [main] during startup. Because a BrowserWindow can be
+ * rebuilt (e.g. the title-bar-style toggle destroys and recreates it), events
+ * are sent to whatever window [currentWindow] resolves at fire time rather
+ * than to a window captured here — so update progress keeps reaching the live
+ * renderer across a window swap.
+ *
+ * @param currentWindow supplier of the live main [BrowserWindow], or `null`
+ *   when none exists yet; provided by [main] where the `mainWindow` global is
+ *   in scope. Events are dropped when it yields `null` or a destroyed window.
+ * @see UpdateChannels for the channels each event maps to.
+ */
+fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
+    // Never download without an explicit user action from the Updates panel.
+    autoUpdater.autoDownload = false
+
+    if (updaterListenersBound) return
+    updaterListenersBound = true
+
+    fun send(channel: String, payload: dynamic = null) {
+        val w = currentWindow() ?: return
+        if (!w.isDestroyed()) w.webContents.send(channel, payload)
+    }
+
+    autoUpdater.on("checking-for-update") { send(UpdateChannels.CHECKING) }
+
+    autoUpdater.on("update-available") { info ->
+        val payload = js("({})")
+        payload.version = info?.version
+        send(UpdateChannels.AVAILABLE, payload)
+    }
+
+    autoUpdater.on("update-not-available") { send(UpdateChannels.NOT_AVAILABLE) }
+
+    autoUpdater.on("download-progress") { progress ->
+        val payload = js("({})")
+        payload.percent = progress?.percent
+        payload.transferred = progress?.transferred
+        payload.total = progress?.total
+        payload.bytesPerSecond = progress?.bytesPerSecond
+        send(UpdateChannels.PROGRESS, payload)
+    }
+
+    autoUpdater.on("update-downloaded") { info ->
+        val payload = js("({})")
+        payload.version = info?.version
+        send(UpdateChannels.DOWNLOADED, payload)
+    }
+
+    autoUpdater.on("error") { err ->
+        val payload = js("({})")
+        payload.message = (err?.message as? String) ?: "Update failed"
+        send(UpdateChannels.ERROR, payload)
+    }
+}
+
+/**
+ * Triggers an update check. No-ops in dev/demo launches: an unpackaged app has
+ * no `app-update.yml`, so electron-updater would throw — the acolite original
+ * lacked this guard and errored on every dev run.
+ *
+ * Called by the `update:check` IPC handler, the "Check for Updates…" menu item,
+ * and once silently at startup (see [main]). Failures (offline, etc.) surface
+ * to the renderer via the `error` event, so the promise rejection is swallowed
+ * here to avoid an unhandled rejection.
+ */
+fun checkForUpdates() {
+    if (!app.isPackaged) return
+    try {
+        autoUpdater.checkForUpdates().catch { /* surfaced via the "error" event */ }
+    } catch (_: Throwable) {
+        // Synchronous failures (misconfiguration) are non-fatal to the app.
+    }
+}
+
+/**
+ * Starts downloading the available update. Called by the `update:download` IPC
+ * handler when the user clicks "Download" in the Updates panel. Progress and
+ * completion are reported via the `download-progress` / `update-downloaded`
+ * events bound in [initAutoUpdater].
+ */
+fun downloadUpdate() {
+    try {
+        autoUpdater.downloadUpdate().catch { /* surfaced via the "error" event */ }
+    } catch (_: Throwable) {
+    }
+}
+
+/**
+ * Quits, installs the downloaded update, and relaunches.
+ *
+ * Called by the `update:quit-and-install` IPC handler after the caller has
+ * cleared the app's quit-confirmation gate (an update install is an
+ * already-confirmed quit). Deferred via [setImmediate] so the IPC reply is
+ * delivered before the app tears down.
+ *
+ * @see AutoUpdaterApi.quitAndInstall
+ */
+fun quitAndInstallUpdate() {
+    setImmediate {
+        autoUpdater.quitAndInstall()
+    }
+}

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/AutoUpdater.kt
@@ -86,8 +86,12 @@ private var updaterListenersBound = false
  * @see UpdateChannels for the channels each event maps to.
  */
 fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
-    // Never download without an explicit user action from the Updates panel.
+    // Never download without an explicit user action from the Updates banner.
     autoUpdater.autoDownload = false
+    // Updates are opt-in: a downloaded update installs ONLY when the user clicks
+    // "Restart to install" (quitAndInstall), never silently on the next app quit
+    // (electron-updater's default would auto-apply a pending download on quit).
+    autoUpdater.autoInstallOnAppQuit = false
 
     if (updaterListenersBound) return
     updaterListenersBound = true
@@ -102,6 +106,7 @@ fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
     autoUpdater.on("update-available") { info ->
         val payload = js("({})")
         payload.version = info?.version
+        payload.releaseNotesUrl = releaseNotesUrl(info?.version as? String)
         send(UpdateChannels.AVAILABLE, payload)
     }
 
@@ -119,6 +124,7 @@ fun initAutoUpdater(currentWindow: () -> BrowserWindow?) {
     autoUpdater.on("update-downloaded") { info ->
         val payload = js("({})")
         payload.version = info?.version
+        payload.releaseNotesUrl = releaseNotesUrl(info?.version as? String)
         send(UpdateChannels.DOWNLOADED, payload)
     }
 
@@ -175,4 +181,42 @@ fun quitAndInstallUpdate() {
     setImmediate {
         autoUpdater.quitAndInstall()
     }
+}
+
+/** Cached `owner/repo`-derived GitHub release-tag URL base, resolved once. */
+private var cachedReleaseTagBase: String? = null
+
+/** Whether [releaseNotesUrl] has already attempted to resolve [cachedReleaseTagBase]. */
+private var releaseTagBaseResolved = false
+
+/**
+ * Build the GitHub release page URL for [version] — the "What's new" link the
+ * renderer's update banner opens — from the packaged `app-update.yml`
+ * (`owner:` / `repo:`), which electron-updater already ships in
+ * `Contents/Resources`. Resolved and cached on first call.
+ *
+ * @param version the release version (without the leading `v`), e.g. "1.4.1".
+ * @return `https://github.com/<owner>/<repo>/releases/tag/v<version>`, or `null`
+ *   when the manifest is absent (e.g. an unpackaged dev launch) or unparseable.
+ */
+private fun releaseNotesUrl(version: String?): String? {
+    if (version.isNullOrBlank()) return null
+    if (!releaseTagBaseResolved) {
+        releaseTagBaseResolved = true
+        try {
+            val ymlPath = NodePath.join(process.resourcesPath, "app-update.yml")
+            if (NodeFs.existsSync(ymlPath)) {
+                val lines = NodeFs.readFileSync(ymlPath, "utf8").split("\n")
+                val owner = lines.firstOrNull { it.trimStart().startsWith("owner:") }?.substringAfter(":")?.trim()
+                val repo = lines.firstOrNull { it.trimStart().startsWith("repo:") }?.substringAfter(":")?.trim()
+                if (!owner.isNullOrEmpty() && !repo.isNullOrEmpty()) {
+                    cachedReleaseTagBase = "https://github.com/$owner/$repo/releases/tag"
+                }
+            }
+        } catch (_: Throwable) {
+            // Best-effort: no link rather than a crash.
+        }
+    }
+    val base = cachedReleaseTagBase ?: return null
+    return "$base/v$version"
 }

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
@@ -546,6 +546,23 @@ private fun showShutdownFailedDialog(): Boolean {
 }
 
 /**
+ * Tells the renderer an in-flight quit was cancelled after it had already
+ * confirmed a kill-server quit. The renderer suppresses its "Connection lost"
+ * modal the moment it confirms such a quit (anticipating the intentional
+ * server teardown); when the quit is then abandoned — server shutdown failed
+ * and the user chose Cancel in [showShutdownFailedDialog] — the app keeps
+ * running, so the renderer must re-arm that modal or every later genuine
+ * disconnect would be swallowed silently.
+ *
+ * Called only from [requestQuit]'s cancel path; received by the renderer via
+ * `onQuitCancelled` (preload.js → web main.kt).
+ */
+private fun notifyQuitCancelled() {
+    val w = mainWindow
+    if (w != null && !w.isDestroyed()) w.webContents.send("quit-cancelled")
+}
+
+/**
  * Orchestrate a quit intent: show the modal, optionally stop the
  * server, then call [ElectronApp.quit] with the [quitConfirmed] flag
  * set so the next `before-quit` lets the quit through.
@@ -588,6 +605,10 @@ private fun requestQuit() {
                     app.quit()
                 } else {
                     quitInProgress = false
+                    // The renderer suppressed its "Connection lost" modal when
+                    // it confirmed this kill-server quit; the quit is now
+                    // abandoned, so tell it to re-arm the modal.
+                    notifyQuitCancelled()
                 }
             }
         } else {
@@ -1668,18 +1689,33 @@ fun main() {
         Unit
     }
     ipcMain.handle(UpdateChannels.QUIT_AND_INSTALL) { _, _ ->
-        // Installing an update is an already-confirmed quit. The window-close
-        // and before-quit gates route through the renderer quit-confirmation
-        // modal unless quitConfirmed is set, so mark it before handing off to
-        // Squirrel — otherwise the install-relaunch would be trapped by the modal.
-        quitConfirmed = true
-        // Stop the bundled server first (the same POST /admin/shutdown the
-        // killServer quit path uses), so the relaunched, updated app starts its
-        // own new-version server instead of reconnecting to the old one still
-        // bound to the TLS port. Best-effort and time-bounded: the install
-        // proceeds even if the server never confirms, so a stuck server can
-        // never trap the update.
-        postShutdown(5000).then { _ -> quitAndInstallUpdate() }
+        if (!isUpdateDownloaded()) {
+            // The renderer's state got ahead of reality (e.g. a stale renderer
+            // after a window rebuild). Refuse — rather than shut the server
+            // down for an install quitAndInstall would throw on — and surface
+            // the refusal in the banner so the button recovers.
+            reportUpdateError("No downloaded update to install — check for updates again")
+        } else {
+            // Installing an update is an already-confirmed quit. The window-close
+            // and before-quit gates route through the renderer quit-confirmation
+            // modal unless quitConfirmed is set, so mark it before handing off to
+            // Squirrel — otherwise the install-relaunch would be trapped by the modal.
+            quitConfirmed = true
+            // Stop the bundled server first (the same POST /admin/shutdown the
+            // killServer quit path uses), so the relaunched, updated app starts its
+            // own new-version server instead of reconnecting to the old one still
+            // bound to the TLS port. Best-effort and time-bounded: the install
+            // proceeds even if the server never confirms, so a stuck server can
+            // never trap the update.
+            postShutdown(5000).then { _ ->
+                quitAndInstallUpdate(onFailure = {
+                    // The app is still running (with its server now stopped);
+                    // re-arm the quit gate so the next quit intent is confirmed
+                    // normally instead of silently sailing through.
+                    quitConfirmed = false
+                })
+            }
+        }
         Unit
     }
 

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
@@ -799,6 +799,18 @@ private fun buildAppMenu() {
     val gitHubItem: dynamic = js("({})")
     gitHubItem.label = "Star on GitHub"
     gitHubItem.click = { shell.openExternal(LUNAMUX_GITHUB_URL) }
+    // "Check for Updates…" runs a check now (packaged builds only — a no-op in
+    // dev) and asks the renderer to open the Updates panel so the result is
+    // visible. See [AutoUpdater] / [UpdateChannels].
+    val updatesItem: dynamic = js("({})")
+    updatesItem.label = "Check for Updates…"
+    updatesItem.click = {
+        val w = mainWindow
+        if (w != null && !w.isDestroyed()) {
+            checkForUpdates()
+            w.webContents.send(UpdateChannels.SHOW_PANEL)
+        }
+    }
     val helpSeparator: dynamic = js("({ type: 'separator' })")
     val privacyItem: dynamic = js("({})")
     privacyItem.label = "Privacy Policy"
@@ -810,7 +822,7 @@ private fun buildAppMenu() {
     helpMenu.label = "Help"
     helpMenu.role = "help"
     helpMenu.submenu = arrayOf<dynamic>(
-        docsItem, websiteItem, forumItem, gitHubItem, helpSeparator,
+        docsItem, websiteItem, forumItem, gitHubItem, updatesItem, helpSeparator,
         privacyItem, termsItem,
     )
     template.add(helpMenu)
@@ -1590,6 +1602,10 @@ fun main() {
 
         ensureServerThenCreateWindow().then {
             if (!IS_DEV_LAUNCH) registerGlobalShortcut()
+            // Silent background update check on launch. Packaged builds only:
+            // checkForUpdates itself no-ops when unpackaged (dev/demo have no
+            // app-update.yml), but guarding here avoids the call entirely.
+            if (app.isPackaged) checkForUpdates()
         }
     }
 
@@ -1634,6 +1650,36 @@ fun main() {
         val url = urlArg as? String
         if (url.isNullOrBlank()) "Invalid URL"
         else shell.openExternal(url)
+    }
+
+    // Auto-update: bind electron-updater's lifecycle listeners once (they send
+    // to whatever the live main window is at fire time, so a window rebuild
+    // doesn't sever progress reporting), then expose the three renderer-driven
+    // controls. The Updates panel in the App Settings sidebar invokes these;
+    // lifecycle events flow back on the [UpdateChannels]. See [AutoUpdater].
+    initAutoUpdater { mainWindow }
+    ipcMain.handle(UpdateChannels.CHECK) { _, _ ->
+        checkForUpdates()
+        Unit
+    }
+    ipcMain.handle(UpdateChannels.DOWNLOAD) { _, _ ->
+        downloadUpdate()
+        Unit
+    }
+    ipcMain.handle(UpdateChannels.QUIT_AND_INSTALL) { _, _ ->
+        // Installing an update is an already-confirmed quit. The window-close
+        // and before-quit gates route through the renderer quit-confirmation
+        // modal unless quitConfirmed is set, so mark it before handing off to
+        // Squirrel — otherwise the install-relaunch would be trapped by the modal.
+        quitConfirmed = true
+        // Stop the bundled server first (the same POST /admin/shutdown the
+        // killServer quit path uses), so the relaunched, updated app starts its
+        // own new-version server instead of reconnecting to the old one still
+        // bound to the TLS port. Best-effort and time-bounded: the install
+        // proceeds even if the server never confirms, so a stuck server can
+        // never trap the update.
+        postShutdown(5000).then { _ -> quitAndInstallUpdate() }
+        Unit
     }
 
     app.on("will-quit") { _, _ -> globalShortcut.unregisterAll() }

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronMain.kt
@@ -799,15 +799,16 @@ private fun buildAppMenu() {
     val gitHubItem: dynamic = js("({})")
     gitHubItem.label = "Star on GitHub"
     gitHubItem.click = { shell.openExternal(LUNAMUX_GITHUB_URL) }
-    // "Check for Updates…" runs a check now (packaged builds only — a no-op in
-    // dev) and asks the renderer to open the Updates panel so the result is
-    // visible. See [AutoUpdater] / [UpdateChannels].
+    // "Check for Updates…" asks the renderer to run a user-initiated check; it
+    // fires the update:check IPC (after marking it user-initiated) so the outcome
+    // — checking / up-to-date / error — shows in the sidebar update banner rather
+    // than being silently swallowed. See [AutoUpdater] / [UpdateChannels] and
+    // AutoUpdaterPanel.triggerUserUpdateCheck.
     val updatesItem: dynamic = js("({})")
     updatesItem.label = "Check for Updates…"
     updatesItem.click = {
         val w = mainWindow
         if (w != null && !w.isDestroyed()) {
-            checkForUpdates()
             w.webContents.send(UpdateChannels.SHOW_PANEL)
         }
     }
@@ -1602,10 +1603,10 @@ fun main() {
 
         ensureServerThenCreateWindow().then {
             if (!IS_DEV_LAUNCH) registerGlobalShortcut()
-            // Silent background update check on launch. Packaged builds only:
-            // checkForUpdates itself no-ops when unpackaged (dev/demo have no
-            // app-update.yml), but guarding here avoids the call entirely.
-            if (app.isPackaged) checkForUpdates()
+            // The renderer fires the initial (silent) update check itself, from
+            // AutoUpdaterPanel.initAutoUpdaterListeners — after it has subscribed to
+            // the update events — so an update-available event can't be emitted
+            // before the renderer is listening (webContents.send doesn't buffer).
         }
     }
 

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronUpdaterExternals.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronUpdaterExternals.kt
@@ -1,0 +1,96 @@
+/* ElectronUpdaterExternals.kt
+ * Minimal `external` declarations for the `electron-updater` package's
+ * `autoUpdater` singleton — the only part of the library the Lunamux
+ * main process touches. Loaded as a CommonJS module via
+ * `@JsModule("electron-updater")`, mirroring the `@file:JsModule`
+ * convention used for the Electron API in [ElectronExternals.kt].
+ *
+ * The actual update lifecycle wiring (event listeners → renderer IPC,
+ * check/download/install control) lives in [AutoUpdater.kt]; this file only
+ * describes the JS surface.
+ */
+@file:JsModule("electron-updater")
+@file:JsNonModule
+
+package se.soderbjorn.lunamux.electron
+
+import kotlin.js.Promise
+
+/**
+ * The `electron-updater` `autoUpdater` singleton (a named export of the
+ * package). Resolves updates against the GitHub Releases `publish` provider
+ * baked into the app's `app-update.yml` at build time.
+ *
+ * Consumed only by [AutoUpdater.kt], which configures it, subscribes to its
+ * lifecycle events, and exposes check/download/install entry points to the
+ * rest of the main process.
+ *
+ * @see AutoUpdaterApi for the subset of methods/properties declared here.
+ */
+external val autoUpdater: AutoUpdaterApi
+
+/**
+ * The subset of electron-updater's `AppUpdater` surface the main process uses.
+ *
+ * Event payloads are intentionally left `dynamic`: [AutoUpdater.kt] reads only
+ * a couple of fields off them (`version`, `percent`, …) and forwards a
+ * hand-built plain object to the renderer, so pinning full electron-updater
+ * typings here would add surface with no benefit.
+ */
+external interface AutoUpdaterApi {
+    /**
+     * When `false`, an available update is not downloaded until
+     * [downloadUpdate] is called. Lunamux sets this so the user explicitly
+     * opts into the download from the Updates panel (mirrors the acolite flow).
+     */
+    var autoDownload: Boolean
+
+    /**
+     * When `true` (electron-updater's default), a downloaded-but-not-installed
+     * update is applied automatically on the next app quit. Left at its default.
+     */
+    var autoInstallOnAppQuit: Boolean
+
+    /**
+     * Checks the configured provider for a newer version. On a hit it emits
+     * `update-available`; otherwise `update-not-available`. Errors (e.g. the
+     * user being offline) surface via the `error` event and reject the promise.
+     *
+     * @return a promise resolving to the check result (shape unused here), or
+     *   rejecting on a network/config error.
+     */
+    fun checkForUpdates(): Promise<dynamic>
+
+    /**
+     * Downloads the update discovered by [checkForUpdates]. Emits
+     * `download-progress` events during transfer and `update-downloaded` on
+     * completion.
+     *
+     * @return a promise resolving when the download finishes.
+     */
+    fun downloadUpdate(): Promise<dynamic>
+
+    /**
+     * Quits the app and installs the downloaded update, then relaunches. Must
+     * only be called after `update-downloaded`. The caller is responsible for
+     * clearing any quit gate first (see the `quit:` IPC handler in [main]).
+     *
+     * @param isSilent on Windows, install without showing the installer UI.
+     * @param isForceRunAfter relaunch the app after a silent install.
+     */
+    fun quitAndInstall(isSilent: Boolean = definedExternally, isForceRunAfter: Boolean = definedExternally)
+
+    /**
+     * Subscribes to an update lifecycle event
+     * (`checking-for-update`, `update-available`, `update-not-available`,
+     * `download-progress`, `update-downloaded`, `error`).
+     *
+     * @param event the electron-updater event name.
+     * @param listener called with the event payload (`dynamic`; absent for
+     *   the no-arg events).
+     */
+    fun on(event: String, listener: (info: dynamic) -> Unit)
+
+    /** Detaches all previously-registered lifecycle listeners. */
+    fun removeAllListeners()
+}

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronUpdaterExternals.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/ElectronUpdaterExternals.kt
@@ -46,8 +46,11 @@ external interface AutoUpdaterApi {
     var autoDownload: Boolean
 
     /**
-     * When `true` (electron-updater's default), a downloaded-but-not-installed
-     * update is applied automatically on the next app quit. Left at its default.
+     * When `true` (electron-updater's default) a downloaded-but-not-installed
+     * update is applied automatically on the next app quit. Lunamux sets this
+     * `false` in [initAutoUpdater] so updates are **opt-in** — a downloaded update
+     * applies only when the user clicks "Restart to install", never silently on
+     * quit.
      */
     var autoInstallOnAppQuit: Boolean
 

--- a/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/NodeExternals.kt
+++ b/electron-main/src/jsMain/kotlin/se/soderbjorn/lunamux/electron/NodeExternals.kt
@@ -93,3 +93,12 @@ external interface NodeProcess {
 
 /** Node.js `__dirname` — absolute directory of the running module. */
 external val __dirname: String
+
+/**
+ * Node.js `setImmediate` — schedules [callback] to run at the end of the
+ * current event-loop turn. Used by [quitAndInstallUpdate] to defer the
+ * app teardown until after the triggering IPC reply has been delivered.
+ *
+ * @param callback invoked once, on the next event-loop tick.
+ */
+external fun setImmediate(callback: () -> Unit)

--- a/electron/build.gradle.kts
+++ b/electron/build.gradle.kts
@@ -270,5 +270,15 @@ abstract class JlinkTask : DefaultTask() {
                 "--output", out.absolutePath,
             )
         }
+        // jlink writes its `legal/` license files read-only (0444). When the
+        // packaged app is downloaded as an auto-update it carries the macOS
+        // quarantine xattr, and Squirrel.Mac's ShipIt strips that xattr from
+        // EVERY file before swapping the bundle — which fails with EPERM on a
+        // read-only file, so ShipIt aborts and silently relaunches the OLD
+        // version. Make the runtime user-writable so the attribute can be
+        // removed. macOS-only task (bundleJre is gated to Mac).
+        execOps.exec {
+            commandLine("chmod", "-R", "u+w", out.absolutePath)
+        }
     }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -7,7 +7,10 @@
   "private": true,
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder"
+    "dist": "electron-builder --publish never"
+  },
+  "dependencies": {
+    "electron-updater": "^6.3.9"
   },
   "devDependencies": {
     "electron": "^32.0.0",
@@ -37,11 +40,20 @@
       "buildResources": "icons",
       "output": "dist"
     },
+    "publish": {
+      "provider": "github",
+      "owner": "soderbjorn",
+      "repo": "lunamux",
+      "releaseType": "draft"
+    },
     "mac": {
-      "target": "dmg",
+      "target": [
+        "dmg",
+        "zip"
+      ],
       "category": "public.app-category.developer-tools",
       "bundleVersion": "12",
-      "bundleShortVersion": "1.8.0",
+      "bundleShortVersion": "1.9.0",
       "identity": "Robert Söderbjörn (CCJP95ZXG4)",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -374,6 +374,22 @@ contextBridge.exposeInMainWorld("electronApi", {
   respondQuitConfirmation: (result) =>
     ipcRenderer.invoke("quit-confirmation-result", result),
 
+  /**
+   * Subscribes to the "quit cancelled" event the main process sends when a
+   * confirmed kill-server quit is abandoned (the server shutdown failed and
+   * the user chose Cancel in the native dialog). The renderer suppressed its
+   * "Connection lost" modal when it confirmed that quit; on this event it
+   * must re-arm the modal, since the app keeps running.
+   *
+   * @param {() => void} handler - Called with no arguments on each event.
+   * @returns {() => void} Unsubscribe function.
+   */
+  onQuitCancelled: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("quit-cancelled", wrapped);
+    return () => ipcRenderer.removeListener("quit-cancelled", wrapped);
+  },
+
   // --- macOS native fullscreen state ---------------------------------------
 
   /**

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -505,9 +505,10 @@ contextBridge.exposeInMainWorld("electronApi", {
   },
 
   /**
-   * Subscribes to the "show updates panel" request the main process sends when
-   * the user picks "Check for Updates…" from the Help menu, so the renderer
-   * can open its Updates panel (App Settings sidebar).
+   * Subscribes to the request the main process sends when the user picks
+   * "Check for Updates…" from the Help menu. The renderer responds by running a
+   * user-initiated update check, whose result shows in the sidebar-footer update
+   * banner. (Channel name is historical — it no longer opens a panel.)
    *
    * @param {() => void} handler - Called with no arguments.
    * @returns {() => void} Unsubscribe function.

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -396,6 +396,127 @@ contextBridge.exposeInMainWorld("electronApi", {
     ipcRenderer.on("fullscreen-changed", wrapped);
     return () => ipcRenderer.removeListener("fullscreen-changed", wrapped);
   },
+
+  // --- Auto-update ---------------------------------------------------------
+  // Renderer-driven controls (invoke) + main-process lifecycle subscriptions
+  // (on). The channel strings match se.soderbjorn.lunamux.electron.UpdateChannels
+  // on the main side. Serviced by AutoUpdater.kt; consumed by the renderer's
+  // Updates panel (web/.../AutoUpdaterPanel.kt).
+
+  /**
+   * Asks the main process to check the release provider for a newer version.
+   * A no-op in dev/unpackaged builds. Results arrive via the `onUpdate*`
+   * subscriptions below. Called by the Updates panel on open and by the
+   * "Check for Updates…" Help-menu item (see {@link onShowUpdatesPanel}).
+   *
+   * @returns {Promise<void>}
+   */
+  checkForUpdates: () => ipcRenderer.invoke("update:check"),
+
+  /**
+   * Asks the main process to download the available update. Progress and
+   * completion arrive via {@link onUpdateProgress} / {@link onUpdateDownloaded}.
+   * Called by the Updates panel's "Download" button.
+   *
+   * @returns {Promise<void>}
+   */
+  downloadUpdate: () => ipcRenderer.invoke("update:download"),
+
+  /**
+   * Asks the main process to quit, install the downloaded update, and
+   * relaunch. Only meaningful after {@link onUpdateDownloaded} has fired.
+   * Called by the Updates panel's "Restart to install" button.
+   *
+   * @returns {Promise<void>}
+   */
+  quitAndInstall: () => ipcRenderer.invoke("update:quit-and-install"),
+
+  /**
+   * Subscribes to the "checking for updates" lifecycle event.
+   *
+   * @param {() => void} handler - Called with no arguments.
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateChecking: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("update:checking", wrapped);
+    return () => ipcRenderer.removeListener("update:checking", wrapped);
+  },
+
+  /**
+   * Subscribes to the "update available" event.
+   *
+   * @param {(info: { version?: string }) => void} handler - Receives the
+   *   available version info. The IPC event object is not leaked.
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateAvailable: (handler) => {
+    const wrapped = (_event, info) => handler(info || {});
+    ipcRenderer.on("update:available", wrapped);
+    return () => ipcRenderer.removeListener("update:available", wrapped);
+  },
+
+  /**
+   * Subscribes to the "no update available" event (app is up to date).
+   *
+   * @param {() => void} handler - Called with no arguments.
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateNotAvailable: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("update:not-available", wrapped);
+    return () => ipcRenderer.removeListener("update:not-available", wrapped);
+  },
+
+  /**
+   * Subscribes to download-progress events during an update download.
+   *
+   * @param {(progress: { percent?: number, transferred?: number, total?: number, bytesPerSecond?: number }) => void} handler
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateProgress: (handler) => {
+    const wrapped = (_event, progress) => handler(progress || {});
+    ipcRenderer.on("update:progress", wrapped);
+    return () => ipcRenderer.removeListener("update:progress", wrapped);
+  },
+
+  /**
+   * Subscribes to the "update downloaded / ready to install" event.
+   *
+   * @param {(info: { version?: string }) => void} handler
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateDownloaded: (handler) => {
+    const wrapped = (_event, info) => handler(info || {});
+    ipcRenderer.on("update:downloaded", wrapped);
+    return () => ipcRenderer.removeListener("update:downloaded", wrapped);
+  },
+
+  /**
+   * Subscribes to update error events (e.g. the download failed).
+   *
+   * @param {(error: { message?: string }) => void} handler
+   * @returns {() => void} Unsubscribe function.
+   */
+  onUpdateError: (handler) => {
+    const wrapped = (_event, error) => handler(error || {});
+    ipcRenderer.on("update:error", wrapped);
+    return () => ipcRenderer.removeListener("update:error", wrapped);
+  },
+
+  /**
+   * Subscribes to the "show updates panel" request the main process sends when
+   * the user picks "Check for Updates…" from the Help menu, so the renderer
+   * can open its Updates panel (App Settings sidebar).
+   *
+   * @param {() => void} handler - Called with no arguments.
+   * @returns {() => void} Unsubscribe function.
+   */
+  onShowUpdatesPanel: (handler) => {
+    const wrapped = () => handler();
+    ipcRenderer.on("show-updates-panel", wrapped);
+    return () => ipcRenderer.removeListener("show-updates-panel", wrapped);
+  },
 });
 
 /**

--- a/scripts/release-electron.sh
+++ b/scripts/release-electron.sh
@@ -21,7 +21,9 @@
 #   --repo <owner/repo>  Target GitHub repo. Default: soderbjorn/lunamux.
 #                        In a test build (see below) this ALSO sets the publish
 #                        provider baked into app-update.yml, so the built app
-#                        checks that repo for updates.
+#                        checks that repo for updates. Test builds REFUSE to
+#                        publish to the production repo — point this at a fork
+#                        (or use --no-publish).
 #   --identity <name>    Sign with this macOS code-signing identity instead of
 #                        the production Developer ID, and skip notarization.
 #                        Use a free self-signed "Code Signing" cert from Keychain
@@ -57,8 +59,13 @@ set -euo pipefail
 shopt -s nullglob
 
 # ── Args ─────────────────────────────────────────────────────────────
+# The real release target. Test builds may never publish here (see the guard
+# after arg parsing): a self-signed draft — or worse, a --clobber onto an
+# existing production tag — must not be one forgotten --repo away.
+PROD_REPO="soderbjorn/lunamux"
+
 VERSION=""
-REPO="soderbjorn/lunamux"
+REPO="$PROD_REPO"
 IDENTITY=""
 NO_NOTARIZE=0
 NO_PUBLISH=0
@@ -68,7 +75,10 @@ while [[ $# -gt 0 ]]; do
         --identity) IDENTITY="$2"; shift 2 ;;
         --no-notarize) NO_NOTARIZE=1; shift ;;
         --no-publish) NO_PUBLISH=1; shift ;;
-        -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
+        # Print the header comment block (everything up to the first non-#
+        # line), stripped of the leading "# " — robust to the header growing,
+        # unlike a fixed line range.
+        -h|--help) awk 'NR>1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
         -*) echo "Unknown option: $1" >&2; exit 2 ;;
         *) if [[ -z "$VERSION" ]]; then VERSION="$1"; shift; else echo "Unexpected arg: $1" >&2; exit 2; fi ;;
     esac
@@ -90,6 +100,16 @@ TAG="v$VERSION"
 # A test build = anything not signed + notarized with the production Developer ID.
 TEST_BUILD=0
 if [[ -n "$IDENTITY" || "$NO_NOTARIZE" == "1" ]]; then TEST_BUILD=1; fi
+
+# Never let a test build near the production repo's releases. Without this, a
+# forgotten --repo on a fork-test run would upload self-signed artifacts to
+# $PROD_REPO — and, if the tag already existed, --clobber them over real ones.
+if [[ $TEST_BUILD == 1 && $NO_PUBLISH == 0 && "$REPO" == "$PROD_REPO" ]]; then
+    echo "error: refusing to publish a TEST build (--identity / --no-notarize) to $PROD_REPO." >&2
+    echo "       Pass --repo <owner/repo> pointing at your fork, or --no-publish for a" >&2
+    echo "       local-only build." >&2
+    exit 2
+fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 ROOT="$(pwd)"
@@ -197,7 +217,15 @@ if [[ $TEST_BUILD == 0 ]]; then
     : "${APPLE_ID_PERSONAL:?set APPLE_ID_PERSONAL for notarization}"
     : "${APPLE_APP_SPECIFIC_PASSWORD_PERSONAL:?set APPLE_APP_SPECIFIC_PASSWORD_PERSONAL}"
     : "${APPLE_TEAM_ID_PERSONAL:?set APPLE_TEAM_ID_PERSONAL}"
-    DMG="$(ls -t "$DIST"/Lunamux-*.dmg | head -1)"
+    # dist/ is wiped at the top of every run, so exactly one DMG exists. Guard
+    # anyway: under nullglob an empty match would otherwise hand `ls -t` zero
+    # args and it would happily pick the newest file of the CURRENT DIRECTORY.
+    DMGS=( "$DIST"/Lunamux-*.dmg )
+    if [[ ${#DMGS[@]} -ne 1 ]]; then
+        echo "error: expected exactly one Lunamux-*.dmg in $DIST, found ${#DMGS[@]}." >&2
+        exit 1
+    fi
+    DMG="${DMGS[0]}"
     IDENTITY_FULL="Developer ID Application: Robert Söderbjörn (CCJP95ZXG4)"
     echo "==> Signing + notarizing + stapling DMG container: $(basename "$DMG")"
     codesign --force --timestamp --sign "$IDENTITY_FULL" "$DMG"
@@ -207,6 +235,42 @@ if [[ $TEST_BUILD == 0 ]]; then
         --team-id "$APPLE_TEAM_ID_PERSONAL" --wait
     xcrun stapler staple "$DMG"
     xcrun stapler validate "$DMG"
+
+    # Signing + stapling just rewrote the DMG, but electron-builder computed
+    # latest-mac.yml's dmg sha512/size from the pre-staple bytes. macOS
+    # auto-update downloads the zip (untouched above), so the stale hash is
+    # latent — but a manifest that misdescribes an asset it lists is a landmine
+    # (it breaks the moment anything validates the dmg entry), so refresh it.
+    # The dmg .blockmap is left as-is deliberately: it only serves dmg
+    # differential downloads, which the macOS updater never performs.
+    DMG_PATH="$DMG" node -e '
+      const fs = require("fs"), path = require("path"), crypto = require("crypto");
+      const dmg = process.env.DMG_PATH;
+      const yml = path.join(path.dirname(dmg), "latest-mac.yml");
+      const name = path.basename(dmg);
+      const sha512 = crypto.createHash("sha512").update(fs.readFileSync(dmg)).digest("base64");
+      const size = fs.statSync(dmg).size;
+      const lines = fs.readFileSync(yml, "utf8").split("\n");
+      let inDmgEntry = false, patched = 0;
+      for (let i = 0; i < lines.length; i++) {
+        const l = lines[i];
+        const url = l.match(/^\s*-\s+url:\s*(.+?)\s*$/);
+        if (url) { inDmgEntry = url[1] === name; continue; }
+        // Top-level `path:` names the primary artifact (the zip on macOS); its
+        // following top-level sha512 is patched only if it names the dmg.
+        const top = l.match(/^path:\s*(.+?)\s*$/);
+        if (top) { inDmgEntry = top[1] === name; continue; }
+        if (!inDmgEntry) continue;
+        if (/^\s*sha512:/.test(l)) { lines[i] = l.replace(/sha512:.*/, "sha512: " + sha512); patched++; }
+        else if (/^\s*size:/.test(l)) { lines[i] = l.replace(/size:.*/, "size: " + size); patched++; }
+      }
+      if (patched === 0) {
+        console.error("error: latest-mac.yml has no entry for " + name + " — refusing to publish a stale manifest.");
+        process.exit(1);
+      }
+      fs.writeFileSync(yml, lines.join("\n"));
+      console.error("==> Refreshed " + patched + " latest-mac.yml field(s) for " + name + " after stapling.");
+    '
 fi
 
 # Build-only: stop before publishing (fast local build → install loops).
@@ -221,14 +285,31 @@ fi
 
 # ── 4. Publish the draft release with ALL update metadata ────────────
 # The fixed glob is the whole point: dmg + zip + latest-mac.yml + every .blockmap,
-# so nothing electron-updater needs can be forgotten.
-ASSETS=( "$DIST"/*.dmg "$DIST"/*.zip "$DIST"/*.blockmap "$DIST"/latest-mac.yml )
+# so nothing electron-updater needs can be forgotten. nullglob would silently
+# drop an entire missing class from the upload — defeating that guarantee — so
+# assert each artifact kind actually exists before building the list.
+DMG_ASSETS=( "$DIST"/*.dmg )
+ZIP_ASSETS=( "$DIST"/*.zip )
+BLOCKMAP_ASSETS=( "$DIST"/*.blockmap )
+[[ ${#DMG_ASSETS[@]} -gt 0 ]] || { echo "error: no .dmg in $DIST." >&2; exit 1; }
+[[ ${#ZIP_ASSETS[@]} -gt 0 ]] || { echo "error: no .zip in $DIST — macOS electron-updater updates from the zip." >&2; exit 1; }
+[[ ${#BLOCKMAP_ASSETS[@]} -gt 0 ]] || { echo "error: no .blockmap in $DIST — differential updates need them." >&2; exit 1; }
+ASSETS=( "${DMG_ASSETS[@]}" "${ZIP_ASSETS[@]}" "${BLOCKMAP_ASSETS[@]}" "$DIST/latest-mac.yml" )
 echo "==> Uploading ${#ASSETS[@]} assets to $REPO draft release $TAG:"
 for a in "${ASSETS[@]}"; do echo "      $(basename "$a")"; done
 
 NOTES="Automated draft for $TAG. Review, then Publish to release the update to clients."
-if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-    echo "==> Release $TAG already exists — clobbering assets."
+if IS_DRAFT="$(gh release view "$TAG" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null)"; then
+    # Overwrite assets only while the release is still an unreviewed draft. A
+    # PUBLISHED release's assets are live for clients (possibly mid-download);
+    # clobbering them in place could hand out a zip that no longer matches the
+    # published latest-mac.yml. Cut a new version instead.
+    if [[ "$IS_DRAFT" != "true" ]]; then
+        echo "error: release $TAG on $REPO is already PUBLISHED — refusing to overwrite its assets." >&2
+        echo "       Cut a new version instead." >&2
+        exit 1
+    fi
+    echo "==> Draft release $TAG already exists — clobbering assets."
     gh release upload "$TAG" --repo "$REPO" --clobber "${ASSETS[@]}"
 else
     gh release create "$TAG" --repo "$REPO" --draft --title "$TAG" --notes "$NOTES" "${ASSETS[@]}"

--- a/scripts/release-electron.sh
+++ b/scripts/release-electron.sh
@@ -32,6 +32,11 @@
 #   --no-notarize        Build unsigned (identity=null) and skip notarization.
 #                        Implies a test build. (Unsigned macOS apps cannot
 #                        auto-update; prefer --identity for update testing.)
+#   --no-publish         Build locally only — skip creating/uploading the GitHub
+#                        release. For fast local build → install test loops (e.g.
+#                        iterating on the app or the update banner) without
+#                        creating a release each time. Artifacts stay in
+#                        electron/dist/ for you to install by hand.
 #
 # Production build (no --identity / --no-notarize): signs + notarizes with the
 # maintainer's Developer ID (from electron/package.json) and staples the DMG,
@@ -56,12 +61,14 @@ VERSION=""
 REPO="soderbjorn/lunamux"
 IDENTITY=""
 NO_NOTARIZE=0
+NO_PUBLISH=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --repo) REPO="$2"; shift 2 ;;
         --identity) IDENTITY="$2"; shift 2 ;;
         --no-notarize) NO_NOTARIZE=1; shift ;;
-        -h|--help) sed -n '2,50p' "$0"; exit 0 ;;
+        --no-publish) NO_PUBLISH=1; shift ;;
+        -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
         -*) echo "Unknown option: $1" >&2; exit 2 ;;
         *) if [[ -z "$VERSION" ]]; then VERSION="$1"; shift; else echo "Unexpected arg: $1" >&2; exit 2; fi ;;
     esac
@@ -187,6 +194,16 @@ if [[ $TEST_BUILD == 0 ]]; then
         --team-id "$APPLE_TEAM_ID_PERSONAL" --wait
     xcrun stapler staple "$DMG"
     xcrun stapler validate "$DMG"
+fi
+
+# Build-only: stop before publishing (fast local build → install loops).
+if [[ $NO_PUBLISH == 1 ]]; then
+    echo
+    echo "==> Built locally (--no-publish); no GitHub release created."
+    echo "    Artifacts in $DIST:"
+    for a in "$DIST"/*.dmg "$DIST"/*.zip; do [[ -e "$a" ]] && echo "      $(basename "$a")"; done
+    echo "    Install the .dmg to test the app / update banner."
+    exit 0
 fi
 
 # ── 4. Publish the draft release with ALL update metadata ────────────

--- a/scripts/release-electron.sh
+++ b/scripts/release-electron.sh
@@ -94,6 +94,19 @@ if [[ -n "$IDENTITY" || "$NO_NOTARIZE" == "1" ]]; then TEST_BUILD=1; fi
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 ROOT="$(pwd)"
 
+# Restore electron/package.json unless we reach a successful PRODUCTION publish, so
+# a failed build, a --no-publish local build, or a fork test publish never leaves
+# the version fields churned (which would double-bump on the next run). KEEP_BUMP
+# flips to 1 only for a real release, where the bump is meant to be committed.
+KEEP_BUMP=0
+PKG_BACKUP="$(mktemp)"
+cp "$ROOT/electron/package.json" "$PKG_BACKUP"
+restore_pkg() {
+    if [[ $KEEP_BUMP -eq 0 ]]; then cp "$PKG_BACKUP" "$ROOT/electron/package.json"; fi
+    rm -f "$PKG_BACKUP"
+}
+trap restore_pkg EXIT
+
 echo "==> Releasing $TAG to $REPO ($([[ $TEST_BUILD == 1 ]] && echo 'TEST build' || echo 'production build'))"
 
 # ── 1. Stamp the version (single source of truth) ────────────────────
@@ -220,6 +233,10 @@ if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
 else
     gh release create "$TAG" --repo "$REPO" --draft --title "$TAG" --notes "$NOTES" "${ASSETS[@]}"
 fi
+
+# A real release is published: keep the version bump (the trap won't revert it) so
+# it can be committed. Test/fork publishes leave package.json untouched.
+if [[ $TEST_BUILD == 0 ]]; then KEEP_BUMP=1; fi
 
 echo
 echo "==> Done. Draft release: https://github.com/$REPO/releases"

--- a/scripts/release-electron.sh
+++ b/scripts/release-electron.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Cut a Lunamux desktop release and publish it — with all the electron-updater
+# metadata — to a GitHub DRAFT release in one command.
+#
+# Why this exists: electron-updater needs `latest-mac.yml` and the per-artifact
+# `.blockmap` files uploaded ALONGSIDE the installer. Doing GitHub releases by
+# hand, a human eventually forgets one of those and silently breaks auto-update
+# for everyone. This script builds locally (no CI — mac CI is slow/expensive),
+# then uploads a fixed GLOB of every required file, so the metadata can never be
+# left out. It always publishes as a DRAFT: a human reviews it in the GitHub UI
+# and clicks Publish, which is when clients start seeing the update.
+#
+# Usage:
+#   scripts/release-electron.sh <version> [options]
+#
+#   <version>            Semver to release, e.g. 1.9.1. Stamped into
+#                        electron/package.json (version + mac.bundleShortVersion)
+#                        and the integer mac.bundleVersion is bumped by one.
+#
+# Options:
+#   --repo <owner/repo>  Target GitHub repo. Default: soderbjorn/lunamux.
+#                        In a test build (see below) this ALSO sets the publish
+#                        provider baked into app-update.yml, so the built app
+#                        checks that repo for updates.
+#   --identity <name>    Sign with this macOS code-signing identity instead of
+#                        the production Developer ID, and skip notarization.
+#                        Use a free self-signed "Code Signing" cert from Keychain
+#                        to test the auto-update loop without an Apple Developer
+#                        ID — Squirrel.Mac only requires the running app and the
+#                        update to share a signing identity (a MATCH), not
+#                        notarization. Implies a test build.
+#   --no-notarize        Build unsigned (identity=null) and skip notarization.
+#                        Implies a test build. (Unsigned macOS apps cannot
+#                        auto-update; prefer --identity for update testing.)
+#
+# Production build (no --identity / --no-notarize): signs + notarizes with the
+# maintainer's Developer ID (from electron/package.json) and staples the DMG,
+# exactly like build-release-electron.sh. Requires the notarization creds in
+# APPLE_ID_PERSONAL / APPLE_APP_SPECIFIC_PASSWORD_PERSONAL / APPLE_TEAM_ID_PERSONAL.
+#
+# Examples:
+#   # Production draft release to soderbjorn/lunamux:
+#   scripts/release-electron.sh 1.9.1
+#
+#   # Self-signed test release to your fork, to exercise the update loop:
+#   scripts/release-electron.sh 1.9.1 --repo ottojaa/lunamux \
+#       --identity "Lunamux Test Signing"
+#
+# Publishing (upload) uses the `gh` CLI, so `gh auth login` must be done and the
+# token must have write access to the target repo.
+set -euo pipefail
+shopt -s nullglob
+
+# ── Args ─────────────────────────────────────────────────────────────
+VERSION=""
+REPO="soderbjorn/lunamux"
+IDENTITY=""
+NO_NOTARIZE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --identity) IDENTITY="$2"; shift 2 ;;
+        --no-notarize) NO_NOTARIZE=1; shift ;;
+        -h|--help) sed -n '2,50p' "$0"; exit 0 ;;
+        -*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *) if [[ -z "$VERSION" ]]; then VERSION="$1"; shift; else echo "Unexpected arg: $1" >&2; exit 2; fi ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "error: <version> is required (e.g. 1.9.1). See --help." >&2
+    exit 2
+fi
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version '$VERSION' is not semver X.Y.Z." >&2
+    exit 2
+fi
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+TAG="v$VERSION"
+
+# A test build = anything not signed + notarized with the production Developer ID.
+TEST_BUILD=0
+if [[ -n "$IDENTITY" || "$NO_NOTARIZE" == "1" ]]; then TEST_BUILD=1; fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+ROOT="$(pwd)"
+
+echo "==> Releasing $TAG to $REPO ($([[ $TEST_BUILD == 1 ]] && echo 'TEST build' || echo 'production build'))"
+
+# ── 1. Stamp the version (single source of truth) ────────────────────
+# electron-updater compares app.getVersion() (== mac.bundleShortVersion on macOS)
+# against latest-mac.yml's version (== package.json version), so these MUST match.
+VERSION="$VERSION" node -e '
+  const fs = require("fs");
+  const p = "electron/package.json";
+  const j = JSON.parse(fs.readFileSync(p, "utf8"));
+  const v = process.env.VERSION;
+  j.version = v;
+  j.build.mac.bundleShortVersion = v;
+  j.build.mac.bundleVersion = String((parseInt(j.build.mac.bundleVersion, 10) || 0) + 1);
+  fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+  console.error(`==> Stamped version=${v}, bundleShortVersion=${v}, bundleVersion=${j.build.mac.bundleVersion}`);
+'
+
+# ── 2. Build ─────────────────────────────────────────────────────────
+# The mac target is dmg+zip and the publish provider is set (electron/package.json),
+# so electron-builder emits latest-mac.yml + .blockmap files into electron/dist/.
+rm -rf electron/dist
+
+if [[ $TEST_BUILD == 0 ]]; then
+    # Production: the proven signed + notarized path. `:electron:dist` runs the
+    # native-signing staging tasks then electron-builder (which signs, notarizes,
+    # and staples the .app). app-update.yml is baked from the package.json publish
+    # config (soderbjorn/lunamux).
+    if [[ "$REPO" != "soderbjorn/lunamux" ]]; then
+        echo "WARNING: production build bakes app-update.yml from package.json" >&2
+        echo "         (soderbjorn/lunamux), but you're uploading to $REPO — the" >&2
+        echo "         installed app would check soderbjorn/lunamux, not $REPO." >&2
+        echo "         For a fork test build, pass --identity so the repo override" >&2
+        echo "         is applied to app-update.yml too." >&2
+    fi
+    ./gradlew --no-daemon :electron:dist
+else
+    # Test: stage without native signing (mirrors build-electron-no-notarize.sh),
+    # then run electron-builder directly with the overrides. -c.publish.owner/repo
+    # bakes the fork into app-update.yml so the built app checks it.
+    ./gradlew --no-daemon \
+        :electron:npmInstall \
+        :electron:copyServerJar \
+        :electron:bundleJre \
+        :electron:copyMainBundle
+
+    EB_ARGS=(
+        -c.publish.owner="$OWNER"
+        -c.publish.repo="$REPO_NAME"
+        -c.mac.notarize=false
+        # Self-signed / unsigned apps can't satisfy hardened-runtime nested-signing
+        # expectations; turn it off so the test build launches and Squirrel.Mac can
+        # apply the update (it checks the signature MATCH, not hardened runtime).
+        -c.mac.hardenedRuntime=false
+    )
+    if [[ -n "$IDENTITY" ]]; then
+        EB_ARGS+=(-c.mac.identity="$IDENTITY")
+    else
+        EB_ARGS+=(-c.mac.identity=null)
+    fi
+
+    cd electron
+    if [[ -z "$IDENTITY" ]]; then
+        CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "${EB_ARGS[@]}" --publish never
+    else
+        ./node_modules/.bin/electron-builder "${EB_ARGS[@]}" --publish never
+    fi
+    cd "$ROOT"
+fi
+
+DIST="$ROOT/electron/dist"
+
+# electron-updater is useless without this file; fail loudly if the build didn't
+# produce it (usually means the mac `zip` target or the publish config is missing).
+if [[ ! -f "$DIST/latest-mac.yml" ]]; then
+    echo "error: $DIST/latest-mac.yml was not generated — electron-updater needs it." >&2
+    echo "       Check that electron/package.json has mac.target including 'zip' and" >&2
+    echo "       a 'publish' block." >&2
+    exit 1
+fi
+
+# ── 3. Staple the DMG container (production only) ─────────────────────
+# electron-builder signs/notarizes/staples the .app (inside both dmg and zip) but
+# leaves the DMG *container* unsigned, so a downloaded DMG hits Gatekeeper
+# friction. Apple's DMG workflow is sign -> notarize -> staple. (The auto-update
+# path uses the zip, whose .app is already stapled, so this is only for the
+# first-install DMG download.)
+if [[ $TEST_BUILD == 0 ]]; then
+    : "${APPLE_ID_PERSONAL:?set APPLE_ID_PERSONAL for notarization}"
+    : "${APPLE_APP_SPECIFIC_PASSWORD_PERSONAL:?set APPLE_APP_SPECIFIC_PASSWORD_PERSONAL}"
+    : "${APPLE_TEAM_ID_PERSONAL:?set APPLE_TEAM_ID_PERSONAL}"
+    DMG="$(ls -t "$DIST"/Lunamux-*.dmg | head -1)"
+    IDENTITY_FULL="Developer ID Application: Robert Söderbjörn (CCJP95ZXG4)"
+    echo "==> Signing + notarizing + stapling DMG container: $(basename "$DMG")"
+    codesign --force --timestamp --sign "$IDENTITY_FULL" "$DMG"
+    xcrun notarytool submit "$DMG" \
+        --apple-id "$APPLE_ID_PERSONAL" \
+        --password "$APPLE_APP_SPECIFIC_PASSWORD_PERSONAL" \
+        --team-id "$APPLE_TEAM_ID_PERSONAL" --wait
+    xcrun stapler staple "$DMG"
+    xcrun stapler validate "$DMG"
+fi
+
+# ── 4. Publish the draft release with ALL update metadata ────────────
+# The fixed glob is the whole point: dmg + zip + latest-mac.yml + every .blockmap,
+# so nothing electron-updater needs can be forgotten.
+ASSETS=( "$DIST"/*.dmg "$DIST"/*.zip "$DIST"/*.blockmap "$DIST"/latest-mac.yml )
+echo "==> Uploading ${#ASSETS[@]} assets to $REPO draft release $TAG:"
+for a in "${ASSETS[@]}"; do echo "      $(basename "$a")"; done
+
+NOTES="Automated draft for $TAG. Review, then Publish to release the update to clients."
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+    echo "==> Release $TAG already exists — clobbering assets."
+    gh release upload "$TAG" --repo "$REPO" --clobber "${ASSETS[@]}"
+else
+    gh release create "$TAG" --repo "$REPO" --draft --title "$TAG" --notes "$NOTES" "${ASSETS[@]}"
+fi
+
+echo
+echo "==> Done. Draft release: https://github.com/$REPO/releases"
+echo "    Review the draft and click Publish; clients update only once it is published."
+if [[ $TEST_BUILD == 0 ]]; then
+    echo "    Remember to commit the version bump in electron/package.json ($TAG)."
+fi

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AppSettingsContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AppSettingsContent.kt
@@ -558,6 +558,9 @@ fun buildAppSettingsContent(): HTMLElement {
 
     container.appendChild(buildNavigationSection())
     container.appendChild(buildGeneralSection())
+    // Auto-update controls — Electron desktop only (electron-updater lives in the
+    // main process; a plain browser has no updater to drive). See AutoUpdaterPanel.kt.
+    if (isElectronClient) container.appendChild(buildUpdatesSection())
     container.appendChild(buildOverview3dSection())
     container.appendChild(buildWorld3dSection())
     container.appendChild(buildExperimentalSection())

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AppSettingsContent.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AppSettingsContent.kt
@@ -558,9 +558,6 @@ fun buildAppSettingsContent(): HTMLElement {
 
     container.appendChild(buildNavigationSection())
     container.appendChild(buildGeneralSection())
-    // Auto-update controls — Electron desktop only (electron-updater lives in the
-    // main process; a plain browser has no updater to drive). See AutoUpdaterPanel.kt.
-    if (isElectronClient) container.appendChild(buildUpdatesSection())
     container.appendChild(buildOverview3dSection())
     container.appendChild(buildWorld3dSection())
     container.appendChild(buildExperimentalSection())

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
@@ -17,7 +17,9 @@
  * The initial (silent) check is fired by the renderer itself in
  * [initAutoUpdaterListeners], *after* it has subscribed, so the main process can
  * never emit `update-available` before the renderer is listening
- * (`webContents.send` does not buffer). [triggerUserUpdateCheck] backs the
+ * (`webContents.send` does not buffer). The same function arms a slow periodic
+ * re-check ([UPDATE_RECHECK_INTERVAL_MS]) so a long-running app still learns of
+ * new releases without a relaunch. [triggerUserUpdateCheck] backs the
  * "Check for Updates…" Help-menu item.
  *
  * All entry points are safe outside Electron: they no-op when the `electronApi`
@@ -81,6 +83,15 @@ private data class UpdaterUiState(
     val releaseNotesUrl: String? = null,
 )
 
+/**
+ * How often the silent periodic re-check runs (4 hours). Lunamux is a terminal
+ * app that stays open for days or weeks, so the single launch check alone would
+ * leave long-running sessions permanently unaware of new releases. Silent like
+ * the launch check: only an actionable outcome (update available) surfaces the
+ * banner. See the interval armed in [initAutoUpdaterListeners].
+ */
+private const val UPDATE_RECHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
+
 /** The live updater state, updated by the events wired in [initAutoUpdaterListeners]. */
 private var updaterState = UpdaterUiState()
 
@@ -140,12 +151,33 @@ fun initAutoUpdaterListeners() {
         ))
     })
     api.onUpdateError({ err: dynamic ->
+        // If this error follows a "Restart to install" click, the app is still
+        // running after we suppressed the "Connection lost" modal in
+        // anticipation of the teardown — re-arm it and re-evaluate, so a server
+        // that WAS shut down before the install failed surfaces as disconnected
+        // instead of dying silently. No-op when nothing was suppressed.
+        if (suppressDisconnectedModal) {
+            suppressDisconnectedModal = false
+            updateAggregateStatus()
+        }
         setUpdaterState(UpdaterUiState(UpdaterStatus.ERROR, message = err?.message as? String))
     })
 
     // Silent initial check, fired only now that we're subscribed. Not user-initiated,
     // so a "nothing new" / offline result leaves the banner hidden.
     if (api.checkForUpdates != null) api.checkForUpdates()
+
+    // Slow periodic re-check (silent, like the launch check) so an app left
+    // open for weeks still learns of new releases. Skipped while an update flow
+    // is in progress: re-checking then would re-emit update-available and
+    // downgrade a DOWNLOADED banner back to "Download".
+    window.setInterval({
+        val s = updaterState.status
+        val busy = s == UpdaterStatus.CHECKING ||
+            s == UpdaterStatus.DOWNLOADING ||
+            s == UpdaterStatus.DOWNLOADED
+        if (!busy && api.checkForUpdates != null) api.checkForUpdates()
+    }, UPDATE_RECHECK_INTERVAL_MS)
 }
 
 /**
@@ -280,6 +312,11 @@ fun buildUpdateBanner(): HTMLElement {
         banner.style.setProperty("display", if (visible) "flex" else "none")
         if (!visible) return
         currentNotesUrl = s.releaseNotesUrl
+        // The "Restart to install" click disables the button optimistically
+        // (the pre-install server shutdown takes a few seconds). Every rendered
+        // state re-enables it, so a failed install's ERROR → "Try again" is
+        // actually clickable instead of inheriting the dead button.
+        (actionBtn.asDynamic()).disabled = false
 
         val showBody = s.status == UpdaterStatus.AVAILABLE ||
             s.status == UpdaterStatus.DOWNLOADED ||
@@ -326,7 +363,10 @@ fun buildUpdateBanner(): HTMLElement {
                 leftEl.textContent = s.message ?: "Something went wrong"
                 actionBtn.textContent = "Try again"
             }
-            else -> {}
+            // IDLE / NOT_AVAILABLE can't reach here: the visibility early-return
+            // above filters them out, which the compiler tracks through `visible`
+            // (so an `else` branch would be flagged as redundant).
+            UpdaterStatus.IDLE, UpdaterStatus.NOT_AVAILABLE -> {}
         }
     }
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
@@ -1,0 +1,305 @@
+/**
+ * AutoUpdaterPanel.kt
+ * -------------------
+ * Renderer half of the Lunamux desktop auto-updater (Electron only).
+ *
+ * The Electron main process drives electron-updater (see the `electron-main`
+ * module's `AutoUpdater.kt`) and forwards each lifecycle event to the renderer
+ * over the preload bridge (`window.electronApi.onUpdate*`). This file:
+ *
+ *  - keeps a tiny [UpdaterUiState] state machine fed by those events
+ *    ([initAutoUpdaterListeners]),
+ *  - renders it as an **"Updates" section** in the App Settings sidebar
+ *    ([buildUpdatesSection], registered from
+ *    [buildAppSettingsContent]) with a status line, a download progress bar,
+ *    and a single primary button (Check / Download / Restart), and
+ *  - reflects "an update is pending" onto the existing top-bar bell (reusing
+ *    [electronUpdatePending] / [applyNewsTopbarIcon] in NewsLabel.kt) and opens
+ *    the panel on demand ([openUpdatesPanel] — used by the bell click and the
+ *    "Check for Updates…" Help-menu item).
+ *
+ * All entry points are safe to call outside Electron: they no-op when the
+ * `electronApi` bridge (or its updater methods) is absent, and the section is
+ * only appended for [isElectronClient].
+ *
+ * @see initAutoUpdaterListeners
+ * @see buildUpdatesSection
+ * @see openUpdatesPanel
+ */
+package se.soderbjorn.lunamux
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import kotlin.math.roundToInt
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.Event
+
+/** DOM id of the Updates section, so [openUpdatesPanel] can scroll it into view. */
+private const val UPDATES_SECTION_ID = "lunamux-updates-section"
+
+/**
+ * The phases of an update, mirroring electron-updater's lifecycle events. Drives
+ * the status text and which action the primary button performs.
+ */
+private enum class UpdaterStatus {
+    /** No check has run yet this session. */
+    IDLE,
+
+    /** A check is in flight. */
+    CHECKING,
+
+    /** A newer version exists and can be downloaded. */
+    AVAILABLE,
+
+    /** The update is downloading. */
+    DOWNLOADING,
+
+    /** The update finished downloading and can be installed. */
+    DOWNLOADED,
+
+    /** The last check found the app already up to date. */
+    NOT_AVAILABLE,
+
+    /** The last operation failed. */
+    ERROR,
+}
+
+/**
+ * Immutable snapshot of the updater UI.
+ *
+ * @property status the current lifecycle phase.
+ * @property version the target version, when known (available/downloaded).
+ * @property percent download progress 0..100, when downloading.
+ * @property message an error message, when [status] is [UpdaterStatus.ERROR].
+ */
+private data class UpdaterUiState(
+    val status: UpdaterStatus = UpdaterStatus.IDLE,
+    val version: String? = null,
+    val percent: Double? = null,
+    val message: String? = null,
+)
+
+/** The live updater state, updated by the events wired in [initAutoUpdaterListeners]. */
+private var updaterState = UpdaterUiState()
+
+/**
+ * The mounted panel's re-render callback, or `null` when the Updates section is
+ * not currently in the DOM. Set by [buildUpdatesSection] each time the sidebar
+ * body is (re)built; only one App Settings sidebar exists at a time, so a single
+ * slot suffices. Updates to a since-detached panel are harmless no-ops.
+ */
+private var panelRender: ((UpdaterUiState) -> Unit)? = null
+
+/** Guards one-time event subscription in [initAutoUpdaterListeners]. */
+private var listenersInitialized = false
+
+/**
+ * Whether the current (or most recent) update lifecycle was started by an
+ * explicit user gesture — the panel's button or the "Check for Updates…" menu —
+ * as opposed to the silent check at launch. [setUpdaterState] suppresses the
+ * non-actionable phases (checking / up-to-date / error) unless this is set, so a
+ * silent startup check never plants a stale resting state in the panel.
+ * Available/downloading/downloaded are always surfaced regardless.
+ */
+private var userInitiatedAction = false
+
+/**
+ * Subscribe once to the main process's update lifecycle events and route them
+ * into [updaterState] (+ the bell + any mounted panel).
+ *
+ * Called from `main.kt`'s startup inside the `isElectronClient` branch. No-ops
+ * when the `electronApi` bridge or its updater methods are absent (a plain
+ * browser, or an older preload), so it is always safe to call.
+ */
+fun initAutoUpdaterListeners() {
+    if (listenersInitialized) return
+    val api = window.asDynamic().electronApi ?: return
+    if (api.onUpdateAvailable == null) return
+    listenersInitialized = true
+
+    api.onUpdateChecking({ setUpdaterState(UpdaterUiState(UpdaterStatus.CHECKING)) })
+    api.onUpdateAvailable({ info: dynamic ->
+        setUpdaterState(UpdaterUiState(UpdaterStatus.AVAILABLE, version = info?.version as? String))
+    })
+    api.onUpdateNotAvailable({ setUpdaterState(UpdaterUiState(UpdaterStatus.NOT_AVAILABLE)) })
+    api.onUpdateProgress({ p: dynamic ->
+        setUpdaterState(UpdaterUiState(UpdaterStatus.DOWNLOADING, percent = (p?.percent as? Number)?.toDouble()))
+    })
+    api.onUpdateDownloaded({ info: dynamic ->
+        setUpdaterState(UpdaterUiState(UpdaterStatus.DOWNLOADED, version = info?.version as? String))
+    })
+    api.onUpdateError({ err: dynamic ->
+        setUpdaterState(UpdaterUiState(UpdaterStatus.ERROR, message = err?.message as? String))
+    })
+}
+
+/**
+ * Commit a new [UpdaterUiState]: store it, mirror "update pending" onto the
+ * top-bar bell, and re-render the panel if it is mounted.
+ *
+ * @param next the state to apply.
+ */
+private fun setUpdaterState(next: UpdaterUiState) {
+    // Don't let the silent startup check plant a resting state: suppress the
+    // non-actionable phases (checking / up-to-date / error) unless the user asked.
+    // Available/downloading/downloaded are always surfaced (actionable regardless).
+    when (next.status) {
+        UpdaterStatus.CHECKING -> if (!userInitiatedAction) return
+        UpdaterStatus.NOT_AVAILABLE, UpdaterStatus.ERROR -> {
+            if (!userInitiatedAction) return
+            userInitiatedAction = false // terminal outcome of the user's action
+        }
+        else -> {}
+    }
+    updaterState = next
+    // Light the shared bell while an update is available/downloading/ready. The
+    // flag is OR'd with the news state inside applyNewsTopbarIcon, so this never
+    // clobbers a concurrent news signal (and vice versa).
+    electronUpdatePending = when (next.status) {
+        UpdaterStatus.AVAILABLE, UpdaterStatus.DOWNLOADING, UpdaterStatus.DOWNLOADED -> true
+        else -> false
+    }
+    applyNewsTopbarIcon()
+    panelRender?.invoke(next)
+}
+
+/**
+ * Mark the next update lifecycle as user-initiated, so its "Checking…" /
+ * "up to date" / error outcome is shown in the panel (the silent startup check
+ * is not). Called by `main.kt`'s "Check for Updates…" menu handler, which
+ * triggers a main-process check; the panel's own button sets the flag directly.
+ */
+fun markUserInitiatedUpdateAction() {
+    userInitiatedAction = true
+}
+
+/**
+ * Open the App Settings sidebar and scroll the Updates section into view.
+ *
+ * Called by the top-bar bell click (when an update is pending, see
+ * `buildNewsTopbarAction`) and by the "Check for Updates…" Help-menu item (via
+ * the `onShowUpdatesPanel` bridge). No-op-safe outside Electron.
+ *
+ * @see openAppSettingsSidebar
+ */
+fun openUpdatesPanel() {
+    openAppSettingsSidebar()
+    // The sidebar body is (re)built and slid in by the toolkit; wait a beat for
+    // it to mount before scrolling the section into view.
+    window.setTimeout({
+        val section = document.getElementById(UPDATES_SECTION_ID)
+        section?.asDynamic()?.scrollIntoView(js("({ behavior: 'smooth', block: 'start' })"))
+        Unit
+    }, 250)
+}
+
+/**
+ * Build the "Updates" section for the App Settings sidebar body.
+ *
+ * Registers itself as the live [panelRender] target and renders the current
+ * [updaterState] immediately, so a section opened after an update was already
+ * found shows the right state. Appended by [buildAppSettingsContent], gated on
+ * [isElectronClient].
+ *
+ * @return the freshly-built section element.
+ */
+fun buildUpdatesSection(): HTMLElement {
+    val section = document.createElement("section") as HTMLElement
+    section.className = "lunamux-app-settings-section"
+    section.id = UPDATES_SECTION_ID
+
+    val title = document.createElement("h3") as HTMLElement
+    title.className = "lunamux-app-settings-section-title"
+    title.textContent = "Updates"
+    section.appendChild(title)
+
+    val row = document.createElement("div") as HTMLElement
+    row.className = "lunamux-app-settings-toggle-row"
+
+    val header = document.createElement("div") as HTMLElement
+    header.className = "lunamux-app-settings-toggle-header"
+    val statusLabel = document.createElement("span") as HTMLElement
+    statusLabel.className = "lunamux-app-settings-toggle-label"
+    header.appendChild(statusLabel)
+    row.appendChild(header)
+
+    // Download progress bar — a thin track with a currentColor fill, shown only
+    // while downloading. currentColor keeps it readable in either theme.
+    val progressTrack = document.createElement("div") as HTMLElement
+    progressTrack.style.height = "4px"
+    progressTrack.style.borderRadius = "2px"
+    progressTrack.style.background = "rgba(127, 127, 127, 0.25)"
+    progressTrack.style.margin = "8px 0"
+    progressTrack.style.setProperty("overflow", "hidden")
+    val progressBar = document.createElement("div") as HTMLElement
+    progressBar.style.height = "100%"
+    progressBar.style.width = "0%"
+    progressBar.style.background = "currentColor"
+    progressBar.style.opacity = "0.8"
+    progressBar.style.transition = "width 120ms linear"
+    progressTrack.appendChild(progressBar)
+    row.appendChild(progressTrack)
+
+    val btnRow = document.createElement("div") as HTMLElement
+    btnRow.className = "dt-settings-button-row"
+    val primaryBtn = document.createElement("button") as HTMLElement
+    (primaryBtn.asDynamic()).type = "button"
+    primaryBtn.className = "dt-settings-choice-btn"
+    // One handler, dispatching on the live status at click time so we never
+    // stack listeners across re-renders.
+    primaryBtn.addEventListener("click", { _: Event ->
+        val api = window.asDynamic().electronApi ?: return@addEventListener
+        // Explicit user action, so its outcome (including errors) is shown.
+        userInitiatedAction = true
+        // Guard each method: an older preload (renderer/preload version skew) may
+        // expose electronApi without the updater methods.
+        when (updaterState.status) {
+            UpdaterStatus.AVAILABLE -> if (api.downloadUpdate != null) api.downloadUpdate()
+            UpdaterStatus.DOWNLOADED -> if (api.quitAndInstall != null) api.quitAndInstall()
+            else -> if (api.checkForUpdates != null) api.checkForUpdates()
+        }
+        Unit
+    })
+    btnRow.appendChild(primaryBtn)
+    row.appendChild(btnRow)
+
+    section.appendChild(row)
+
+    /** Reflect [s] onto the status line, progress bar, and primary button. */
+    fun render(s: UpdaterUiState) {
+        val pct = s.percent?.roundToInt()
+        progressTrack.style.display = if (s.status == UpdaterStatus.DOWNLOADING) "block" else "none"
+        if (s.status == UpdaterStatus.DOWNLOADING) progressBar.style.width = "${pct ?: 0}%"
+
+        val (statusText, buttonText, disabled) = when (s.status) {
+            UpdaterStatus.IDLE ->
+                Triple("Check whether a newer version is available.", "Check for updates", false)
+            UpdaterStatus.CHECKING ->
+                Triple("Checking for updates…", "Checking…", true)
+            UpdaterStatus.AVAILABLE ->
+                Triple(
+                    "Update available" + (s.version?.let { " — v$it" } ?: "") + ".",
+                    "Download", false,
+                )
+            UpdaterStatus.DOWNLOADING ->
+                Triple("Downloading update…" + (pct?.let { " $it%" } ?: ""), "Downloading…", true)
+            UpdaterStatus.DOWNLOADED ->
+                Triple(
+                    "Update ready" + (s.version?.let { " (v$it)" } ?: "") + " — restart to install.",
+                    "Restart to install", false,
+                )
+            UpdaterStatus.NOT_AVAILABLE ->
+                Triple("You're on the latest version.", "Check for updates", false)
+            UpdaterStatus.ERROR ->
+                Triple("Update check failed" + (s.message?.let { ": $it" } ?: "") + ".", "Try again", false)
+        }
+        statusLabel.textContent = statusText
+        primaryBtn.textContent = buttonText
+        (primaryBtn.asDynamic()).disabled = disabled
+    }
+
+    panelRender = ::render
+    render(updaterState)
+
+    return section
+}

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/AutoUpdaterPanel.kt
@@ -3,28 +3,30 @@
  * -------------------
  * Renderer half of the Lunamux desktop auto-updater (Electron only).
  *
- * The Electron main process drives electron-updater (see the `electron-main`
- * module's `AutoUpdater.kt`) and forwards each lifecycle event to the renderer
- * over the preload bridge (`window.electronApi.onUpdate*`). This file:
+ * electron-updater runs in the Electron main process (see the electron-main
+ * module's AutoUpdater.kt) and forwards each lifecycle event to the renderer over
+ * the preload bridge (`window.electronApi.onUpdate*`). This file keeps a small
+ * [UpdaterUiState] state machine fed by those events and renders it as a compact
+ * banner pinned to the TOP of the left sidebar footer (mounted from
+ * `LunamuxToolkitBootstrap.buildSidebarFooter`, styled by `.lunamux-update-banner`
+ * in styles.css) — modeled on acolite's side-menu auto-updater: hidden while idle,
+ * appearing with an accent title + version, a "What's new" link (opens the GitHub
+ * release page for the new version), a progress bar, and a Download / Restart
+ * action.
  *
- *  - keeps a tiny [UpdaterUiState] state machine fed by those events
- *    ([initAutoUpdaterListeners]),
- *  - renders it as an **"Updates" section** in the App Settings sidebar
- *    ([buildUpdatesSection], registered from
- *    [buildAppSettingsContent]) with a status line, a download progress bar,
- *    and a single primary button (Check / Download / Restart), and
- *  - reflects "an update is pending" onto the existing top-bar bell (reusing
- *    [electronUpdatePending] / [applyNewsTopbarIcon] in NewsLabel.kt) and opens
- *    the panel on demand ([openUpdatesPanel] — used by the bell click and the
- *    "Check for Updates…" Help-menu item).
+ * The initial (silent) check is fired by the renderer itself in
+ * [initAutoUpdaterListeners], *after* it has subscribed, so the main process can
+ * never emit `update-available` before the renderer is listening
+ * (`webContents.send` does not buffer). [triggerUserUpdateCheck] backs the
+ * "Check for Updates…" Help-menu item.
  *
- * All entry points are safe to call outside Electron: they no-op when the
- * `electronApi` bridge (or its updater methods) is absent, and the section is
- * only appended for [isElectronClient].
+ * All entry points are safe outside Electron: they no-op when the `electronApi`
+ * bridge (or its updater methods) is absent, and the banner is only mounted for
+ * [isElectronClient].
  *
  * @see initAutoUpdaterListeners
- * @see buildUpdatesSection
- * @see openUpdatesPanel
+ * @see buildUpdateBanner
+ * @see triggerUserUpdateCheck
  */
 package se.soderbjorn.lunamux
 
@@ -34,18 +36,15 @@ import kotlin.math.roundToInt
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
 
-/** DOM id of the Updates section, so [openUpdatesPanel] can scroll it into view. */
-private const val UPDATES_SECTION_ID = "lunamux-updates-section"
-
 /**
  * The phases of an update, mirroring electron-updater's lifecycle events. Drives
- * the status text and which action the primary button performs.
+ * the banner's title, visibility, and which action its button performs.
  */
 private enum class UpdaterStatus {
-    /** No check has run yet this session. */
+    /** No check has surfaced anything this session; the banner is hidden. */
     IDLE,
 
-    /** A check is in flight. */
+    /** A user-initiated check is in flight. */
     CHECKING,
 
     /** A newer version exists and can be downloaded. */
@@ -57,10 +56,10 @@ private enum class UpdaterStatus {
     /** The update finished downloading and can be installed. */
     DOWNLOADED,
 
-    /** The last check found the app already up to date. */
+    /** The last check found the app already up to date (banner hidden). */
     NOT_AVAILABLE,
 
-    /** The last operation failed. */
+    /** The last user-initiated operation failed. */
     ERROR,
 }
 
@@ -71,45 +70,49 @@ private enum class UpdaterStatus {
  * @property version the target version, when known (available/downloaded).
  * @property percent download progress 0..100, when downloading.
  * @property message an error message, when [status] is [UpdaterStatus.ERROR].
+ * @property releaseNotesUrl the new version's GitHub release page, when known;
+ *   opened by the banner's "What's new" link. Built main-side in AutoUpdater.kt.
  */
 private data class UpdaterUiState(
     val status: UpdaterStatus = UpdaterStatus.IDLE,
     val version: String? = null,
     val percent: Double? = null,
     val message: String? = null,
+    val releaseNotesUrl: String? = null,
 )
 
 /** The live updater state, updated by the events wired in [initAutoUpdaterListeners]. */
 private var updaterState = UpdaterUiState()
 
 /**
- * The mounted panel's re-render callback, or `null` when the Updates section is
- * not currently in the DOM. Set by [buildUpdatesSection] each time the sidebar
- * body is (re)built; only one App Settings sidebar exists at a time, so a single
- * slot suffices. Updates to a since-detached panel are harmless no-ops.
+ * The mounted banner's re-render callback, or `null` before the sidebar footer is
+ * built. Set once by [buildUpdateBanner]; the footer element is cached by the
+ * toolkit bootstrap, so the banner (and this callback) survive toolkit rerenders.
  */
-private var panelRender: ((UpdaterUiState) -> Unit)? = null
+private var bannerRender: ((UpdaterUiState) -> Unit)? = null
 
 /** Guards one-time event subscription in [initAutoUpdaterListeners]. */
 private var listenersInitialized = false
 
 /**
- * Whether the current (or most recent) update lifecycle was started by an
- * explicit user gesture — the panel's button or the "Check for Updates…" menu —
- * as opposed to the silent check at launch. [setUpdaterState] suppresses the
- * non-actionable phases (checking / up-to-date / error) unless this is set, so a
- * silent startup check never plants a stale resting state in the panel.
+ * Whether the current (or most recent) update lifecycle was started by an explicit
+ * user gesture — the banner's button or the "Check for Updates…" menu — as opposed
+ * to the silent check at launch. [setUpdaterState] suppresses the non-actionable
+ * phases (checking / up-to-date / error) unless this is set, so a silent startup
+ * check never surfaces the banner for a no-op or a transient offline error.
  * Available/downloading/downloaded are always surfaced regardless.
  */
 private var userInitiatedAction = false
 
 /**
- * Subscribe once to the main process's update lifecycle events and route them
- * into [updaterState] (+ the bell + any mounted panel).
+ * Subscribe once to the main process's update lifecycle events, then kick off the
+ * initial silent check.
  *
- * Called from `main.kt`'s startup inside the `isElectronClient` branch. No-ops
- * when the `electronApi` bridge or its updater methods are absent (a plain
- * browser, or an older preload), so it is always safe to call.
+ * Called from `main.kt`'s startup inside the `isElectronClient` branch. The check
+ * is fired here — *after* the `onUpdate*` subscriptions are registered — so the
+ * main process cannot emit `update-available` before the renderer is listening
+ * (that race is why an available update previously never showed on launch). No-ops
+ * when the `electronApi` bridge or its updater methods are absent.
  */
 fun initAutoUpdaterListeners() {
     if (listenersInitialized) return
@@ -119,30 +122,42 @@ fun initAutoUpdaterListeners() {
 
     api.onUpdateChecking({ setUpdaterState(UpdaterUiState(UpdaterStatus.CHECKING)) })
     api.onUpdateAvailable({ info: dynamic ->
-        setUpdaterState(UpdaterUiState(UpdaterStatus.AVAILABLE, version = info?.version as? String))
+        setUpdaterState(UpdaterUiState(
+            UpdaterStatus.AVAILABLE,
+            version = info?.version as? String,
+            releaseNotesUrl = info?.releaseNotesUrl as? String,
+        ))
     })
     api.onUpdateNotAvailable({ setUpdaterState(UpdaterUiState(UpdaterStatus.NOT_AVAILABLE)) })
     api.onUpdateProgress({ p: dynamic ->
         setUpdaterState(UpdaterUiState(UpdaterStatus.DOWNLOADING, percent = (p?.percent as? Number)?.toDouble()))
     })
     api.onUpdateDownloaded({ info: dynamic ->
-        setUpdaterState(UpdaterUiState(UpdaterStatus.DOWNLOADED, version = info?.version as? String))
+        setUpdaterState(UpdaterUiState(
+            UpdaterStatus.DOWNLOADED,
+            version = info?.version as? String,
+            releaseNotesUrl = info?.releaseNotesUrl as? String,
+        ))
     })
     api.onUpdateError({ err: dynamic ->
         setUpdaterState(UpdaterUiState(UpdaterStatus.ERROR, message = err?.message as? String))
     })
+
+    // Silent initial check, fired only now that we're subscribed. Not user-initiated,
+    // so a "nothing new" / offline result leaves the banner hidden.
+    if (api.checkForUpdates != null) api.checkForUpdates()
 }
 
 /**
- * Commit a new [UpdaterUiState]: store it, mirror "update pending" onto the
- * top-bar bell, and re-render the panel if it is mounted.
+ * Commit a new [UpdaterUiState] and re-render the banner.
+ *
+ * A silent (startup) check must not surface the banner for a non-actionable
+ * outcome, so checking / up-to-date / error are dropped unless the user asked
+ * ([userInitiatedAction]); available/downloading/downloaded are always applied.
  *
  * @param next the state to apply.
  */
 private fun setUpdaterState(next: UpdaterUiState) {
-    // Don't let the silent startup check plant a resting state: suppress the
-    // non-actionable phases (checking / up-to-date / error) unless the user asked.
-    // Available/downloading/downloaded are always surfaced (actionable regardless).
     when (next.status) {
         UpdaterStatus.CHECKING -> if (!userInitiatedAction) return
         UpdaterStatus.NOT_AVAILABLE, UpdaterStatus.ERROR -> {
@@ -152,154 +167,170 @@ private fun setUpdaterState(next: UpdaterUiState) {
         else -> {}
     }
     updaterState = next
-    // Light the shared bell while an update is available/downloading/ready. The
-    // flag is OR'd with the news state inside applyNewsTopbarIcon, so this never
-    // clobbers a concurrent news signal (and vice versa).
-    electronUpdatePending = when (next.status) {
-        UpdaterStatus.AVAILABLE, UpdaterStatus.DOWNLOADING, UpdaterStatus.DOWNLOADED -> true
-        else -> false
-    }
-    applyNewsTopbarIcon()
-    panelRender?.invoke(next)
+    bannerRender?.invoke(next)
 }
 
 /**
- * Mark the next update lifecycle as user-initiated, so its "Checking…" /
- * "up to date" / error outcome is shown in the panel (the silent startup check
- * is not). Called by `main.kt`'s "Check for Updates…" menu handler, which
- * triggers a main-process check; the panel's own button sets the flag directly.
+ * Run a user-initiated update check (marks the action so its checking / up-to-date
+ * / error outcome shows in the banner, then asks the main process to check).
+ * Backs the "Check for Updates…" Help-menu item (routed via `main.kt`). No-op-safe
+ * outside Electron.
  */
-fun markUserInitiatedUpdateAction() {
+fun triggerUserUpdateCheck() {
+    val api = window.asDynamic().electronApi ?: return
     userInitiatedAction = true
+    if (api.checkForUpdates != null) api.checkForUpdates()
 }
 
 /**
- * Open the App Settings sidebar and scroll the Updates section into view.
+ * Build the update banner for the sidebar footer.
  *
- * Called by the top-bar bell click (when an update is pending, see
- * `buildNewsTopbarAction`) and by the "Check for Updates…" Help-menu item (via
- * the `onShowUpdatesPanel` bridge). No-op-safe outside Electron.
+ * Compact and acolite-style, laid out as two short rows so nothing truncates:
+ *  - title row: an uppercase accent title + a right-aligned version (or, while
+ *    downloading, the percent);
+ *  - action row: a "What's new" link (opens the GitHub release page) or the error
+ *    message, plus a Download / Restart / Try again button — the button fills the
+ *    row when there's no left cell (once downloaded, or when no release URL);
+ *  - a full-width progress bar while downloading.
+ * Hidden entirely while idle / up-to-date. Registers itself as the live
+ * [bannerRender] target and renders the current [updaterState] immediately.
  *
- * @see openAppSettingsSidebar
+ * Mounted once by `LunamuxToolkitBootstrap.buildSidebarFooter` (gated on
+ * [isElectronClient]); the footer is cached, so this is built a single time.
+ * Styled by `.lunamux-update-banner` in styles.css (theme-token colours).
+ *
+ * @return the banner element (initially hidden via its CSS `display:none`).
  */
-fun openUpdatesPanel() {
-    openAppSettingsSidebar()
-    // The sidebar body is (re)built and slid in by the toolkit; wait a beat for
-    // it to mount before scrolling the section into view.
-    window.setTimeout({
-        val section = document.getElementById(UPDATES_SECTION_ID)
-        section?.asDynamic()?.scrollIntoView(js("({ behavior: 'smooth', block: 'start' })"))
-        Unit
-    }, 250)
-}
+fun buildUpdateBanner(): HTMLElement {
+    val banner = document.createElement("div") as HTMLElement
+    banner.className = "lunamux-update-banner"
 
-/**
- * Build the "Updates" section for the App Settings sidebar body.
- *
- * Registers itself as the live [panelRender] target and renders the current
- * [updaterState] immediately, so a section opened after an update was already
- * found shows the right state. Appended by [buildAppSettingsContent], gated on
- * [isElectronClient].
- *
- * @return the freshly-built section element.
- */
-fun buildUpdatesSection(): HTMLElement {
-    val section = document.createElement("section") as HTMLElement
-    section.className = "lunamux-app-settings-section"
-    section.id = UPDATES_SECTION_ID
+    // Title row: title (left) + version / percent chip (right).
+    val titleRow = document.createElement("div") as HTMLElement
+    titleRow.className = "lu-update-row"
+    val titleEl = document.createElement("span") as HTMLElement
+    titleEl.className = "lu-update-title"
+    val versionEl = document.createElement("span") as HTMLElement
+    versionEl.className = "lu-update-version"
+    titleRow.appendChild(titleEl)
+    titleRow.appendChild(versionEl)
+    banner.appendChild(titleRow)
 
-    val title = document.createElement("h3") as HTMLElement
-    title.className = "lunamux-app-settings-section-title"
-    title.textContent = "Updates"
-    section.appendChild(title)
+    // Action row: "What's new" link (or the error message) + the primary action.
+    val bodyRow = document.createElement("div") as HTMLElement
+    bodyRow.className = "lu-update-row"
+    val leftEl = document.createElement("span") as HTMLElement
+    leftEl.className = "lu-update-left"
+    // "What's new" opens the new version's GitHub release page in the browser.
+    // Captured by both this handler (reads) and render (writes).
+    var currentNotesUrl: String? = null
+    leftEl.addEventListener("click", { _: Event -> currentNotesUrl?.let { openExternalUrl(it) } })
+    bodyRow.appendChild(leftEl)
 
-    val row = document.createElement("div") as HTMLElement
-    row.className = "lunamux-app-settings-toggle-row"
-
-    val header = document.createElement("div") as HTMLElement
-    header.className = "lunamux-app-settings-toggle-header"
-    val statusLabel = document.createElement("span") as HTMLElement
-    statusLabel.className = "lunamux-app-settings-toggle-label"
-    header.appendChild(statusLabel)
-    row.appendChild(header)
-
-    // Download progress bar — a thin track with a currentColor fill, shown only
-    // while downloading. currentColor keeps it readable in either theme.
-    val progressTrack = document.createElement("div") as HTMLElement
-    progressTrack.style.height = "4px"
-    progressTrack.style.borderRadius = "2px"
-    progressTrack.style.background = "rgba(127, 127, 127, 0.25)"
-    progressTrack.style.margin = "8px 0"
-    progressTrack.style.setProperty("overflow", "hidden")
-    val progressBar = document.createElement("div") as HTMLElement
-    progressBar.style.height = "100%"
-    progressBar.style.width = "0%"
-    progressBar.style.background = "currentColor"
-    progressBar.style.opacity = "0.8"
-    progressBar.style.transition = "width 120ms linear"
-    progressTrack.appendChild(progressBar)
-    row.appendChild(progressTrack)
-
-    val btnRow = document.createElement("div") as HTMLElement
-    btnRow.className = "dt-settings-button-row"
-    val primaryBtn = document.createElement("button") as HTMLElement
-    (primaryBtn.asDynamic()).type = "button"
-    primaryBtn.className = "dt-settings-choice-btn"
-    // One handler, dispatching on the live status at click time so we never
-    // stack listeners across re-renders.
-    primaryBtn.addEventListener("click", { _: Event ->
+    val actionBtn = document.createElement("button") as HTMLElement
+    (actionBtn.asDynamic()).type = "button"
+    actionBtn.className = "lu-update-action"
+    // One handler, dispatching on the live status at click time. Guards each
+    // method (older preload may lack them), and optimistically advances the UI so
+    // the click feels instant rather than waiting on the first event.
+    actionBtn.addEventListener("click", { _: Event ->
         val api = window.asDynamic().electronApi ?: return@addEventListener
-        // Explicit user action, so its outcome (including errors) is shown.
         userInitiatedAction = true
-        // Guard each method: an older preload (renderer/preload version skew) may
-        // expose electronApi without the updater methods.
         when (updaterState.status) {
-            UpdaterStatus.AVAILABLE -> if (api.downloadUpdate != null) api.downloadUpdate()
-            UpdaterStatus.DOWNLOADED -> if (api.quitAndInstall != null) api.quitAndInstall()
-            else -> if (api.checkForUpdates != null) api.checkForUpdates()
+            UpdaterStatus.AVAILABLE -> {
+                if (api.downloadUpdate != null) api.downloadUpdate()
+                setUpdaterState(UpdaterUiState(UpdaterStatus.DOWNLOADING, percent = 0.0))
+            }
+            UpdaterStatus.DOWNLOADED -> {
+                // The install shuts the server down first (up to a few seconds)
+                // before the app quits, so give immediate feedback, not a dead button.
+                actionBtn.textContent = "Restarting…"
+                (actionBtn.asDynamic()).disabled = true
+                // The server is about to be stopped on purpose; don't flash the
+                // "Connection lost" modal in the moment before the app exits.
+                suppressDisconnectedModal = true
+                hideDisconnectedModal()
+                if (api.quitAndInstall != null) api.quitAndInstall()
+            }
+            else -> {
+                if (api.checkForUpdates != null) api.checkForUpdates()
+                setUpdaterState(UpdaterUiState(UpdaterStatus.CHECKING))
+            }
         }
         Unit
     })
-    btnRow.appendChild(primaryBtn)
-    row.appendChild(btnRow)
+    bodyRow.appendChild(actionBtn)
+    banner.appendChild(bodyRow)
 
-    section.appendChild(row)
+    // Progress row (shown only while downloading): a full-width bar.
+    val progressRow = document.createElement("div") as HTMLElement
+    progressRow.className = "lu-update-progress-row"
+    val track = document.createElement("div") as HTMLElement
+    track.className = "lu-update-progress"
+    val fill = document.createElement("div") as HTMLElement
+    fill.className = "lu-update-progress-fill"
+    fill.style.setProperty("width", "0%")
+    track.appendChild(fill)
+    progressRow.appendChild(track)
+    banner.appendChild(progressRow)
 
-    /** Reflect [s] onto the status line, progress bar, and primary button. */
+    /** Reflect [s] onto the banner: visibility, title/version, link/message, progress, button. */
     fun render(s: UpdaterUiState) {
-        val pct = s.percent?.roundToInt()
-        progressTrack.style.display = if (s.status == UpdaterStatus.DOWNLOADING) "block" else "none"
-        if (s.status == UpdaterStatus.DOWNLOADING) progressBar.style.width = "${pct ?: 0}%"
+        val visible = s.status != UpdaterStatus.IDLE && s.status != UpdaterStatus.NOT_AVAILABLE
+        banner.style.setProperty("display", if (visible) "flex" else "none")
+        if (!visible) return
+        currentNotesUrl = s.releaseNotesUrl
 
-        val (statusText, buttonText, disabled) = when (s.status) {
-            UpdaterStatus.IDLE ->
-                Triple("Check whether a newer version is available.", "Check for updates", false)
-            UpdaterStatus.CHECKING ->
-                Triple("Checking for updates…", "Checking…", true)
-            UpdaterStatus.AVAILABLE ->
-                Triple(
-                    "Update available" + (s.version?.let { " — v$it" } ?: "") + ".",
-                    "Download", false,
-                )
-            UpdaterStatus.DOWNLOADING ->
-                Triple("Downloading update…" + (pct?.let { " $it%" } ?: ""), "Downloading…", true)
-            UpdaterStatus.DOWNLOADED ->
-                Triple(
-                    "Update ready" + (s.version?.let { " (v$it)" } ?: "") + " — restart to install.",
-                    "Restart to install", false,
-                )
-            UpdaterStatus.NOT_AVAILABLE ->
-                Triple("You're on the latest version.", "Check for updates", false)
-            UpdaterStatus.ERROR ->
-                Triple("Update check failed" + (s.message?.let { ": $it" } ?: "") + ".", "Try again", false)
+        val showBody = s.status == UpdaterStatus.AVAILABLE ||
+            s.status == UpdaterStatus.DOWNLOADED ||
+            s.status == UpdaterStatus.ERROR
+        bodyRow.style.setProperty("display", if (showBody) "flex" else "none")
+        progressRow.style.setProperty("display", if (s.status == UpdaterStatus.DOWNLOADING) "flex" else "none")
+
+        // "What's new" shows only when available with a release URL; the error
+        // message uses the same cell. Once downloaded (or when there's no URL) the
+        // button fills the row — installing/downloading is the only action left.
+        val hasNotes = !s.releaseNotesUrl.isNullOrBlank()
+        val showLeft = (s.status == UpdaterStatus.AVAILABLE && hasNotes) || s.status == UpdaterStatus.ERROR
+        val fullButton = s.status == UpdaterStatus.DOWNLOADED || (s.status == UpdaterStatus.AVAILABLE && !hasNotes)
+        leftEl.style.setProperty("display", if (showLeft) "" else "none")
+        actionBtn.classList.toggle("lu-update-action-full", fullButton)
+
+        when (s.status) {
+            UpdaterStatus.CHECKING -> {
+                titleEl.textContent = "Checking for updates"
+                versionEl.textContent = ""
+            }
+            UpdaterStatus.AVAILABLE -> {
+                titleEl.textContent = "Update available"
+                versionEl.textContent = s.version?.let { "v$it" } ?: ""
+                leftEl.className = "lu-update-left lu-update-link"
+                leftEl.textContent = "What's new"
+                actionBtn.textContent = "Download"
+            }
+            UpdaterStatus.DOWNLOADING -> {
+                titleEl.textContent = "Downloading"
+                val pct = s.percent?.roundToInt() ?: 0
+                versionEl.textContent = "$pct%"
+                fill.style.setProperty("width", "$pct%")
+            }
+            UpdaterStatus.DOWNLOADED -> {
+                titleEl.textContent = "Update ready"
+                versionEl.textContent = s.version?.let { "v$it" } ?: ""
+                actionBtn.textContent = "Restart to install"
+            }
+            UpdaterStatus.ERROR -> {
+                titleEl.textContent = "Update failed"
+                versionEl.textContent = ""
+                leftEl.className = "lu-update-left"
+                leftEl.textContent = s.message ?: "Something went wrong"
+                actionBtn.textContent = "Try again"
+            }
+            else -> {}
         }
-        statusLabel.textContent = statusText
-        primaryBtn.textContent = buttonText
-        (primaryBtn.asDynamic()).disabled = disabled
     }
 
-    panelRender = ::render
+    bannerRender = ::render
     render(updaterState)
-
-    return section
+    return banner
 }

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LunamuxToolkitBootstrap.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LunamuxToolkitBootstrap.kt
@@ -724,28 +724,17 @@ private fun buildAboutTopbarAction(): TopbarAction = TopbarAction(
  * via the `tt-news-topbar` marker class on its SVG. Replaces the former
  * sidebar-footer news/update pills, matching the mobile toolbar bell.
  *
- * @return the bell topbar action. News keeps priority (it is the bell's identity
- *   and is dismissible): the click opens the Updates panel only when a desktop
- *   update is pending AND there is no unread news; otherwise it opens the combined
- *   News & Updates screen using the shared [newsUpdatesViewModel]'s current state
- *   (a no-op before the checker starts). A pending update is always also reachable
- *   via the "Check for Updates…" menu / App Settings.
+ * @return the bell topbar action; its click opens the screen using the shared
+ *   [newsUpdatesViewModel]'s current state (a no-op before the checker starts).
+ *   (Desktop app updates are surfaced separately in the sidebar-footer update
+ *   banner — see AutoUpdaterPanel.kt — so this bell is news-only.)
  */
 private fun buildNewsTopbarAction(): TopbarAction = TopbarAction(
     id = "tt-topbar-news",
     iconHtml = ICON_NEWS,
     label = "News & updates",
     onActivate = {
-        // The bell is shared between news and the desktop auto-updater. News keeps
-        // priority so it is never stranded behind a pending update; route to the
-        // Updates panel only when an update is pending AND there is no unread news.
-        // See AutoUpdaterPanel.kt / NewsLabel.kt.
-        val hasNews = newsUpdatesViewModel?.stateFlow?.value?.hasNews == true
-        if (electronUpdatePending && !hasNews) {
-            openUpdatesPanel()
-        } else {
-            newsUpdatesViewModel?.let { showNewsDialog(it, it.stateFlow.value) }
-        }
+        newsUpdatesViewModel?.let { showNewsDialog(it, it.stateFlow.value) }
     },
 )
 
@@ -995,9 +984,11 @@ private fun buildSidebarLogo(): HTMLElement {
 }
 
 /**
- * Builds (once) the sidebar footer for the toolkit's `sidebarFooter` slot: the
- * Claude usage rows. (News and updates now live behind the pulsing top-bar bell
- * — see [buildNewsTopbarAction] — not a footer pill.)
+ * Builds (once) the sidebar footer for the toolkit's `sidebarFooter` slot: on
+ * Electron, the auto-update banner pinned at the top (see
+ * AutoUpdaterPanel.buildUpdateBanner), then the Claude usage rows and the
+ * world-status block. (News still lives behind the pulsing top-bar bell — see
+ * [buildNewsTopbarAction].)
  *
  * The Claude usage bar element keeps its `claude-usage-bar` id and is cached
  * into [usageBar] so subsequent [updateClaudeUsageBadge] writes land here; the
@@ -1013,6 +1004,13 @@ private fun buildSidebarFooter(): HTMLElement {
     sidebarFooterEl?.let { return it }
     val footer = document.createElement("div") as HTMLElement
     footer.className = "tt-sidebar-footer"
+
+    // Desktop auto-update banner, pinned at the TOP of the footer (above the
+    // Claude usage bar) — the lunamux analog of acolite's side-menu updater:
+    // hidden until an update is available / in progress, then an accent title +
+    // status/progress + Download/Restart. Electron only — a plain browser has no
+    // updater to drive. See AutoUpdaterPanel.buildUpdateBanner.
+    if (isElectronClient) footer.appendChild(buildUpdateBanner())
 
     val usage = document.createElement("div") as HTMLElement
     usage.id = "claude-usage-bar"

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LunamuxToolkitBootstrap.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LunamuxToolkitBootstrap.kt
@@ -724,15 +724,28 @@ private fun buildAboutTopbarAction(): TopbarAction = TopbarAction(
  * via the `tt-news-topbar` marker class on its SVG. Replaces the former
  * sidebar-footer news/update pills, matching the mobile toolbar bell.
  *
- * @return the bell topbar action; its click opens the screen using the shared
- *   [newsUpdatesViewModel]'s current state (a no-op before the checker starts).
+ * @return the bell topbar action. News keeps priority (it is the bell's identity
+ *   and is dismissible): the click opens the Updates panel only when a desktop
+ *   update is pending AND there is no unread news; otherwise it opens the combined
+ *   News & Updates screen using the shared [newsUpdatesViewModel]'s current state
+ *   (a no-op before the checker starts). A pending update is always also reachable
+ *   via the "Check for Updates…" menu / App Settings.
  */
 private fun buildNewsTopbarAction(): TopbarAction = TopbarAction(
     id = "tt-topbar-news",
     iconHtml = ICON_NEWS,
     label = "News & updates",
     onActivate = {
-        newsUpdatesViewModel?.let { showNewsDialog(it, it.stateFlow.value) }
+        // The bell is shared between news and the desktop auto-updater. News keeps
+        // priority so it is never stranded behind a pending update; route to the
+        // Updates panel only when an update is pending AND there is no unread news.
+        // See AutoUpdaterPanel.kt / NewsLabel.kt.
+        val hasNews = newsUpdatesViewModel?.stateFlow?.value?.hasNews == true
+        if (electronUpdatePending && !hasNews) {
+            openUpdatesPanel()
+        } else {
+            newsUpdatesViewModel?.let { showNewsDialog(it, it.stateFlow.value) }
+        }
     },
 )
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/NewsLabel.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/NewsLabel.kt
@@ -67,6 +67,10 @@ fun startNewsUpdatesChecker() {
         platformId = UpdatePlatform.MAC,
         currentVersionCode = versionCode,
         currentVersionName = versionName,
+        // The desktop build updates in-app via electron-updater (see
+        // AutoUpdaterPanel.kt), so the versions.json update branch is suppressed
+        // here to avoid double-notifying; this checker still surfaces news.
+        enableUpdateCheck = false,
     )
     newsUpdatesViewModel = viewModel
     viewModel.start()
@@ -78,7 +82,41 @@ fun startNewsUpdatesChecker() {
 }
 
 /**
+ * The most recent news/update state, retained so [applyNewsTopbarIcon] can
+ * re-apply the bell when the *other* signal ([electronUpdatePending]) changes
+ * without a fresh news emission.
+ */
+private var lastNewsUpdatesState: NewsUpdatesBackingViewModel.State =
+    NewsUpdatesBackingViewModel.State()
+
+/**
+ * Whether electron-updater currently has an update available, downloading, or
+ * ready to install. Maintained by the desktop auto-updater (see
+ * [setUpdaterState] in AutoUpdaterPanel.kt) and OR'd into the bell's lit state
+ * by [applyNewsTopbarIcon], so the update and news signals share the one bell
+ * without clobbering each other. The versions.json update branch is suppressed
+ * on desktop (`enableUpdateCheck = false` above), so this is the sole update
+ * source for the bell here.
+ */
+internal var electronUpdatePending: Boolean = false
+
+/**
  * Reflect the current news/update state onto the top-bar bell's appearance.
+ *
+ * Stores [state] as [lastNewsUpdatesState] and defers the actual DOM update to
+ * [applyNewsTopbarIcon], so the bell reflects both this news state and the
+ * independent [electronUpdatePending] flag.
+ *
+ * @param state the latest news/update state.
+ */
+internal fun refreshNewsTopbarIcon(state: NewsUpdatesBackingViewModel.State) {
+    lastNewsUpdatesState = state
+    applyNewsTopbarIcon()
+}
+
+/**
+ * Apply the bell's appearance from [lastNewsUpdatesState] combined with
+ * [electronUpdatePending].
  *
  * The bell button (`tt-topbar-news`) always lives in the DOM *and* is always
  * visible and clickable, so the News & Updates screen — and its Restore button —
@@ -86,21 +124,24 @@ fun startNewsUpdatesChecker() {
  * mutating the toolkit-owned button, so the state survives the toolkit's topbar
  * rerenders):
  *
- *  - `data-tt-news="1"` when there is an update or unread news; absent (rendering
- *    the bell muted/grayed via CSS) when there is nothing new.
+ *  - `data-tt-news="1"` when there is unread news **or** a pending desktop
+ *    update; absent (rendering the bell muted/grayed via CSS) when there is
+ *    nothing new.
  *  - `data-tt-news-pulse="1"` when there is actual news, so the bell pulses; a
- *    version update on its own shows the bell coloured but static.
+ *    pending update on its own shows the bell coloured but static.
  *
- * @param state the latest news/update state.
+ * Called by [refreshNewsTopbarIcon] on each news emission and by the auto-updater
+ * whenever [electronUpdatePending] flips.
  */
-internal fun refreshNewsTopbarIcon(state: NewsUpdatesBackingViewModel.State) {
+internal fun applyNewsTopbarIcon() {
     val body = document.body ?: return
-    if (state.hasContent) {
+    val state = lastNewsUpdatesState
+    if (state.hasContent || electronUpdatePending) {
         body.setAttribute("data-tt-news", "1")
     } else {
         body.removeAttribute("data-tt-news")
     }
-    // Pulse only when there is actual news; a version update on its own shows
+    // Pulse only when there is actual news; a pending update on its own shows
     // the icon coloured (via `data-tt-news`) but leaves it static.
     if (state.hasNews) {
         body.setAttribute("data-tt-news-pulse", "1")

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/NewsLabel.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/NewsLabel.kt
@@ -82,41 +82,7 @@ fun startNewsUpdatesChecker() {
 }
 
 /**
- * The most recent news/update state, retained so [applyNewsTopbarIcon] can
- * re-apply the bell when the *other* signal ([electronUpdatePending]) changes
- * without a fresh news emission.
- */
-private var lastNewsUpdatesState: NewsUpdatesBackingViewModel.State =
-    NewsUpdatesBackingViewModel.State()
-
-/**
- * Whether electron-updater currently has an update available, downloading, or
- * ready to install. Maintained by the desktop auto-updater (see
- * [setUpdaterState] in AutoUpdaterPanel.kt) and OR'd into the bell's lit state
- * by [applyNewsTopbarIcon], so the update and news signals share the one bell
- * without clobbering each other. The versions.json update branch is suppressed
- * on desktop (`enableUpdateCheck = false` above), so this is the sole update
- * source for the bell here.
- */
-internal var electronUpdatePending: Boolean = false
-
-/**
  * Reflect the current news/update state onto the top-bar bell's appearance.
- *
- * Stores [state] as [lastNewsUpdatesState] and defers the actual DOM update to
- * [applyNewsTopbarIcon], so the bell reflects both this news state and the
- * independent [electronUpdatePending] flag.
- *
- * @param state the latest news/update state.
- */
-internal fun refreshNewsTopbarIcon(state: NewsUpdatesBackingViewModel.State) {
-    lastNewsUpdatesState = state
-    applyNewsTopbarIcon()
-}
-
-/**
- * Apply the bell's appearance from [lastNewsUpdatesState] combined with
- * [electronUpdatePending].
  *
  * The bell button (`tt-topbar-news`) always lives in the DOM *and* is always
  * visible and clickable, so the News & Updates screen — and its Restore button —
@@ -124,24 +90,24 @@ internal fun refreshNewsTopbarIcon(state: NewsUpdatesBackingViewModel.State) {
  * mutating the toolkit-owned button, so the state survives the toolkit's topbar
  * rerenders):
  *
- *  - `data-tt-news="1"` when there is unread news **or** a pending desktop
- *    update; absent (rendering the bell muted/grayed via CSS) when there is
- *    nothing new.
+ *  - `data-tt-news="1"` when there is an update or unread news; absent (rendering
+ *    the bell muted/grayed via CSS) when there is nothing new.
  *  - `data-tt-news-pulse="1"` when there is actual news, so the bell pulses; a
- *    pending update on its own shows the bell coloured but static.
+ *    version update on its own shows the bell coloured but static.
  *
- * Called by [refreshNewsTopbarIcon] on each news emission and by the auto-updater
- * whenever [electronUpdatePending] flips.
+ * (Desktop app updates surface in the sidebar-footer update banner — see
+ * AutoUpdaterPanel.kt — not through this bell.)
+ *
+ * @param state the latest news/update state.
  */
-internal fun applyNewsTopbarIcon() {
+internal fun refreshNewsTopbarIcon(state: NewsUpdatesBackingViewModel.State) {
     val body = document.body ?: return
-    val state = lastNewsUpdatesState
-    if (state.hasContent || electronUpdatePending) {
+    if (state.hasContent) {
         body.setAttribute("data-tt-news", "1")
     } else {
         body.removeAttribute("data-tt-news")
     }
-    // Pulse only when there is actual news; a pending update on its own shows
+    // Pulse only when there is actual news; a version update on its own shows
     // the icon coloured (via `data-tt-news`) but leaves it static.
     if (state.hasNews) {
         body.setAttribute("data-tt-news-pulse", "1")

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/Overlays.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/Overlays.kt
@@ -102,6 +102,13 @@ fun hidePendingApprovalOverlay() {
  * — a desktop update install ("Restart to install") or a confirmed quit that stops
  * the server — where the server is shut down on purpose and the brief "Connection
  * lost" flash before the app exits would be misleading.
+ *
+ * The teardown is expected to end the session, but when it is abandoned with the
+ * app still running the flag is cleared again so real disconnects aren't silently
+ * swallowed for the rest of the session: on the main process's `quit-cancelled`
+ * event (kill-server quit abandoned after a failed shutdown — see main.kt) and on
+ * an update-install error (see AutoUpdaterPanel's `onUpdateError`). Both re-run
+ * [updateAggregateStatus] so an already-dead server surfaces immediately.
  */
 internal var suppressDisconnectedModal = false
 

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/Overlays.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/Overlays.kt
@@ -98,15 +98,25 @@ fun hidePendingApprovalOverlay() {
 }
 
 /**
+ * When `true`, [showDisconnectedModal] no-ops. Set during an intentional teardown
+ * — a desktop update install ("Restart to install") or a confirmed quit that stops
+ * the server — where the server is shut down on purpose and the brief "Connection
+ * lost" flash before the app exits would be misleading.
+ */
+internal var suppressDisconnectedModal = false
+
+/**
  * Shows a full-screen overlay indicating that the WebSocket connection to the
  * server has been lost. Includes a "Retry" button that reloads the page.
  *
  * Called by [updateAggregateStatus] when any PTY connection enters the "disconnected" state.
+ * No-op while [suppressDisconnectedModal] is set (intentional teardown).
  *
  * @see hideDisconnectedModal
  * @see updateAggregateStatus
  */
 fun showDisconnectedModal() {
+    if (suppressDisconnectedModal) return
     if (document.getElementById("disconnected-overlay") != null) return
     val overlay = document.createElement("div") as HTMLElement
     overlay.id = "disconnected-overlay"

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
@@ -715,6 +715,18 @@ private fun start() {
         })
     }
 
+    // A confirmed kill-server quit was abandoned in the main process (server
+    // shutdown failed, user chose Cancel in the native dialog) — the app keeps
+    // running, so re-arm the "Connection lost" modal suppressed above and
+    // re-evaluate the current connection state. Without this, every later
+    // genuine disconnect for the rest of the session would fail silently.
+    if (electronApi?.onQuitCancelled != null) {
+        electronApi.onQuitCancelled({
+            suppressDisconnectedModal = false
+            updateAggregateStatus()
+        })
+    }
+
     // Browser dev console fallback for the macOS Debug menu (the menu
     // exists only inside Electron). Power users can still drive the
     // override from `window.__ttDebugSetPaneState('working')` etc.

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
@@ -659,12 +659,9 @@ private fun start() {
     // (App Settings sidebar). Forwarded from the Electron main process via the
     // `show-updates-panel` IPC.
     if (electronApi?.onShowUpdatesPanel != null) {
-        // The menu item triggers a main-process check, so its outcome should show
-        // in the panel (unlike the silent startup check).
-        electronApi.onShowUpdatesPanel({
-            markUserInitiatedUpdateAction()
-            openUpdatesPanel()
-        })
+        // Help menu → "Check for Updates…": run a user-initiated check; the result
+        // shows in the sidebar-footer update banner. See triggerUserUpdateCheck.
+        electronApi.onShowUpdatesPanel({ triggerUserUpdateCheck() })
     }
 
     // 3D world → leave engage mode from inside a web pane. A `<webview>`
@@ -707,6 +704,12 @@ private fun start() {
                 val payload = js("({})")
                 payload.confirmed = result.confirmed
                 payload.killServer = result.killServer
+                // Stopping the server drops the socket; don't flash the "Connection
+                // lost" modal in the moment before the app quits.
+                if (result.confirmed && result.killServer) {
+                    suppressDisconnectedModal = true
+                    hideDisconnectedModal()
+                }
                 electronApi.respondQuitConfirmation(payload)
             }
         })

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/main.kt
@@ -595,6 +595,12 @@ private fun start() {
         // build.
         startNewsUpdatesChecker()
 
+        // Wire the in-app auto-updater (electron-updater). Subscribes to the main
+        // process's update lifecycle events, reflects "update available" onto the
+        // top-bar bell, and feeds the Updates panel in App Settings. No-op when the
+        // preload lacks the updater bridge. See AutoUpdaterPanel.kt.
+        initAutoUpdaterListeners()
+
         GlobalScope.launch {
             var prev: Boolean? = null
             appVm.stateFlow
@@ -647,6 +653,18 @@ private fun start() {
     // `show-hotkeys` IPC.
     if (electronApi?.onShowHotkeys != null) {
         electronApi.onShowHotkeys({ openHotkeysSidebar() })
+    }
+
+    // macOS Help menu → "Check for Updates…" opens the in-app Updates panel
+    // (App Settings sidebar). Forwarded from the Electron main process via the
+    // `show-updates-panel` IPC.
+    if (electronApi?.onShowUpdatesPanel != null) {
+        // The menu item triggers a main-process check, so its outcome should show
+        // in the panel (unlike the silent startup check).
+        electronApi.onShowUpdatesPanel({
+            markUserInitiatedUpdateAction()
+            openUpdatesPanel()
+        })
     }
 
     // 3D world → leave engage mode from inside a web pane. A `<webview>`

--- a/web/src/jsMain/resources/styles.css
+++ b/web/src/jsMain/resources/styles.css
@@ -366,6 +366,110 @@ body.appearance-light *::-webkit-scrollbar-thumb:hover {
     font-weight: 600;
 }
 
+/* Desktop auto-update banner — pinned at the TOP of the sidebar footer (above the
+   Claude usage bar). Mirrors the footer idiom (.claude-usage-bar /
+   .world-status-bar): compact, an uppercase accent title, theme tokens. Hidden
+   until an update is available / downloading / ready (JS toggles `display`).
+   Built by AutoUpdaterPanel.buildUpdateBanner (Electron only). */
+.lunamux-update-banner {
+    display: none;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 12px 10px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--t-chrome-text, var(--text-secondary));
+    white-space: nowrap;
+    user-select: none;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    /* Hairline below, separating the banner from the usage bar, matching the
+       footer's own divider. */
+    border-bottom: 1px solid var(--t-chrome-border, color-mix(in srgb, currentColor 12%, transparent));
+}
+/* Uppercase accent title — the theme accent (same token the world-status
+   "working" state uses) so the notice pops in the active appearance's colour. */
+.lunamux-update-banner .lu-update-title {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--t-accent, #4fb8ff);
+}
+.lunamux-update-banner .lu-update-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+/* Version / percent chip on the right of the title row (muted, tabular). */
+.lunamux-update-banner .lu-update-version {
+    flex: 0 0 auto;
+    font-size: 10px;
+    font-weight: 600;
+    opacity: 0.65;
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+}
+/* Left cell of the action row: the "What's new" link (opens the in-app News &
+   Updates feed), or the message on error. Ellipsises so the button always fits. */
+.lunamux-update-banner .lu-update-left {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.lunamux-update-banner .lu-update-left.lu-update-link {
+    opacity: 0.75;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+}
+.lunamux-update-banner .lu-update-left.lu-update-link:hover { opacity: 1; }
+/* Primary action (Download / Restart / Try again): accent-outlined pill. */
+.lunamux-update-banner .lu-update-action {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    color: var(--t-accent, #4fb8ff);
+    background: none;
+    border: 1px solid var(--t-accent, #4fb8ff);
+    border-radius: 5px;
+    padding: 2px 8px;
+    line-height: 1.4;
+}
+.lunamux-update-banner .lu-update-action:hover {
+    background: color-mix(in srgb, var(--t-accent, #4fb8ff) 15%, transparent);
+}
+/* When the action stands alone (e.g. "Restart to install" after download), let it
+   fill the row rather than hugging its label on the right. */
+.lunamux-update-banner .lu-update-action.lu-update-action-full {
+    flex: 1 1 auto;
+    text-align: center;
+}
+/* Download progress row (shown only while downloading), reusing the usage-bar
+   track/fill metrics. */
+.lunamux-update-banner .lu-update-progress-row {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+.lunamux-update-banner .lu-update-progress {
+    flex: 1 1 auto;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--t-chrome-track, color-mix(in srgb, currentColor 16%, transparent));
+    overflow: hidden;
+}
+.lunamux-update-banner .lu-update-progress-fill {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+    background: var(--t-accent, #4fb8ff);
+    transition: width 120ms linear;
+}
+
 /* Consolidated hover popup for the Claude usage bar (ClaudeUsageBar.kt's
    `buildUsagePopupHtml`). Parented to <body> and fixed-positioned by JS
    (the `.dt-sidebar` clips with overflow:hidden, so it can't live inside the


### PR DESCRIPTION
## What

In-app auto-update for the Electron desktop build (`electron-updater`) plus a local, metadata-safe release/publish flow (MacOS).

## In-app updater

- **Main process:** `ElectronUpdaterExternals.kt` + `AutoUpdater.kt` — configure electron-updater, forward lifecycle events → renderer, and check/download/quit-and-install. Guarded on `app.isPackaged`; `autoDownload=false` and `autoInstallOnAppQuit=false` so it's fully **opt-in** (a downloaded update applies only when the user clicks "Restart to install", never silently on quit). quit-and-install stops the bundled server first (`POST /admin/shutdown`) so the relaunched app doesn't reconnect to the stale server. Wired into `ElectronMain.kt` (IPC channels + a "Check for Updates…" Help-menu item).
- **Preload:** `checkForUpdates` / `downloadUpdate` / `quitAndInstall` + `onUpdate*` subscriptions.
- **Renderer:** a compact update **banner pinned to the top of the left sidebar footer** (`AutoUpdaterPanel.kt`, `.lunamux-update-banner`), styled to the footer idiom (theme tokens) — accent title + version, a **"What's new"** link (opens the GitHub release page), a progress bar, and a **Download / Restart to install** action (full-width once downloaded). Clicks transition optimistically so they feel instant. The renderer fires the initial check itself *after* subscribing, so `update-available` can't be missed on launch. A silent **4-hour periodic re-check** keeps long-running sessions informed (skipped mid-flow so a DOWNLOADED banner is never downgraded). The "Connection lost" modal is suppressed during the intentional install teardown.
- Desktop suppresses the `versions.json` update branch (`enableUpdateCheck=false`; **mobile unchanged**); the top-bar bell stays news-only.

## Failure-path hardening

The install teardown assumes nothing:

- `update:quit-and-install` is guarded on a main-side `updateDownloaded` flag, so a state-desynced renderer can't shut the server down for an install that would throw; the install itself is wrapped so a failure surfaces on the banner's error channel and re-arms the quit-confirmation gate instead of dying as an uncaught main-process exception.
- The banner re-enables its action button on every render, so a failed install's "Try again" is actually clickable.
- The "Connection lost" suppression un-sticks when the teardown it anticipated is abandoned: a `quit-cancelled` IPC fires when a kill-server quit is cancelled after a failed shutdown, and the banner's error handler clears it after a failed install — both re-evaluate the aggregate connection status immediately.

## Release / publish (local, metadata-safe)

- `electron/package.json`: mac `zip` target (required for `latest-mac.yml`), GitHub `publish` (draft) provider, `electron-updater` dep, and `dist` never auto-publishes.
- `electron/build.gradle.kts`: **`chmod -R u+w` the jlink'd JRE** — its `legal/` files are read-only, which blocked Squirrel.Mac from stripping the download quarantine on install (the update aborted and relaunched the OLD version; this would have broken production auto-updates too).
- `scripts/release-electron.sh`: builds **locally** (no CI), staples the DMG, and publishes a GitHub **draft** release uploading a fixed glob (dmg + zip + `latest-mac.yml` + `.blockmap`) so metadata can't be forgotten. Flags: `--repo`, `--identity` (self-signed fork testing), `--no-notarize`, `--no-publish` (local build→install loops). Guardrails: test builds **refuse to publish to the production repo**, already-**published** releases are never clobbered, every artifact class is asserted present before upload, and `latest-mac.yml`'s dmg hash is refreshed after stapling rewrites the DMG.

## Verified

- `:electron-main` + `:web` compile.
- **Full end-to-end loop tested** with a free self-signed cert against the fork: banner → Download → progress → Restart → relaunch into the new version. Signature-match + ShipIt install confirmed working (after the JRE-writable fix).
- The release-script guards (production-repo refusal, `--help`) and the `latest-mac.yml` refresh logic exercised directly; the hardening paths compile-verified and reviewed (they need a staged install failure to exercise live).

## Notes

- Production signing stays the maintainer's Developer ID (unchanged). Fork testing uses a free self-signed cert (Squirrel.Mac checks a signature *match*, not notarization).
- "What's new" links to the GitHub release for now; an in-app release **news post** + **auto versioning/changelog** are deferred to **SOD-37**.

Refs SOD-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
