### PR TITLE
Keep the MCP SSE stream inside Netty's write timeout

### DIFF
--- a/server/src/main/kotlin/se/soderbjorn/lunamux/mcp/McpRoutes.kt
+++ b/server/src/main/kotlin/se/soderbjorn/lunamux/mcp/McpRoutes.kt
@@ -57,8 +57,19 @@ private val log = LoggerFactory.getLogger("McpRoutes")
 /** Header carrying the MCP session id (per the streamable-HTTP spec). */
 private const val SESSION_HEADER = "Mcp-Session-Id"
 
-/** Keepalive cadence for SSE responses while a tool call blocks. */
-private const val SSE_KEEPALIVE_MS = 15_000L
+/**
+ * Keepalive cadence for SSE responses while a tool call blocks.
+ *
+ * **Must stay comfortably below Netty's `responseWriteTimeoutSeconds`
+ * (default 10s)** — that handler tears down any HTTP/1.1 connection whose
+ * response goes that long without producing bytes. HTTP/2 clients are
+ * exempt, so a too-slow cadence fails only for HTTP/1.1 callers: notably
+ * Node/undici, and therefore Claude Code, whose watch tools all died at
+ * exactly 10s until this was lowered from 15s.
+ *
+ * @see McpSseKeepaliveTest
+ */
+private const val SSE_KEEPALIVE_MS = 5_000L
 
 /**
  * Authorize an `/mcp` request. On failure the response has already been
@@ -122,6 +133,13 @@ fun Route.mcpRoutes(
             call.respondTextWriter(ContentType.Text.EventStream) {
                 coroutineScope {
                     val pending = async { McpServer.handleMessage(body, scope, session) }
+                    // Flush one keepalive up front so the response headers and
+                    // a first byte reach the client immediately. Without this
+                    // the whole SSE_KEEPALIVE_MS window elapses before anything
+                    // is written, which both starves Netty's write timeout and
+                    // leaves clients unsure the stream ever opened.
+                    write(": keepalive\n\n")
+                    flush()
                     while (true) {
                         val finished = withTimeoutOrNull(SSE_KEEPALIVE_MS) { pending.join() }
                         if (finished != null) break

--- a/server/src/test/kotlin/se/soderbjorn/lunamux/mcp/McpSseKeepaliveTest.kt
+++ b/server/src/test/kotlin/se/soderbjorn/lunamux/mcp/McpSseKeepaliveTest.kt
@@ -1,0 +1,102 @@
+/**
+ * Regression test for the SSE keepalive cadence on the `/mcp` endpoint.
+ *
+ * A long-running `tools/call` is answered as an SSE stream (see [mcpRoutes]).
+ * Ktor's Netty engine applies a `responseWriteTimeoutSeconds` of 10s by
+ * default, so if the first keepalive is written later than that — or if two
+ * consecutive writes are more than 10s apart — Netty tears the connection
+ * down mid-call. HTTP/2 clients (curl's ALPN default) are unaffected, which
+ * is why this hid for so long: the primary consumer, Claude Code, speaks
+ * HTTP/1.1 only (Node/undici) and saw every watch tool die at exactly 10s.
+ *
+ * This boots a *real* Netty server on a real port — the Ktor test engine
+ * (used by [McpRoutesTest]) has no Netty pipeline and cannot reproduce it —
+ * and drives it with an explicitly HTTP/1.1 client.
+ *
+ * @see mcpRoutes
+ */
+package se.soderbjorn.lunamux.mcp
+
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import se.soderbjorn.lunamux.ClaudeUsageMonitor
+import se.soderbjorn.lunamux.auth.DeviceAuth
+import se.soderbjorn.lunamux.persistence.SettingsRepository
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class McpSseKeepaliveTest {
+
+    /** Longer than Netty's 10s `responseWriteTimeoutSeconds` default. */
+    private val blockMs = 13_000L
+
+    @Test
+    fun `a blocking tool call survives past netty's write timeout over HTTP1_1`() = runBlocking {
+        val dir = File.createTempFile("lunamux-mcp-sse", "").apply {
+            delete(); mkdirs(); deleteOnExit()
+        }
+        val repo = SettingsRepository(File(dir, "test.db"))
+        repo.setMcpEnabled(true)
+        DeviceAuth.addTrustedToken(repo, "sse-tok", DeviceAuth.MCP_LABEL, DeviceAuth.MCP_SCOPE_READ)
+
+        val server = embeddedServer(Netty, port = 0) {
+            routing { mcpRoutes(repo, ClaudeUsageMonitor()) }
+        }
+        server.start(wait = false)
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+
+            // A tool that only blocks — isolates the transport from session
+            // plumbing. Re-registration by name is supported for tests.
+            McpServer.register(
+                McpTool("__test_block", "Block for the test duration.", schemaObject()) { _, _ ->
+                    delay(blockMs)
+                    McpToolResult.text("unblocked")
+                }
+            )
+
+            val client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build()
+            val req = HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port/mcp"))
+                .header("Content-Type", "application/json")
+                // Claude Code sends exactly this, which selects the SSE branch.
+                .header("Accept", "application/json, text/event-stream")
+                .header("X-Termtastic-Auth", "sse-tok")
+                .timeout(Duration.ofSeconds(60))
+                .POST(
+                    HttpRequest.BodyPublishers.ofString(
+                        """{"jsonrpc":"2.0","id":1,"method":"tools/call",""" +
+                            """"params":{"name":"__test_block","arguments":{}}}"""
+                    )
+                )
+                .build()
+
+            val started = System.currentTimeMillis()
+            val resp = client.send(req, HttpResponse.BodyHandlers.ofString())
+            val elapsed = System.currentTimeMillis() - started
+
+            assertTrue(
+                resp.body().contains("unblocked"),
+                "SSE stream did not deliver the tool result (elapsed ${elapsed}ms, " +
+                    "body=${resp.body().take(200)})",
+            )
+            assertTrue(
+                elapsed >= blockMs,
+                "Returned too early (${elapsed}ms) — the call did not actually block",
+            )
+        } finally {
+            server.stop(1000, 2000)
+        }
+    }
+}


### PR DESCRIPTION
Every blocking MCP tool — `watch_output`, `wait_for_idle`, `wait_for_exit`, and `run_command` with `waitForExit` — dies after **exactly 10 seconds** when driven from Claude Code. The client sees the connection drop (`UND_ERR_SOCKET`), not a tool-level error. Fast tools are unaffected, which is what makes it look like a client problem rather than ours.

## Cause

`mcpRoutes` answers a long `tools/call` as an SSE stream, and the first keepalive went out after `SSE_KEEPALIVE_MS` = 15s. Ktor's Netty engine applies a `responseWriteTimeoutSeconds` of 10s, tearing down any HTTP/1.1 connection whose response has produced no bytes for that long — five seconds before the keepalive that was meant to hold it open.

HTTP/2 callers are exempt from that handler, which is why this went unnoticed: `curl` negotiates h2 via ALPN and always worked. Node/undici speaks HTTP/1.1 only, so Claude Code — the surface these tools exist to serve — hit it on every blocking call.

| Client / path | Result |
|---|---|
| curl, default (HTTP/2 via ALPN) | works — keepalive at 15s, result at 20s |
| curl `--http1.1` | killed at exactly 10s (`Empty reply from server`) |
| Node `fetch` (undici, HTTP/1.1) | killed at exactly 10.0s (`UND_ERR_SOCKET`) |
| Node, blocking 5s / 9s | fine — under the threshold |

A plain Node HTTP server with the same 15s delay to first byte does not reproduce it, which rules out the client and points at the Netty pipeline.

## Change

- `SSE_KEEPALIVE_MS` 15s → 5s, so no write gap can exceed Netty's window. The reason is documented on the constant so it doesn't get tuned back up.
- Flush one keepalive before entering the wait loop, so headers and a first byte leave immediately.

`GET /mcp` shares the constant and is fixed alongside.

## Tests

`McpSseKeepaliveTest` boots a real `embeddedServer(Netty)` on a real port and drives it with an explicitly HTTP/1.1 client. This is deliberate: `McpRoutesTest`'s `testApplication` host has no Netty pipeline, so it cannot observe this class of bug at all.

Red before the change (`IOException: HTTP/1.1 header parser received no bytes` at 11.99s), green after (14.81s). Full MCP suite: 28 tests, 0 failures.

Also verified live against a patched server driven by Node/undici over HTTP/1.1 — `watch_output` 20s returned at 20.0s, and `run_command "sleep 12 && echo ..."` with `waitForExit` returned `exitCode: 0` at 12.0s. Both previously died at 10s.

One judgement call worth flagging: the new test costs ~15s of wall clock, since reproducing the bug means genuinely blocking past 10s. Happy to put it behind a JUnit tag if that's unwelcome in the default suite.

LMX-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)