### PR TITLE
Make the Android overview an app switcher, with truthful previews and a dive transition

### DIFF
--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/net/ConnectionHolder.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/net/ConnectionHolder.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import se.soderbjorn.lunamux.HostPort
 import se.soderbjorn.lunamux.android.BuildConfig
+import se.soderbjorn.lunamux.android.ui.MiniTerminalRegistry
 import se.soderbjorn.lunamux.client.CandidateConnection
 import se.soderbjorn.lunamux.client.CandidateConnector
 import se.soderbjorn.lunamux.client.ClientIdentity
@@ -259,6 +260,11 @@ object ConnectionHolder {
         currentWindowSocket = null
         currentClient?.close()
         currentClient = null
+        // The thumbnail frame cache outlives any registry (it is process-wide,
+        // so returning to the overview paints instantly), which means leaving a
+        // host would otherwise keep its rendered screens in memory and seed the
+        // next host's overview from them.
+        MiniTerminalRegistry.clearFrameCache()
     }
 
     /**

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/DiveTransition.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/DiveTransition.kt
@@ -1,0 +1,118 @@
+/**
+ * Shared-element "dive" transition plumbing between the overview's mini panes
+ * and the full-screen terminal.
+ *
+ * Tapping a terminal card in the overview should feel like diving into it: the
+ * card's bounds morph into the terminal screen's content box, and the reverse
+ * plays on back. This file carries the two composition locals the
+ * transition needs ([LunamuxApp] provides them: the app-level
+ * [SharedTransitionScope] around the NavHost and each involved destination's
+ * [AnimatedVisibilityScope]) and the [diveSharedBounds] modifier both ends
+ * attach.
+ *
+ * The experimental shared-transition opt-in is deliberately confined to this
+ * file and [LunamuxApp]; call sites only see a plain [Modifier] extension.
+ *
+ * IMPORTANT constraint: [diveSharedBounds] keeps `sharedBounds`' default
+ * `resizeMode = ScaleToBounds`, which measures the content once at its final
+ * bounds and only layer-scales during the flight. The terminal side wraps an
+ * `AndroidView` whose relayout fires size votes to the server
+ * (see `TerminalScreen`'s layout listener) — `RemeasureToBounds` would relayout
+ * it every frame of the animation and must never be used here.
+ *
+ * @see LunamuxApp
+ * @see OverviewContent
+ * @see TerminalScreen
+ */
+package se.soderbjorn.lunamux.android.ui
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+
+/**
+ * The app-level [SharedTransitionScope] wrapping the NavHost, or `null` when
+ * the current composition is not inside one (previews, tests). Provided by
+ * [LunamuxApp].
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+
+/**
+ * The nav destination's [AnimatedVisibilityScope] (nav-compose's `composable`
+ * content receiver), or `null` outside a destination that provides one.
+ * Provided by [LunamuxApp] for the `tree` and `terminal/{sessionId}` routes —
+ * the two ends of the dive.
+ */
+val LocalNavAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
+
+/**
+ * Shared-content key for the dive between a session's mini card and its
+ * full-screen terminal. Keyed by session id; the overview attaches it only to
+ * the single tapped pane (see `divePaneId` in [OverviewContent]) so linked
+ * panes sharing a session can never register duplicate keys.
+ *
+ * @param sessionId the PTY session both ends render.
+ * @return the shared-content key.
+ */
+fun diveKey(sessionId: String): String = "terminal-dive/$sessionId"
+
+/**
+ * How long the bounds take to fly, and on what curve. A tween rather than the
+ * default spring, and the same duration as the routes' own fades in
+ * [LunamuxApp], so the card's flight and the chrome swapping around it read as
+ * one movement instead of two overlapping ones.
+ */
+private const val DIVE_DURATION_MS = 300
+
+/**
+ * How long the *outgoing* end stays visible. Both ends of the dive render the
+ * same session, but not identically framed — the card shows it inside a mini
+ * pane with a title bar, the terminal shows it in the full content box — so the
+ * default half-second crossfade drew two copies of the same text at two scales
+ * through each other for the whole flight, which is the "double image" the
+ * transition looked wrong for. The incoming end is instead opaque from the first
+ * frame and the outgoing one is gone within a couple of frames, leaving a single
+ * rendering to scale up.
+ */
+private const val DIVE_HANDOFF_MS = 70
+
+/**
+ * Attach `sharedBounds` for [key] when composed inside a live shared-transition
+ * scope AND a nav destination scope; a no-op otherwise, so call sites degrade
+ * gracefully wherever the transition can't run (sidebar-originated opens, host
+ * previews, tests).
+ *
+ * Keeps the default `ScaleToBounds` resize mode — see the file header for why
+ * that default is load-bearing — and replaces the default crossfade with an
+ * immediate handoff (see [DIVE_HANDOFF_MS]). The same spec serves both
+ * directions: whichever end is entering appears at once, whichever is leaving
+ * fades out immediately.
+ *
+ * @param key a [diveKey]; the same key must be attached on both ends.
+ * @return this modifier, with `sharedBounds` appended when the scopes exist.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.diveSharedBounds(key: String): Modifier {
+    val sharedScope = LocalSharedTransitionScope.current ?: return this
+    val navScope = LocalNavAnimatedVisibilityScope.current ?: return this
+    return with(sharedScope) {
+        this@diveSharedBounds.sharedBounds(
+            sharedContentState = rememberSharedContentState(key),
+            animatedVisibilityScope = navScope,
+            enter = EnterTransition.None,
+            exit = fadeOut(tween(durationMillis = DIVE_HANDOFF_MS)),
+            boundsTransform = { _, _ ->
+                tween(durationMillis = DIVE_DURATION_MS, easing = FastOutSlowInEasing)
+            },
+        )
+    }
+}

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/LunamuxApp.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/LunamuxApp.kt
@@ -2,10 +2,12 @@
  * Main app composable and navigation graph for the Lunamux Android app.
  *
  * Defines the [LunamuxApp] composable which sets up a Jetpack Navigation
- * [NavHost] with horizontal-slide transitions. Routes include hosts selection,
- * tree overview, terminal sessions, file browser (list and content), and git
- * (list and diff). All destinations are driven by URI-style route parameters
- * for pane IDs, session IDs, and file paths.
+ * [NavHost] with horizontal-slide transitions, except tree↔terminal which
+ * cross-fades under a shared-element "dive" (the tapped overview card morphs
+ * into the terminal's content box — see [DiveTransition]). Routes include
+ * hosts selection, tree overview, terminal sessions, file browser (list and
+ * content), and git (list and diff). All destinations are driven by URI-style
+ * route parameters for pane IDs, session IDs, and file paths.
  *
  * On connection, fetches the user's theme config from the server, resolves it
  * to a flat [se.soderbjorn.lunula.core.ResolvedTheme], and provides it via
@@ -22,7 +24,11 @@ package se.soderbjorn.lunamux.android.ui
 
 import android.content.Context
 import android.net.Uri
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
@@ -80,6 +86,7 @@ import se.soderbjorn.lunamux.WindowConfig
  * @see se.soderbjorn.lunamux.android.MainActivity
  * @see LocalUiSettings
  */
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun LunamuxApp(applicationContext: Context) {
     // First-launch onboarding gate, sourced from the shared LocalRepository.
@@ -240,6 +247,11 @@ fun LunamuxApp(applicationContext: Context) {
         colorScheme = colorScheme,
     ) {
       CompositionLocalProvider(LocalUiSettings provides theme) {
+       // The dive transition's shared-element overlay lives at this layout; the
+       // scope is published so the two ends (overview card, terminal box) can
+       // attach diveSharedBounds without threading receivers through screens.
+       SharedTransitionLayout {
+        CompositionLocalProvider(LocalSharedTransitionScope provides this) {
         NavHost(
             navController = navController,
             startDestination = "hosts",
@@ -278,7 +290,29 @@ fun LunamuxApp(applicationContext: Context) {
                     onOpenNews = { navController.navigate("news") },
                 )
             }
-            composable("tree") {
+            composable(
+                "tree",
+                // Toward/from the terminal the tree must not slide — a sliding
+                // source/target warps the shared-element flight path — so those
+                // legs cross-fade and the dive overlay carries the motion.
+                // Returning null falls back to the NavHost-level slides for
+                // every other neighbor (files/git/news).
+                exitTransition = {
+                    if (targetState.destination.route?.startsWith("terminal/") == true) {
+                        fadeOut(tween(durationMillis = 300))
+                    } else {
+                        null
+                    }
+                },
+                popEnterTransition = {
+                    if (initialState.destination.route?.startsWith("terminal/") == true) {
+                        fadeIn(tween(durationMillis = 300))
+                    } else {
+                        null
+                    }
+                },
+            ) {
+                CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
                 TreeScreen(
                     themeVm = themeVm,
                     onOpenTerminal = { sessionId ->
@@ -298,6 +332,7 @@ fun LunamuxApp(applicationContext: Context) {
                     },
                     onOpenNews = { navController.navigate("news") },
                 )
+                }
             }
             composable("news") {
                 NewsUpdatesScreen(onBack = { navController.popBackStack() })
@@ -305,12 +340,21 @@ fun LunamuxApp(applicationContext: Context) {
             composable(
                 route = "terminal/{sessionId}",
                 arguments = listOf(navArgument("sessionId") { type = NavType.StringType }),
+                // Fades on every leg: the dive overlay (shared bounds between the
+                // overview card and the terminal box) carries the motion, and a
+                // slide underneath it would warp the flight path.
+                enterTransition = { fadeIn(tween(durationMillis = 300)) },
+                exitTransition = { fadeOut(tween(durationMillis = 300)) },
+                popEnterTransition = { fadeIn(tween(durationMillis = 300)) },
+                popExitTransition = { fadeOut(tween(durationMillis = 300)) },
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
+                CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
                 TerminalScreen(
                     sessionId = sessionId,
                     onBack = { navController.popBackStack() },
                 )
+                }
             }
             composable(
                 route = "files/{paneId}",
@@ -394,6 +438,8 @@ fun LunamuxApp(applicationContext: Context) {
                 )
             }
         }
+        }
+       }
       }
     }
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalPane.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalPane.kt
@@ -1,66 +1,51 @@
 /**
  * Read-only terminal miniature for the overview screen.
  *
- * Fills the pane with the **most recent output lines** at a legible font,
- * anchored to the bottom and growing upward — so you get an actual sense of
- * what the pane is doing. Long lines are word-wrapped to the (narrow) pane
- * width; older lines scroll off the top (clipped) like a real terminal tail.
+ * Renders the session's screen as a truthful scaled-down "screenshot": the
+ * server's real cols×rows grid, its real wrapping, ANSI colors and the cursor,
+ * letterboxed to the pane (see [TerminalThumbnail]). Text at this scale may be
+ * tiny — the miniature is meant to look like the OS app switcher's live cards,
+ * where layout and color carry the recognition, not legibility.
  *
  * This composable is a thin renderer: all socket/emulator lifecycle lives in
  * the overview-scoped [MiniTerminalRegistry] (provided via
  * [LocalMiniTerminalRegistry]), which keeps one live emulator per session alive
- * across tab switches and recompositions. The miniature just collects the
- * registry's per-session lines flow, so re-entering a tab renders instantly
- * with no reconnect.
- *
- * Rendering uses a `reverseLayout` [LazyColumn] so the newest line is always
- * pinned to the bottom and surplus lines clip off the top (a plain
- * bottom-aligned Column instead gets height-constrained and shows its *oldest*
- * rows, which looked like content "from a page up" or an empty pane).
+ * across tab switches and recompositions and publishes resolved
+ * [TerminalFrame] snapshots. The miniature just collects the registry's
+ * per-session frame flow, so re-entering a tab renders instantly with no
+ * reconnect.
  *
  * Composed by [OverviewContent]'s pane dispatch for terminal leaves; the
  * whole-pane tap that drills into the full-screen terminal is owned by the
  * caller's overlay, so this composable stays render-only.
  *
  * CONSOLIDATION: this is the Android "paint" end of the terminal-thumbnail
- * pipeline (the iOS analogue is `MiniTerminalPane` in `OverviewView.swift`; the
- * web analogue is `renderThumbnail` in `LinkThumbnailRenderer.kt`). The paint is
- * irreducibly platform-specific (Compose `LazyColumn` here, SwiftUI overlay on
- * iOS, HTML5 canvas on web), but it leans on Compose `Text` to re-wrap each
- * logical line to the pane width and on `reverseLayout` to bottom-anchor — two
- * steps the web has to do by hand and which could become shared pure helpers.
- * See the design note in `web/.../LinkThumbnailRenderer.kt`.
+ * pipeline. Android now paints the exact colored grid (the fidelity web's
+ * `Overview3DThumb.kt` `ThumbView.paintGrid` reaches on its 3D cards), while
+ * iOS (`MiniTerminalPane` in `OverviewView.swift`) and web's link picker
+ * (`LinkThumbnailRenderer.kt`) still re-wrap transcript *text* to the card
+ * width — the platforms have diverged; reconcile toward the grid-truthful
+ * approach when those thumbnails are next touched.
  *
  * @see MiniTerminalRegistry
+ * @see TerminalThumbnail
  * @see OverviewContent
  * @see TerminalScreen
  */
 package se.soderbjorn.lunamux.android.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import se.soderbjorn.lunamux.android.net.ConnectionHolder
 
-/** Legible monospace font size (sp) for the miniature's content lines. */
-private const val MINI_TERMINAL_FONT_SP = 9
-
 /**
- * Live, read-only terminal miniature for [sessionId] that fills the pane with
- * the most recent (word-wrapped) output lines, bottom-anchored.
+ * Live, read-only terminal miniature for [sessionId]: the session's screen as
+ * a colored grid, uniformly scaled to fit the pane.
  *
  * @param sessionId the PTY session to mirror.
  * @param modifier  layout modifier from the enclosing mini-pane.
@@ -78,32 +63,13 @@ fun MiniTerminalPane(
     }
 
     val palette = rememberTerminalPalette(client, sessionId)
-    val context = LocalContext.current
-    val terminalFontFamily = remember(context) { FontFamily(TerminalFont.typeface(context)) }
-    val linesFlow = remember(registry, sessionId) { registry.linesFor(sessionId) }
-    val lines by linesFlow.collectAsStateWithLifecycle()
-
-    // Newest line first, rendered with reverseLayout so item 0 sits at the
-    // bottom and older lines fill upward, clipping off the top.
-    val display = remember(lines) { lines.asReversed() }
-    LazyColumn(
-        modifier = modifier.background(Color(palette.bg)),
-        reverseLayout = true,
-        userScrollEnabled = false,
-        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 2.dp),
-    ) {
-        items(display) { line ->
-            Text(
-                text = line,
-                color = Color(palette.text),
-                // The shared terminal face, not FontFamily.Monospace: the system mono
-                // font carries no Iosevka fallback, so the terminal symbols JetBrains Mono
-                // lacks (⏺, ⎿, …) fall through to Noto Color Emoji and the miniature fills
-                // with emoji buttons (#141).
-                fontFamily = terminalFontFamily,
-                fontSize = MINI_TERMINAL_FONT_SP.sp,
-                lineHeight = (MINI_TERMINAL_FONT_SP + 2).sp,
-            )
-        }
-    }
+    val frameFlow = remember(registry, sessionId) { registry.frameFor(sessionId) }
+    val frame by frameFlow.collectAsStateWithLifecycle()
+    // Until the first frame lands the box shows the theme background, so the
+    // frame that replaces it changes content, not color.
+    TerminalThumbnail(
+        frame = frame,
+        fallbackBackground = Color(palette.bg),
+        modifier = modifier,
+    )
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
@@ -185,13 +185,19 @@ class MiniTerminalRegistry(
             handleInput = {},
         )
         val emulator = createSyncedEmulator(session)
-        val frame = MutableStateFlow<TerminalFrame?>(null)
+        // Seed from the process-wide last-frame cache: a registry rebuilt after
+        // navigation (tree → terminal → back) shows each session's last-known
+        // screen instantly while its socket reattaches, instead of a blank box —
+        // which is also what the dive transition's reverse flight renders.
+        val frame = MutableStateFlow<TerminalFrame?>(lastFrames.get(sessionId))
         val dirty = Channel<Unit>(Channel.CONFLATED)
-        val revision = AtomicLong(0)
+        val revision = AtomicLong(frame.value?.revision ?: 0)
         // Nothing is worth snapshotting until the server's attach redraw lands:
         // a fresh emulator is a blank 80x24 grid, and the theme/size signals
         // below both fire long before the socket's first bytes (each entry opens
-        // its own socket, so the replay is a connect + RTT away).
+        // its own socket, so the replay is a connect + RTT away) — publishing
+        // that blank would replace the seeded last-known screen and poison the
+        // cache the dive transition flies back to.
         val hasContent = AtomicBoolean(false)
         // Set while a dirty signal went unpublished because nothing was
         // collecting the flow; cleared when the deferred snapshot is taken.
@@ -263,9 +269,11 @@ class MiniTerminalRegistry(
                 deferred.set(true)
                 if (frame.subscriptionCount.value == 0) continue
                 deferred.set(false)
-                frame.value = withContext(dispatcher) {
+                val next = withContext(dispatcher) {
                     synchronized(emulator) { snapshotFrame(emulator, revision.incrementAndGet()) }
                 }
+                frame.value = next
+                lastFrames.put(sessionId, next)
                 delay(THUMB_FRAME_MIN_INTERVAL_MS)
             }
         }
@@ -292,6 +300,58 @@ class MiniTerminalRegistry(
      */
     private fun reapplyTheme(emulator: TerminalEmulator) {
         theme?.let { applyDefaultColors(emulator, it) }
+    }
+
+    companion object {
+        /**
+         * Process-wide cache of each session's most recent frame, surviving
+         * registry teardown (the overview closes all sockets whenever the tree
+         * leaves composition). Seeds fresh entries so returning to the overview
+         * — including the dive transition's reverse flight — paints the
+         * last-known screen immediately. Sixteen entries comfortably covers a
+         * world's visible panes; stale sessions age out.
+         */
+        private val lastFrames = android.util.LruCache<String, TerminalFrame>(16)
+
+        /**
+         * The last frame published for [sessionId] by any registry, or `null`.
+         *
+         * Read by `TerminalScreen`, which paints it over its still-empty view
+         * until the session's own output lands — the dive transition would
+         * otherwise grow an empty box.
+         *
+         * @param sessionId the session whose frame to look up.
+         * @return the cached frame, or `null` if none was ever published.
+         */
+        internal fun lastFrameFor(sessionId: String): TerminalFrame? = lastFrames.get(sessionId)
+
+        /**
+         * Publish a frame captured outside any registry.
+         *
+         * Called by `TerminalScreen` as the user leaves a terminal: the
+         * full-screen view owns a live emulator, and it is the only thing that
+         * knows the session's current screen while the overview's registry is
+         * torn down. Without it the card the reverse flight lands on shows the
+         * session as it was before the dive, until its socket has reattached.
+         *
+         * @param sessionId the session the frame belongs to.
+         * @param frame     the snapshot to cache.
+         */
+        internal fun putFrame(sessionId: String, frame: TerminalFrame) {
+            lastFrames.put(sessionId, frame)
+        }
+
+        /**
+         * Drop every cached frame. Called when the app disconnects from a host
+         * (see [se.soderbjorn.lunamux.android.net.ConnectionHolder.disconnect]):
+         * the cache is process-wide and keyed by bare session id, so without
+         * this it would both keep up to sixteen rendered screens of a host the
+         * user has left in memory, and — if two hosts ever mint the same id —
+         * seed the next host's overview with the previous host's screen.
+         */
+        fun clearFrameCache() {
+            lastFrames.evictAll()
+        }
     }
 
     /**

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
@@ -75,6 +75,13 @@ import se.soderbjorn.lunula.core.ResolvedTheme
 private const val THUMB_FRAME_MIN_INTERVAL_MS = 100L
 
 /**
+ * How many sessions may hold a live socket + emulator at once. Comfortably above
+ * the handful of cards the switcher composes, so the cap only ever retires
+ * sessions the row has been flung past (see [MiniTerminalRegistry.trimToCap]).
+ */
+private const val MAX_LIVE_ENTRIES = 8
+
+/**
  * CompositionLocal exposing the active [MiniTerminalRegistry], or `null` when
  * not inside an overview that provides one.
  */
@@ -107,10 +114,29 @@ class MiniTerminalRegistry(
         val resubscribeJob: Job,
         val dirty: Channel<Unit>,
         val frame: MutableStateFlow<TerminalFrame?>,
-    )
+    ) {
+        /**
+         * Stop this entry for good: cancel its jobs, detach its socket (so the close
+         * reaches the server even as the overview's scope unwinds) and release its
+         * thread. Called by [close] and by [trimToCap].
+         */
+        fun shutdown() {
+            job.cancel()
+            publishJob.cancel()
+            resubscribeJob.cancel()
+            dirty.close()
+            socket.closeDetached()
+            runCatching { dispatcher.close() }
+        }
+    }
 
     private val lock = Any()
-    private val entries = HashMap<String, Entry>()
+
+    /**
+     * Live entries, in least-recently-requested order (a [LinkedHashMap] in access
+     * order), so [trimToCap] knows which to retire first.
+     */
+    private val entries = LinkedHashMap<String, Entry>(16, 0.75f, true)
     private var closed = false
 
     /**
@@ -157,8 +183,44 @@ class MiniTerminalRegistry(
      * @return a hot [StateFlow] of resolved screen snapshots; `null` until the
      *   first frame is published after attach.
      */
-    fun frameFor(sessionId: String): StateFlow<TerminalFrame?> = synchronized(lock) {
-        entries.getOrPut(sessionId) { createEntry(sessionId) }.frame.asStateFlow()
+    fun frameFor(sessionId: String): StateFlow<TerminalFrame?> {
+        val entry = synchronized(lock) {
+            // After close() the scope is cancelled, so a new entry's collector and
+            // publisher would never run — it would only leak a socket the server
+            // never sees detached and a thread nothing closes. A pane composed
+            // during teardown gets the last known frame instead.
+            if (closed) return MutableStateFlow(lastFrames.get(sessionId)).asStateFlow()
+            entries.getOrPut(sessionId) { createEntry(sessionId) }
+        }
+        trimToCap()
+        return entry.frame.asStateFlow()
+    }
+
+    /**
+     * Retire entries beyond [MAX_LIVE_ENTRIES], oldest first, skipping any a
+     * thumbnail is still collecting.
+     *
+     * Entries used to live until the overview closed, and each one is a PTY socket,
+     * an OS thread and an emulator holding a screen. That was tolerable when a swipe
+     * reached one tab; the switcher's row is flung across many, so browsing a
+     * world's worth of tabs accumulated all of them. The cap is well above what is
+     * ever composed at once, so this only ever collects sessions the user has
+     * scrolled away from.
+     */
+    private fun trimToCap() {
+        val retire = synchronized(lock) {
+            if (entries.size <= MAX_LIVE_ENTRIES) return
+            val doomed = mutableListOf<Entry>()
+            val stale = entries.entries
+                .filter { it.value.frame.subscriptionCount.value == 0 }
+                .take(entries.size - MAX_LIVE_ENTRIES)
+            for (candidate in stale) {
+                entries.remove(candidate.key)
+                doomed += candidate.value
+            }
+            doomed
+        }
+        retire.forEach { it.shutdown() }
     }
 
     /**
@@ -368,13 +430,6 @@ class MiniTerminalRegistry(
             entries.clear()
             snapshot
         }
-        for (entry in toClose) {
-            entry.job.cancel()
-            entry.publishJob.cancel()
-            entry.resubscribeJob.cancel()
-            entry.dirty.close()
-            entry.socket.closeDetached()
-            runCatching { entry.dispatcher.close() }
-        }
+        toClose.forEach { it.shutdown() }
     }
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
@@ -10,21 +10,37 @@
  * This registry decouples the PTY socket + headless emulator lifecycle from the
  * pane composables. It opens at most one socket per session id, keeps it alive
  * for as long as the overview is on screen (across tab switches and
- * recompositions), and exposes each session's most recent lines as a
- * [StateFlow]. A thumbnail composable simply collects that flow, so leaving and
- * re-entering a tab re-attaches to an already-populated emulator and renders
- * instantly — no reconnect, no churn. Panes that share a session (linked views)
- * share a single socket.
+ * recompositions), and exposes each session's screen as a [StateFlow] of
+ * [TerminalFrame] snapshots — the resolved colored grid at the server's own
+ * cols×rows, published at most every [THUMB_FRAME_MIN_INTERVAL_MS] ms. A
+ * thumbnail composable simply collects that flow, so leaving and re-entering a
+ * tab re-attaches to an already-populated emulator and renders instantly — no
+ * reconnect, no churn. Panes that share a session (linked views) share a
+ * single socket.
  *
  * The registry is created by [OverviewContent], provided via
  * [LocalMiniTerminalRegistry], and [close]d when the overview leaves
- * composition.
+ * composition. [OverviewContent] also pushes the resolved theme through
+ * [setDefaultColors] — the headless emulators otherwise keep the Termux stock
+ * palette for the default fg/bg/cursor slots, which the full-screen terminal
+ * overrides via `applyTerminalColors`. Because every server attach redraw (and
+ * every reconnect) starts with RIS, which resets the emulator's color table,
+ * the theme is re-applied whenever a reset passes through — the same rule the
+ * full-screen path follows via `containsTerminalReset`.
+ *
+ * Snapshots are gated twice, so a publisher only ever does work that shows up
+ * on screen: nothing is published before the attach redraw lands (a snapshot of
+ * the fresh 80×24 emulator is a blank frame that would replace real content),
+ * and nothing is published while no thumbnail is collecting the flow (an
+ * offscreen switcher card keeps its socket, not its snapshot cost) — a deferred
+ * snapshot is re-armed the moment someone collects again.
  *
  * Read-only invariant: like [MiniTerminalPane], entries never call
  * [se.soderbjorn.lunamux.client.PtySocket.resize]/`send`, so a thumbnail can
  * never shrink the real PTY for other clients.
  *
  * @see MiniTerminalPane
+ * @see TerminalFrame
  * @see OverviewContent
  */
 package se.soderbjorn.lunamux.android.ui
@@ -35,6 +51,8 @@ import com.termux.terminal.TerminalEmulator
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,12 +60,19 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import se.soderbjorn.lunamux.client.PtyEvent
 import se.soderbjorn.lunamux.client.PtySocket
 import se.soderbjorn.lunamux.client.LunamuxClient
+import se.soderbjorn.lunula.core.ResolvedTheme
 
-/** Max recent logical lines kept per miniature (see [MiniTerminalPane]). */
-private const val MINI_REGISTRY_MAX_LINES = 80
+/**
+ * Minimum interval between published frames per session (~10 fps). Bursty
+ * output coalesces in the conflated dirty channel; the first event after an
+ * idle stretch snapshots immediately.
+ */
+private const val THUMB_FRAME_MIN_INTERVAL_MS = 100L
 
 /**
  * CompositionLocal exposing the active [MiniTerminalRegistry], or `null` when
@@ -70,14 +95,18 @@ class MiniTerminalRegistry(
 ) {
     /**
      * A single live miniature: the PTY socket, its externally-fed emulator, the
-     * single-thread dispatcher serialising emulator access, the collector job,
-     * and the published lines.
+     * single-thread dispatcher serialising emulator access, the collector +
+     * publisher jobs, the dirty signal between them, and the published frames.
      */
     private class Entry(
         val socket: PtySocket,
+        val emulator: TerminalEmulator,
         val dispatcher: kotlinx.coroutines.ExecutorCoroutineDispatcher,
         val job: Job,
-        val lines: MutableStateFlow<List<String>>,
+        val publishJob: Job,
+        val resubscribeJob: Job,
+        val dirty: Channel<Unit>,
+        val frame: MutableStateFlow<TerminalFrame?>,
     )
 
     private val lock = Any()
@@ -85,20 +114,57 @@ class MiniTerminalRegistry(
     private var closed = false
 
     /**
-     * Return the most-recent-lines flow for [sessionId], creating and starting
-     * the underlying socket + emulator on first request. Subsequent calls (and
+     * The resolved theme applied to every entry's emulator (see
+     * [setDefaultColors]) and re-applied after every terminal reset. Null until
+     * the theme first resolves; entries created before that keep the Termux
+     * defaults until it lands.
+     */
+    @Volatile
+    private var theme: ResolvedTheme? = null
+
+    /**
+     * Theme every live emulator (present and future) via [applyDefaultColors] —
+     * the same three palette slots the full-screen terminal overrides through
+     * `applyTerminalColors` — and republish each session's frame so
+     * already-rendered thumbnails repaint.
+     *
+     * Called by [OverviewContent] whenever the resolved theme changes. The theme
+     * is also remembered here, both for entries created later and for the
+     * re-apply after a terminal reset.
+     *
+     * @param resolved the theme whose text/bg/accent become the emulators'
+     *   default fg/bg/cursor.
+     */
+    fun setDefaultColors(resolved: ResolvedTheme) {
+        theme = resolved
+        val snapshot = synchronized(lock) { entries.values.toList() }
+        for (entry in snapshot) {
+            scope.launch {
+                withContext(entry.dispatcher) {
+                    synchronized(entry.emulator) { applyDefaultColors(entry.emulator, resolved) }
+                }
+                entry.dirty.trySend(Unit)
+            }
+        }
+    }
+
+    /**
+     * Return the frame flow for [sessionId], creating and starting the
+     * underlying socket + emulator on first request. Subsequent calls (and
      * other panes sharing the session) get the same flow.
      *
      * @param sessionId the PTY session to mirror.
-     * @return a hot [StateFlow] of the session's trailing lines, oldest-to-newest.
+     * @return a hot [StateFlow] of resolved screen snapshots; `null` until the
+     *   first frame is published after attach.
      */
-    fun linesFor(sessionId: String): StateFlow<List<String>> = synchronized(lock) {
-        entries.getOrPut(sessionId) { createEntry(sessionId) }.lines.asStateFlow()
+    fun frameFor(sessionId: String): StateFlow<TerminalFrame?> = synchronized(lock) {
+        entries.getOrPut(sessionId) { createEntry(sessionId) }.frame.asStateFlow()
     }
 
     /**
      * Build and start a live entry for [sessionId]: open the socket, wire a
-     * headless emulator, and collect size + output into the lines flow.
+     * headless emulator, collect size + output events, and publish throttled
+     * [TerminalFrame] snapshots.
      */
     private fun createEntry(sessionId: String): Entry {
         val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
@@ -119,7 +185,26 @@ class MiniTerminalRegistry(
             handleInput = {},
         )
         val emulator = createSyncedEmulator(session)
-        val lines = MutableStateFlow<List<String>>(emptyList())
+        val frame = MutableStateFlow<TerminalFrame?>(null)
+        val dirty = Channel<Unit>(Channel.CONFLATED)
+        val revision = AtomicLong(0)
+        // Nothing is worth snapshotting until the server's attach redraw lands:
+        // a fresh emulator is a blank 80x24 grid, and the theme/size signals
+        // below both fire long before the socket's first bytes (each entry opens
+        // its own socket, so the replay is a connect + RTT away).
+        val hasContent = AtomicBoolean(false)
+        // Set while a dirty signal went unpublished because nothing was
+        // collecting the flow; cleared when the deferred snapshot is taken.
+        val deferred = AtomicBoolean(false)
+
+        // Theme the fresh emulator if the resolved theme already landed; a
+        // theme arriving later reaches it via setDefaultColors.
+        theme?.let { resolved ->
+            scope.launch {
+                withContext(dispatcher) { synchronized(emulator) { applyDefaultColors(emulator, resolved) } }
+                dirty.trySend(Unit)
+            }
+        }
 
         // One ordered collector: size, output and reconnect resets applied to
         // the headless preview emulator in the order the server produced them
@@ -137,7 +222,18 @@ class MiniTerminalRegistry(
                                 runCatching {
                                     emulator.resize(ev.cols, ev.rows, 1, 1)
                                 }
-                            is PtyEvent.Bytes -> emulator.append(ev.data, ev.data.size)
+                            is PtyEvent.Bytes -> {
+                                emulator.append(ev.data, ev.data.size)
+                                hasContent.set(true)
+                                // The attach redraw is RIS-prefixed, and a real
+                                // `reset` in the shell sends one too. RIS resets
+                                // the color table to the Termux stock palette, so
+                                // the phone theme has to be written back or the
+                                // thumbnail renders stock-black from the first
+                                // attach onwards (the full-screen path re-applies
+                                // on the same detection).
+                                if (containsTerminalReset(ev.data)) reapplyTheme(emulator)
+                            }
                             // A thumbnail renders at whatever width the server sends and
                             // never votes, so it is never the governor and has nothing to
                             // change when governance moves.
@@ -145,23 +241,64 @@ class MiniTerminalRegistry(
                             PtyEvent.Reset -> {
                                 val ris = byteArrayOf(0x1b, 'c'.code.toByte())
                                 emulator.append(ris, ris.size)
+                                reapplyTheme(emulator)
                             }
                         }
                     }
                 }
-                lines.value = synchronized(emulator) {
-                    extractRecentLines(emulator, MINI_REGISTRY_MAX_LINES)
-                }
+                dirty.trySend(Unit)
             }
         }
-        return Entry(socket, dispatcher, job, lines)
+
+        // Throttled publisher: one snapshot per dirty signal, then a floor
+        // interval so a byte storm coalesces instead of snapshotting per event.
+        // The snapshot runs on the same dispatcher (and under the same lock) as
+        // the mutations above, so the published DTO is a consistent copy.
+        val publishJob = scope.launch {
+            for (unit in dirty) {
+                if (!hasContent.get()) continue
+                // Mark the signal deferred before testing the subscriber count,
+                // so a collector that arrives in between is seen by the watcher
+                // below rather than falling between the two.
+                deferred.set(true)
+                if (frame.subscriptionCount.value == 0) continue
+                deferred.set(false)
+                frame.value = withContext(dispatcher) {
+                    synchronized(emulator) { snapshotFrame(emulator, revision.incrementAndGet()) }
+                }
+                delay(THUMB_FRAME_MIN_INTERVAL_MS)
+            }
+        }
+
+        // A card scrolled back into the switcher row (or a tab returned to) has
+        // to show the session as it is now, not as it was when the last
+        // collector went away — re-arm the deferred snapshot on resubscribe.
+        val resubscribeJob = scope.launch {
+            frame.subscriptionCount.collect { count ->
+                if (count > 0 && deferred.get()) dirty.trySend(Unit)
+            }
+        }
+        return Entry(socket, emulator, dispatcher, job, publishJob, resubscribeJob, dirty, frame)
     }
 
     /**
-     * Tear down every live entry: cancel collectors, close sockets (detached so
-     * the close reaches the server even as the overview's scope unwinds), and
-     * release the dispatchers. Idempotent. Called by [OverviewContent] on
-     * dispose.
+     * Re-write the resolved theme into [emulator]'s color table after a
+     * terminal reset wiped it. No-op until the theme resolves.
+     *
+     * Called from the event collector, which already holds the emulator lock on
+     * its dispatcher — the contract [applyDefaultColors] requires.
+     *
+     * @param emulator the entry's headless emulator, freshly reset.
+     */
+    private fun reapplyTheme(emulator: TerminalEmulator) {
+        theme?.let { applyDefaultColors(emulator, it) }
+    }
+
+    /**
+     * Tear down every live entry: cancel collectors and publishers, close
+     * sockets (detached so the close reaches the server even as the overview's
+     * scope unwinds), and release the dispatchers. Idempotent. Called by
+     * [OverviewContent] on dispose.
      */
     fun close() {
         val toClose = synchronized(lock) {
@@ -173,37 +310,11 @@ class MiniTerminalRegistry(
         }
         for (entry in toClose) {
             entry.job.cancel()
+            entry.publishJob.cancel()
+            entry.resubscribeJob.cancel()
+            entry.dirty.close()
             entry.socket.closeDetached()
             runCatching { entry.dispatcher.close() }
         }
     }
-}
-
-/**
- * Extract the most recent up-to-[maxLines] logical lines from [emulator]'s
- * transcript (scrollback + current screen). Uses the joined-line transcript so
- * terminal-width hard wraps become single logical lines the miniature re-wraps
- * to its own width; trailing blank lines are trimmed. Returned oldest-to-newest.
- * Must be called under the emulator lock.
- *
- * CONSOLIDATION: the split + trim-to-maxLines below is duplicated, identically
- * in intent, on iOS (`MiniTerminalRegistry.swift` `extractRecentLines`) and web
- * (`LinkThumbnailRenderer.kt` `readLogicalLines`). Only the line above — reading
- * `transcriptText` from this platform's native emulator — is platform-specific.
- * The pure transform could be hoisted into `client/commonMain` (e.g.
- * `TerminalThumbnailModel.trimRecentLines`) and shared by all three front-ends;
- * see the full design note in `web/.../LinkThumbnailRenderer.kt`. Note Android
- * relies on Compose `Text` to re-wrap each logical line to the pane width (see
- * [MiniTerminalPane]), whereas web re-wraps explicitly — reconcile that before
- * sharing the wrap step.
- *
- * @param emulator the externally-fed emulator to read.
- * @param maxLines the most lines to return.
- * @return the trailing logical lines, oldest-to-newest.
- */
-internal fun extractRecentLines(emulator: TerminalEmulator, maxLines: Int): List<String> {
-    val text = runCatching { emulator.screen.transcriptText }.getOrDefault("")
-    if (text.isBlank()) return emptyList()
-    val all = text.split('\n')
-    return if (all.size > maxLines) all.subList(all.size - maxLines, all.size) else all
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -1,11 +1,13 @@
 /**
  * Overview mode content for the Lunamux Android app.
  *
- * Renders a miniaturised, *interactive* replica of the web/Electron tabs-and-
- * panes experience (issues #42, #58): a "scaled exposé" of the active tab's
- * pane layout in the content area, with a horizontally-scrollable strip of tab
- * chips above it. Selecting a tab activates it server-side; tapping any pane
- * focuses it and drills into that pane's full-screen route.
+ * Renders the tabs-and-panes model in the **app-switcher idiom**: one rounded
+ * card per tab (each card a "scaled exposé" of that tab's pane layout) in a
+ * free-flinging, center-snapping row — moving across many tabs is one gesture
+ * — with a labelled tab dock at the bottom for orientation and direct jumps
+ * (see [TabDock]). Browsing the row never changes server state; diving into a
+ * pane (tap on the centered card) activates the tab, focuses the pane, and
+ * drills into that pane's full-screen route.
  *
  * Window management (issue #58):
  *  - Tapping a pane also makes it the tab's active/focused pane.
@@ -29,26 +31,37 @@ package se.soderbjorn.lunamux.android.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.gestures.TargetedFlingBehavior
+import androidx.compose.foundation.gestures.snapping.SnapLayoutInfoProvider
+import androidx.compose.foundation.gestures.snapping.SnapPosition
+import androidx.compose.foundation.gestures.snapping.snapFlingBehavior
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
@@ -64,12 +77,8 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -80,11 +89,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -93,6 +101,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -100,6 +110,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import kotlin.math.abs
+import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import se.soderbjorn.lunamux.FileBrowserContent
@@ -118,7 +130,36 @@ import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.OverviewT
 import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.UnlistedTab
 
 /**
- * The overview content: tab strip + exposé canvas (+ dock) + window-management
+ * Fraction of the switcher row's width one card occupies.
+ *
+ * Nearly all of it. The OS switcher spends a fifth of its width on peeking
+ * neighbours because its cards are app screenshots you recognise at a glance; a
+ * card here is a terminal you have to *read*, so the screen goes to the text and
+ * the neighbours are reduced to a sliver at the edges. The row still snaps and
+ * flings the same way.
+ *
+ * Also the horizontal end scale of the return gesture's flight when no card has
+ * been measured yet (see `returnFlight`).
+ */
+internal const val SWITCHER_CARD_FRACTION = 0.89f
+
+/**
+ * The switcher's vertical rhythm: the gap above the cards, between the cards and
+ * the dock, and below the dock, all the same.
+ *
+ * The dock used to sit flush against the bottom edge with the card row's leftover
+ * slack above it, so it read as stuck to the bottom of the screen rather than as
+ * one of three evenly spaced bands. Cards now fill their row exactly and this is
+ * the only vertical spacing in the switcher.
+ */
+internal val SwitcherEdgeGap = 12.dp
+
+/** Corner radius of a switcher card, and of the return gesture's shrinking screen. */
+internal val SwitcherCardCorner = 20.dp
+
+/**
+ * The overview content: the switcher card row + bottom tab dock (or, while
+ * editing a layout, that tab's full-surface exposé canvas) + window-management
  * affordances.
  *
  * @param vm                the shared overview model (hoisted from [TreeScreen]
@@ -135,6 +176,7 @@ fun OverviewContent(
     onOpenFileBrowser: (String) -> Unit,
     onOpenGit: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onBrowsedTabChanged: (String?) -> Unit = {},
 ) {
     val client = ConnectionHolder.client()
     if (client == null) {
@@ -180,59 +222,120 @@ fun OverviewContent(
 
     val tabs = state.tabs
     val activeIndex = tabs.indexOfFirst { it.isActive }.coerceAtLeast(0)
-    // Re-key the pager on the active world. Each world shows a disjoint tab
-    // list, so a world switch must give the pager a *fresh* state seeded to the
-    // new world's active index. Without this the pager retains the previous
-    // world's settled page; on switching back, that stale index reports through
-    // the pager→server effect below (line ~174) as a spurious `setActiveTab`,
-    // which then ping-pongs with the server→pager effect — the "active tab
-    // flips back and forth every few seconds after a world round-trip" bug.
-    val pagerState = key(state.worldId) {
-        rememberPagerState(initialPage = activeIndex, pageCount = { tabs.size })
+    // Re-key the card row on the active world. Each world shows a disjoint tab
+    // list, so a world switch must give the row a *fresh* state seeded to the
+    // new world's active index (the old pager's stale-settled-page ping-pong
+    // bug, avoided the same way).
+    val rowListState = key(state.worldId) {
+        rememberLazyListState(initialFirstVisibleItemIndex = activeIndex)
     }
 
-    LaunchedEffect(activeIndex) {
-        if (activeIndex in tabs.indices && activeIndex != pagerState.currentPage) {
-            pagerState.animateScrollToPage(activeIndex)
+    // The card the row is on. Browsing is centering, not committing: unlike the old
+    // pager, scrolling the row NEVER sends setActiveTab — only diving into a pane
+    // commits the tab (see divePane below), matching the app-switcher idiom this
+    // row replicates.
+    //
+    // Follows the row *while it moves*, changing as each card takes over most of
+    // the screen, so a card can be tapped the moment it is the one on screen rather
+    // than only after the settle finishes. Quantised on purpose: a snapshotFlow of
+    // the rounded position emits once per card crossed, where the continuously
+    // derived value it replaces recomposed on every frame of a fling — this screen
+    // holds every card's canvas and live thumbnails, so that difference is the
+    // difference between one hitch per card and a stutter throughout.
+    var centeredIndex by remember(rowListState) { mutableStateOf(0) }
+    LaunchedEffect(rowListState) {
+        snapshotFlow { switcherFocusIndex(rowListState).roundToInt() }
+            .collect { index -> centeredIndex = index }
+    }
+
+    // One-way server→row sync: an external active-tab change (desktop, another
+    // phone) re-centers the row, but never mid-gesture — a fling in progress
+    // wins over a remote echo. Keyed on WHICH tab is active, not on its index:
+    // closing a tab ahead of the active one shifts that index without changing
+    // what is active, and re-centering then would yank the row away from the
+    // card the user had browsed to.
+    val activeTabId = tabs.firstOrNull { it.isActive }?.id
+    LaunchedEffect(activeTabId) {
+        val index = tabs.indexOfFirst { it.id == activeTabId }
+        if (index >= 0 && !rowListState.isScrollInProgress && centeredIndex != index) {
+            rowListState.animateScrollToItem(index)
         }
     }
-    val latestTabs = rememberUpdatedState(tabs)
-    val latestActive = rememberUpdatedState(activeIndex)
-    LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.settledPage }.collect { page ->
-            val t = latestTabs.value
-            if (page in t.indices && page != latestActive.value) {
-                vm.setActiveTab(t[page].id)
-            }
-        }
-    }
+
+    // Publish the browsed card so the screen's toolbar actions (new pane,
+    // layout preset) target what the user is looking at. Browsing deliberately
+    // never activates a tab server-side, so the active tab is NOT that target.
+    val browsedTabId = tabs.getOrNull(centeredIndex)?.id
+    LaunchedEffect(browsedTabId) { onBrowsedTabChanged(browsedTabId) }
+    DisposableEffect(Unit) { onDispose { onBrowsedTabChanged(null) } }
 
     // While editing layout, Back leaves edit mode rather than the screen.
     BackHandler(enabled = editTabId != null) { vm.exitEdit() }
 
+    // Diving into a pane is the ONLY thing that commits a tab server-side:
+    // activate the tab (browsing never did — see centeredIndex above), focus
+    // the pane, and navigate immediately (openPane is synchronous, so the dive
+    // transition starts this frame; the server round-trip stays async and
+    // non-blocking). One launch keeps the two commands' send order.
+    // Diving navigates, so it must happen once per gesture: while the row is
+    // settling a tap is watched for at the card level as well as by the pane's own
+    // handler (see SwitcherCardRow), and two navigations would stack two terminals
+    // on the back stack. Reset by leaving and re-entering the overview, which is
+    // exactly when a second dive becomes legitimate again.
+    var diveStarted by remember { mutableStateOf(false) }
+    val divePane: (OverviewTab, OverviewPane) -> Unit = { tab, pane ->
+        if (!diveStarted) {
+            diveStarted = true
+            divePaneId = pane.leaf.id
+            scope.launch {
+                if (!tab.isActive) vm.setActiveTab(tab.id)
+                vm.focusPane(tab.id, pane.leaf.id)
+            }
+            openPane(pane.leaf, onOpenTerminal, onOpenFileBrowser, onOpenGit)
+        }
+    }
+
+    // Diving into a tab rather than a specific pane: its focused pane, or the
+    // topmost one. Shared by the dock's centred chip and by a tap on a card the
+    // row has not finished settling on — both mean "open the tab I can see".
+    val diveIntoTab: (OverviewTab) -> Unit = { tab ->
+        val target = tab.panes.firstOrNull { it.isFocused } ?: tab.panes.maxByOrNull { it.z }
+        if (target != null) {
+            divePane(tab, target)
+        } else if (!tab.isActive) {
+            // Every pane is docked, so there is nothing to dive into — activate
+            // the tab instead, or the tap reads as a dead button. Restoring a
+            // pane is one tap away on the card's dock strip.
+            scope.launch { vm.setActiveTab(tab.id) }
+        }
+    }
+
+    // One canvas parameterization shared by the two hosts below (a switcher
+    // card, or the full-screen edit surface), so the 12 callbacks stay in sync.
+    val canvasFor: @Composable (OverviewTab, Boolean) -> Unit = { tab, editing ->
+        ExposeCanvas(
+            tab = tab,
+            editing = editing,
+            drag = drag?.takeIf { it.tabId == tab.id },
+            divePaneId = divePaneId,
+            onOpenPane = { pane -> divePane(tab, pane) },
+            onToggleMaximize = { pane -> scope.launch { vm.toggleMaximize(tab.id, pane.leaf.id) } },
+            onMinimize = { pane -> scope.launch { vm.minimize(tab.id, pane.leaf.id) } },
+            onEnterEdit = { vm.enterEdit(tab.id) },
+            onRename = { leaf -> renameTarget = leaf },
+            onClose = { leaf -> closeTarget = leaf },
+            onBeginDrag = { pane -> vm.beginDrag(tab.id, pane.leaf.id) },
+            onDragMove = { dx, dy -> vm.dragMoveBy(dx, dy) },
+            onDragResize = { dw, dh -> vm.dragResizeBy(dw, dh) },
+            onDragEnd = { scope.launch { vm.endDrag() } },
+            onRestoreDock = { docked -> scope.launch { vm.restore(tab.id, docked.leaf.id) } },
+        )
+    }
+
     CompositionLocalProvider(LocalMiniTerminalRegistry provides miniTerminals) {
         Column(modifier) {
-            // Hide the tab strip while editing layout: the move/resize gestures
-            // own the screen, and the strip's chips would compete for taps.
-            if (editTabId == null) {
-                OverviewTabStrip(
-                    tabs = tabs,
-                    unlistedTabs = state.unlistedTabs,
-                    activeIndex = activeIndex,
-                    closeEnabled = tabs.size > 1,
-                    onSelect = { id -> scope.launch { vm.setActiveTab(id) } },
-                    onRename = { tab -> renameTabTarget = tab },
-                    onToggleHidden = { tab ->
-                        scope.launch { vm.setTabHidden(tab.id, !tab.isHidden) }
-                    },
-                    onToggleSidebarHidden = { tab ->
-                        scope.launch {
-                            vm.setTabHiddenFromSidebar(tab.id, !tab.isHiddenFromSidebar)
-                        }
-                    },
-                    onClose = { tab -> closeTabTarget = tab },
-                )
-            } else {
+            val editingTab = tabs.firstOrNull { it.id == editTabId }
+            if (editingTab != null) {
                 // Edit-mode banner: names the mode and offers an unambiguous exit.
                 EditBanner(onDone = { vm.exitEdit() })
             }
@@ -244,38 +347,52 @@ fun OverviewContent(
                 ) {
                     Text("No tabs", color = SidebarTextSecondary)
                 }
-            } else {
-                HorizontalPager(
-                    state = pagerState,
-                    // Don't steal horizontal drags from an edit-mode gesture.
-                    userScrollEnabled = editTabId == null,
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
-                ) { page ->
-                    val tab = tabs[page]
-                    ExposeCanvas(
-                        tab = tab,
-                        editing = editTabId == tab.id,
-                        drag = drag?.takeIf { it.tabId == tab.id },
-                        divePaneId = divePaneId,
-                        onOpenPane = { pane ->
-                            // Anchor the dive before navigating (openPane fires
-                            // synchronously; the focus round-trip stays async).
-                            divePaneId = pane.leaf.id
-                            scope.launch { vm.focusPane(tab.id, pane.leaf.id) }
-                            openPane(pane.leaf, onOpenTerminal, onOpenFileBrowser, onOpenGit)
-                        },
-                        onToggleMaximize = { pane -> scope.launch { vm.toggleMaximize(tab.id, pane.leaf.id) } },
-                        onMinimize = { pane -> scope.launch { vm.minimize(tab.id, pane.leaf.id) } },
-                        onEnterEdit = { vm.enterEdit(tab.id) },
-                        onRename = { leaf -> renameTarget = leaf },
-                        onClose = { leaf -> closeTarget = leaf },
-                        onBeginDrag = { pane -> vm.beginDrag(tab.id, pane.leaf.id) },
-                        onDragMove = { dx, dy -> vm.dragMoveBy(dx, dy) },
-                        onDragResize = { dw, dh -> vm.dragResizeBy(dw, dh) },
-                        onDragEnd = { scope.launch { vm.endDrag() } },
-                        onRestoreDock = { docked -> scope.launch { vm.restore(tab.id, docked.leaf.id) } },
-                    )
+            } else if (editingTab != null) {
+                // Editing expands the tab to the full surface (the pre-switcher
+                // full-width layout), so move/resize keep today's precision; the
+                // dock is hidden because its chips would compete for taps.
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    canvasFor(editingTab, true)
                 }
+            } else {
+                // App-switcher card row: one card per tab at ~70% width in the
+                // screen's aspect, free momentum flinging with center snap,
+                // neighbors peeking in from both sides.
+                SwitcherCardRow(
+                    tabs = tabs,
+                    rowListState = rowListState,
+                    centeredIndex = centeredIndex,
+                    onCenter = { index -> scope.launch { rowListState.animateScrollToItem(index) } },
+                    onDiveTab = diveIntoTab,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(top = SwitcherEdgeGap),
+                ) { tab -> canvasFor(tab, false) }
+
+                // The bottom tab dock — the switcher's app-icon-row analog:
+                // one labelled chip per tab for orientation and direct jumps.
+                TabDock(
+                    tabs = tabs,
+                    unlistedTabs = state.unlistedTabs,
+                    focusIndex = { switcherFocusIndex(rowListState) },
+                    centeredIndex = centeredIndex,
+                    closeEnabled = tabs.size > 1,
+                    onCenter = { index -> scope.launch { rowListState.animateScrollToItem(index) } },
+                    onDive = diveIntoTab,
+                    onActivateUnlisted = { id -> scope.launch { vm.setActiveTab(id) } },
+                    onRename = { tab -> renameTabTarget = tab },
+                    onToggleHidden = { tab ->
+                        scope.launch { vm.setTabHidden(tab.id, !tab.isHidden) }
+                    },
+                    onToggleSidebarHidden = { tab ->
+                        scope.launch {
+                            vm.setTabHiddenFromSidebar(tab.id, !tab.isHiddenFromSidebar)
+                        }
+                    },
+                    onClose = { tab -> closeTabTarget = tab },
+                    modifier = Modifier.padding(vertical = SwitcherEdgeGap),
+                )
             }
         }
     }
@@ -333,6 +450,358 @@ fun OverviewContent(
                 scope.launch { closeTab(socket, tab.id) }
             },
         )
+    }
+}
+
+/**
+ * The app-switcher card row: one rounded card per tab, ~70% of the surface
+ * width at the surface's own aspect ratio, in a snapping [LazyRow] with free
+ * momentum flinging — so moving across many tabs is one gesture, not one
+ * swipe per tab. Neighbors peek in from both sides and shrink/dim slightly
+ * with distance from center, matching the OS app switcher this replicates.
+ *
+ * Browsing is passive: only the centered card is interactive; tapping (or
+ * long-pressing) a peeking card centers it and nothing else, so a fling can
+ * never accidentally dive into a pane or open its menu. Selection semantics
+ * live in the caller ([OverviewContent]).
+ *
+ * @param tabs          the tabs to render, one card each.
+ * @param rowListState  the hoisted row state ([OverviewContent] re-keys it per
+ *   world and drives centering from server echoes).
+ * @param centeredIndex index of the card snapped to (or nearest) center; only
+ *   it passes touches through to its panes.
+ * @param onCenter      center the card at the given index.
+ * @param modifier      layout modifier from the caller.
+ * @param cardContent   the card's content for a tab (the tab's exposé canvas).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+/**
+ * Velocity, in dp/s, above which a release is a *flick* rather than a let-go.
+ * Deliberately tiny: the OS switcher moves on with the smallest deliberate
+ * push, and a row that instead rubber-banded back to where you started felt
+ * like it was refusing the gesture.
+ */
+internal const val SWITCHER_FLICK_INTENT_DP = 80f
+
+/**
+ * The velocity a flick is reported as when it clears [SWITCHER_FLICK_INTENT_DP]
+ * but falls under Foundation's own "advance a card" threshold (400 dp/s). Raising
+ * it to exactly that line is what turns every deliberate flick into one card
+ * forward instead of a bounce back.
+ */
+private const val SWITCHER_ADVANCE_VELOCITY_DP = 400f
+
+/**
+ * Stiffness of the settle, and its damping ratio. Chosen on the device with the
+ * tuning sliders: a very soft spring, but *overdamped*, so it eases to a stop
+ * without ever looking pulled into place. Foundation's default (400, damping 1)
+ * arrived before the gesture felt finished, and the same softness at damping 1
+ * felt weightless.
+ */
+internal const val SWITCHER_SNAP_STIFFNESS = 50f
+
+/** Damping ratio of the settle; above 1 approaches the target without overshoot. */
+internal const val SWITCHER_SNAP_DAMPING = 1.2f
+
+/**
+ * The card row's fling: the platform's own momentum, an edge-aware approach, and a
+ * soft overdamped settle.
+ *
+ * The decay is the platform spline — the same friction every Android scroller
+ * uses, which is what the OS switcher is being compared against; a lower-friction
+ * decay tried earlier coasted further than any of them. What is *not* borrowed is
+ * the ending: Foundation's snap would let the decay target a position past the
+ * first or last card and leave the scroll container to clamp it, which arrives as
+ * a wall. [calculateApproachOffset] instead never proposes more than the distance
+ * that actually remains, so a fling toward either end decays into the edge card
+ * and the spring lands it.
+ *
+ * The two decisions stay separate: how *far* a fling travels is the decay's job,
+ * while whether a release advances at all is the snap's — and any deliberate flick
+ * advances (see [SWITCHER_FLICK_INTENT_DP]). Only a release with essentially no
+ * velocity falls back to "whichever card is nearest", which is what a slow drag
+ * deserves.
+ *
+ * @param rowListState the row's list state, whose centred snap positions the
+ *   behaviour snaps to and whose layout tells it how much room is left.
+ * @return the fling behaviour to hand [LazyRow].
+ */
+@Composable
+private fun rememberSwitcherFlingBehavior(rowListState: LazyListState): TargetedFlingBehavior {
+    val density = LocalDensity.current
+    val splineDecay = rememberSplineBasedDecay<Float>()
+    return remember(rowListState, density, splineDecay) {
+        val base = SnapLayoutInfoProvider(rowListState, SnapPosition.Center)
+        val intentPx = with(density) { SWITCHER_FLICK_INTENT_DP.dp.toPx() }
+        val advancePx = with(density) { SWITCHER_ADVANCE_VELOCITY_DP.dp.toPx() }
+        val provider = object : SnapLayoutInfoProvider {
+            override fun calculateSnapOffset(velocity: Float): Float {
+                // A flick keeps its direction and is reported as at least fast
+                // enough to count; only a genuine let-go reports nothing and lets
+                // position decide.
+                val reported = when {
+                    velocity > intentPx -> maxOf(velocity, advancePx)
+                    velocity < -intentPx -> minOf(velocity, -advancePx)
+                    else -> 0f
+                }
+                return base.calculateSnapOffset(reported)
+            }
+
+            override fun calculateApproachOffset(velocity: Float, decayOffset: Float): Float {
+                val proposed = base.calculateApproachOffset(velocity, decayOffset)
+                val room = roomToEdge(rowListState, forward = proposed >= 0f)
+                    ?: return proposed
+                // Cards are uniform, so "how far can the row still scroll" is
+                // exact rather than estimated. Never propose more than that: the
+                // decay then eases into the first or last card instead of running
+                // at speed into the scroll container's clamp.
+                return if (proposed >= 0f) proposed.coerceAtMost(room) else proposed.coerceAtLeast(-room)
+            }
+        }
+        snapFlingBehavior(
+            snapLayoutInfoProvider = provider,
+            decayAnimationSpec = splineDecay,
+            snapAnimationSpec = spring(
+                dampingRatio = SWITCHER_SNAP_DAMPING,
+                stiffness = SWITCHER_SNAP_STIFFNESS,
+            ),
+        )
+    }
+}
+
+/**
+ * How much of a card has to be on screen for a tap on it to open it rather than
+ * merely centre it. Above half, it is the card the user is looking at.
+ */
+private const val CARD_TAP_DIVE_FRACTION = 0.55f
+
+/** Longest press still treated as a tap by the row's mid-settle tap watcher, in ms. */
+private const val CARD_TAP_MAX_HOLD_MS = 500L
+
+/**
+ * How far the row may move between press and lift — in cards — for the gesture to
+ * still count as a tap rather than a drag. A press stops the settle, so a real tap
+ * moves the row barely at all.
+ */
+private const val CARD_TAP_SCROLL_TOLERANCE = 0.04f
+
+/**
+ * How much of the card at [index] is inside the row's viewport, 0..1.
+ *
+ * Measured at tap time rather than tracked, because it only matters then: it is
+ * what tells a deliberate tap on the incoming card of a settle apart from a tap on
+ * a sliver peeking at the edge.
+ *
+ * @param rowListState the row's list state.
+ * @param index the card's index.
+ * @return the visible fraction, or 0 when the card is not laid out.
+ */
+private fun visibleFraction(rowListState: LazyListState, index: Int): Float {
+    val info = rowListState.layoutInfo
+    val item = info.visibleItemsInfo.firstOrNull { it.index == index } ?: return 0f
+    if (item.size <= 0) return 0f
+    val start = maxOf(item.offset, info.viewportStartOffset)
+    val end = minOf(item.offset + item.size, info.viewportEndOffset)
+    return ((end - start).toFloat() / item.size).coerceIn(0f, 1f)
+}
+
+/**
+ * The row's position as a *fractional* card index — 1.4 meaning "40% of the way
+ * from card 1 to card 2".
+ *
+ * The cards are uniform, so this is just the scroll position over the stride. Read
+ * at draw time by [TabDock], whose chips follow the row continuously rather than
+ * animating when the centred card changes.
+ *
+ * @param rowListState the row's list state.
+ * @return the fractional index, or 0 while the row has no layout yet.
+ */
+private fun switcherFocusIndex(rowListState: LazyListState): Float {
+    val stride = switcherStride(rowListState) ?: return 0f
+    return rowListState.firstVisibleItemIndex + rowListState.firstVisibleItemScrollOffset / stride
+}
+
+/**
+ * The distance from one card's start to the next, in px, or `null` before the row
+ * has been laid out. Cards are all one width, so a single visible pair (or a
+ * single item) is enough to know it.
+ *
+ * @param rowListState the row's list state.
+ * @return the stride in px, or `null` when it cannot be known yet.
+ */
+private fun switcherStride(rowListState: LazyListState): Float? {
+    val visible = rowListState.layoutInfo.visibleItemsInfo
+    if (visible.isEmpty()) return null
+    val stride = if (visible.size >= 2) {
+        (visible[1].offset - visible[0].offset).toFloat()
+    } else {
+        visible[0].size.toFloat()
+    }
+    return stride.takeIf { it > 0f }
+}
+
+/**
+ * How much further the row can scroll before the first or last card is centred,
+ * in px.
+ *
+ * The cards are all one width, so the row's scrollable range is exactly
+ * `(count - 1) × stride` and its position `index × stride + offset` — no
+ * estimation, and no need to have the far end composed. Used by
+ * [rememberSwitcherFlingBehavior] to keep a fling from targeting past an end.
+ *
+ * @param rowListState the row's list state.
+ * @param forward whether to measure toward the last card (true) or the first.
+ * @return the remaining distance, or `null` while the row has no layout yet (in
+ *   which case a caller should not clamp anything).
+ */
+private fun roomToEdge(rowListState: LazyListState, forward: Boolean): Float? {
+    val info = rowListState.layoutInfo
+    if (info.totalItemsCount <= 1) return null
+    val stride = switcherStride(rowListState) ?: return null
+    val position = rowListState.firstVisibleItemIndex * stride +
+        rowListState.firstVisibleItemScrollOffset
+    val range = (info.totalItemsCount - 1) * stride
+    val room = if (forward) range - position else position
+    return room.coerceAtLeast(0f)
+}
+
+@Composable
+private fun SwitcherCardRow(
+    tabs: List<OverviewTab>,
+    rowListState: LazyListState,
+    centeredIndex: Int,
+    onCenter: (Int) -> Unit,
+    onDiveTab: (OverviewTab) -> Unit,
+    modifier: Modifier = Modifier,
+    cardContent: @Composable (OverviewTab) -> Unit,
+) {
+    BoxWithConstraints(modifier) {
+        val cardWidth = maxWidth * SWITCHER_CARD_FRACTION
+        // The card fills the row it is given; the breathing room around the
+        // switcher is [SwitcherEdgeGap], applied once by the caller.
+        val cardHeight = maxHeight
+        val sidePadding = (maxWidth - cardWidth) / 2
+        val cardShape = RoundedCornerShape(SwitcherCardCorner)
+        // Whether the row is mid-drag, mid-fling or mid-settle. Changes twice per
+        // gesture, so reading it here costs nothing.
+        val scrolling = rowListState.isScrollInProgress
+
+        LazyRow(
+            state = rowListState,
+            flingBehavior = rememberSwitcherFlingBehavior(rowListState),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            // Symmetric padding of (viewport - card)/2 makes item offset 0 the
+            // centered position, so snap positions and scrollToItem(i) both
+            // land cards dead-center — including the first and last.
+            contentPadding = PaddingValues(horizontal = sidePadding),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            itemsIndexed(tabs, key = { _, tab -> tab.id }) { index, tab ->
+                // No distance-from-centre scale or fade: the carousel effect was
+                // one more thing moving during a fling, and it read as the row
+                // fighting its own settle rather than as depth. Cards are flat and
+                // identical; the dock carries the depth cue instead.
+                Box(
+                    modifier = Modifier
+                        .width(cardWidth)
+                        .height(cardHeight)
+                        .clip(cardShape)
+                        .background(SidebarSurface.copy(alpha = 0.35f))
+                        // A hairline, never the accent: the panes inside draw
+                        // their own outline (accented when focused), so an
+                        // accent ring around the card read as a double border.
+                        // Which tab is server-active is said by its dock chip.
+                        .border(
+                            width = 1.dp,
+                            color = SidebarTextSecondary.copy(alpha = 0.22f),
+                            shape = cardShape,
+                        ),
+                ) {
+                    cardContent(tab)
+                    // While the row is moving, watch for a tap at the card level
+                    // too. A press during a settle is exactly the case that fell
+                    // through the cracks: it stops the scroll, and stopping the
+                    // scroll can cancel the press before either the pane's
+                    // combinedClickable or the gate below ever sees a click — so
+                    // tapping the card that fills the screen did nothing at all.
+                    //
+                    // This layer consumes nothing (a drag still scrolls the row);
+                    // it only decides, on lift, whether what happened was a tap:
+                    // quick, and with the row's position barely moved, which a drag
+                    // never is. Local pointer movement cannot be the test here — the
+                    // card moves under a stationary finger during a settle, and
+                    // follows the finger during a drag, so the two are the wrong way
+                    // round.
+                    if (scrolling) {
+                        Box(
+                            Modifier
+                                .matchParentSize()
+                                .pointerInput(index) {
+                                    awaitEachGesture {
+                                        val down = awaitFirstDown(
+                                            requireUnconsumed = false,
+                                            pass = PointerEventPass.Initial,
+                                        )
+                                        val focusAtDown = switcherFocusIndex(rowListState)
+                                        var lift: PointerInputChange? = null
+                                        while (true) {
+                                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                                            val change = event.changes
+                                                .firstOrNull { it.id == down.id } ?: break
+                                            if (!change.pressed) {
+                                                lift = change
+                                                break
+                                            }
+                                        }
+                                        val up = lift ?: return@awaitEachGesture
+                                        val heldMs = up.uptimeMillis - down.uptimeMillis
+                                        val moved = abs(
+                                            switcherFocusIndex(rowListState) - focusAtDown,
+                                        )
+                                        if (heldMs <= CARD_TAP_MAX_HOLD_MS &&
+                                            moved <= CARD_TAP_SCROLL_TOLERANCE
+                                        ) {
+                                            if (visibleFraction(rowListState, index) >=
+                                                CARD_TAP_DIVE_FRACTION
+                                            ) {
+                                                onDiveTab(tab)
+                                            } else {
+                                                onCenter(index)
+                                            }
+                                        }
+                                    }
+                                },
+                        )
+                    }
+
+                    if (index != centeredIndex) {
+                        // A card that is not the centred one still gets a gate, so
+                        // a pane's own taps and long-press menu cannot fire on a
+                        // card the row is not on. What the gate DOES depends on how
+                        // much of that card you can see: a sliver at the edge only
+                        // centres, but a card already filling most of the screen —
+                        // which is what the incoming card looks like for the whole
+                        // length of a settle — opens, because tapping the thing you
+                        // are looking at should not have to wait for an animation.
+                        Box(
+                            Modifier
+                                .matchParentSize()
+                                .combinedClickable(
+                                    onClick = {
+                                        if (visibleFraction(rowListState, index) >= CARD_TAP_DIVE_FRACTION) {
+                                            onDiveTab(tab)
+                                        } else {
+                                            onCenter(index)
+                                        }
+                                    },
+                                    onLongClick = { onCenter(index) },
+                                ),
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -844,133 +1313,17 @@ private fun MiniPane(
 }
 
 /**
- * The top tab strip: a single horizontally-scrollable row of [FilterChip]s, the
- * active tab outlined in the accent colour with its aggregate status dot.
+ * The trailing `⋮` button at the end of the tab dock that opens a dropdown of
+ * the unlisted (hidden) tabs. Selecting one activates it, which surfaces it
+ * temporarily among the visible tabs.
  *
- * Tapping a chip selects the tab; long-pressing it opens a context menu to
- * rename or close the tab, mirroring a pane's long-press menu.
- *
- * @param tabs         the tab summaries to render.
- * @param unlistedTabs hidden tabs not in [tabs]; surfaced via a trailing `⋮`
- *   menu so they can be re-activated. Empty hides the menu.
- * @param activeIndex  index of the active tab, or -1.
- * @param closeEnabled whether "Close tab" is offered (false for the last tab).
- * @param onSelect     invoked with a tab id when a chip is tapped.
- * @param onRename     open the rename dialog for the long-pressed tab.
- * @param onToggleHidden flip the long-pressed tab's hidden-from-tab-strip
- *   ("unlisted") flag.
- * @param onToggleSidebarHidden flip the long-pressed tab's hidden-from-sidebar
- *   flag (also hides it from the sessions list, which mirrors the sidebar).
- * @param onClose      confirm + close the long-pressed tab.
- */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
-@Composable
-private fun OverviewTabStrip(
-    tabs: List<OverviewTab>,
-    unlistedTabs: List<UnlistedTab>,
-    activeIndex: Int,
-    closeEnabled: Boolean,
-    onSelect: (String) -> Unit,
-    onRename: (OverviewTab) -> Unit,
-    onToggleHidden: (OverviewTab) -> Unit,
-    onToggleSidebarHidden: (OverviewTab) -> Unit,
-    onClose: (OverviewTab) -> Unit,
-) {
-    if (tabs.isEmpty()) return
-
-    val listState = rememberLazyListState()
-    LaunchedEffect(activeIndex, tabs.size) {
-        if (activeIndex >= 0) listState.animateScrollToItem(activeIndex)
-    }
-
-    // The tab chip whose context menu is currently open (by tab id).
-    var menuTabId by remember { mutableStateOf<String?>(null) }
-
-    LazyRow(
-        state = listState,
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SidebarBackground)
-            .padding(start = 8.dp, end = 8.dp, top = 0.dp, bottom = 2.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        items(tabs, key = { it.id }) { tab ->
-            Box {
-                CompositionLocalProvider(
-                    LocalMinimumInteractiveComponentEnforcement provides false,
-                ) {
-                    FilterChip(
-                        selected = tab.isActive,
-                        onClick = { onSelect(tab.id) },
-                        label = {
-                            Text(tab.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        },
-                        leadingIcon = { StatusDot(state = tab.aggregateState, boxDp = 12) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            containerColor = SidebarBackground,
-                            labelColor = SidebarTextSecondary,
-                            selectedContainerColor = SidebarAccent.copy(alpha = 0.18f),
-                            selectedLabelColor = SidebarAccent,
-                        ),
-                        border = FilterChipDefaults.filterChipBorder(
-                            enabled = true,
-                            selected = tab.isActive,
-                            borderColor = SidebarTextSecondary.copy(alpha = 0.4f),
-                            selectedBorderColor = SidebarAccent,
-                            borderWidth = 1.dp,
-                            selectedBorderWidth = 2.dp,
-                        ),
-                    )
-                }
-                // Transparent overlay that catches the tap (select) and the
-                // long-press (context menu), mirroring a pane's PaneTapOverlay.
-                // It sits above the chip so the chip's own click never fires.
-                Box(
-                    Modifier
-                        .matchParentSize()
-                        .clip(RoundedCornerShape(8.dp))
-                        .combinedClickable(
-                            onClick = { onSelect(tab.id) },
-                            onLongClick = { menuTabId = tab.id },
-                        ),
-                )
-                TabContextMenu(
-                    expanded = menuTabId == tab.id,
-                    isHidden = tab.isHidden,
-                    isHiddenFromSidebar = tab.isHiddenFromSidebar,
-                    closeEnabled = closeEnabled,
-                    onDismiss = { menuTabId = null },
-                    onRename = { menuTabId = null; onRename(tab) },
-                    onToggleHidden = { menuTabId = null; onToggleHidden(tab) },
-                    onToggleSidebarHidden = { menuTabId = null; onToggleSidebarHidden(tab) },
-                    onClose = { menuTabId = null; onClose(tab) },
-                )
-            }
-        }
-
-        // Trailing `⋮` menu listing the unlisted (hidden) tabs. Tapping a row
-        // activates that tab — it then surfaces temporarily in the strip
-        // (see OverviewBackingViewModel.project). Mirrors the web/Mac
-        // far-right overflow menu. Only rendered when some tabs are unlisted.
-        if (unlistedTabs.isNotEmpty()) {
-            item(key = "__unlisted__") {
-                UnlistedTabsMenu(unlistedTabs = unlistedTabs, onSelect = onSelect)
-            }
-        }
-    }
-}
-
-/**
- * The trailing `⋮` button at the end of the overview tab strip that opens a
- * dropdown of the unlisted (hidden) tabs. Selecting one activates it, which
- * surfaces it temporarily among the visible tabs.
+ * Internal so [TabDock] (the strip's switcher-era successor) can reuse it.
  *
  * @param unlistedTabs the hidden tabs to list.
  * @param onSelect     invoked with the chosen tab id.
  */
 @Composable
-private fun UnlistedTabsMenu(
+internal fun UnlistedTabsMenu(
     unlistedTabs: List<UnlistedTab>,
     onSelect: (String) -> Unit,
 ) {
@@ -1013,6 +1366,8 @@ private fun UnlistedTabsMenu(
  * sidebar — orthogonal flags, each labelled by its current state), and close
  * (the whole tab).
  *
+ * Internal so [TabDock] (the strip's switcher-era successor) can reuse it.
+ *
  * @param expanded     whether this tab's menu is open.
  * @param isHidden     whether the tab is currently hidden ("unlisted") from
  *   the tab strip; labels the strip toggle item.
@@ -1026,7 +1381,7 @@ private fun UnlistedTabsMenu(
  * @param onClose      confirm + close the tab.
  */
 @Composable
-private fun TabContextMenu(
+internal fun TabContextMenu(
     expanded: Boolean,
     isHidden: Boolean,
     isHiddenFromSidebar: Boolean,

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -104,6 +104,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -580,6 +581,13 @@ private const val CARD_TAP_DIVE_FRACTION = 0.55f
 private const val CARD_TAP_MAX_HOLD_MS = 500L
 
 /**
+ * How far the finger may travel, in multiples of the platform's touch slop, for a
+ * press during the row's motion to still be a tap. See [midSettleTapWatcher] for
+ * why this is a backstop rather than the test itself, and why it is generous.
+ */
+private const val CARD_TAP_TRAVEL_SLOPS = 3f
+
+/**
  * How long after a dive another one is ignored. Long enough that the two handlers
  * which can see one mid-settle tap cannot both navigate, short enough that a dive
  * interrupted by Back does not leave the switcher unable to open anything.
@@ -587,15 +595,90 @@ private const val CARD_TAP_MAX_HOLD_MS = 500L
 private const val DIVE_DEBOUNCE_NANOS = 400_000_000L
 
 /**
- * How far the row may move between press and lift — in cards — for the gesture to
- * still count as a tap rather than a drag.
+ * Watch a switcher card for a tap that lands while the row is still moving, and
+ * open (or centre) it without waiting for the settle to finish.
  *
- * Generous on purpose: a press cannot stop the settle before the next frame is
- * produced, and at a brisk settle speed the row still travels a few percent of a
- * card in that frame. A drag moves it far more than this, because the row follows
- * the finger.
+ * A press during a settle stops the scroll, and stopping the scroll can cancel the
+ * press before the card's own handlers ever see a click — so tapping the card
+ * filling the screen did nothing at all. This modifier is that missing handler.
+ *
+ * **It goes on the card, never over it.** A pointer modifier in an overlay is not
+ * hit-transparent: Compose hands a pointer to the topmost sibling that wants it and
+ * to nobody behind it, whether or not that sibling consumes anything. An overlay
+ * watcher therefore swallowed every gesture it decided *not* to act on, which is
+ * every tap on a resting row — the card at either end of the row settles instantly
+ * (there is no distance left to travel), so those were dead on arrival while the
+ * cards in the middle, with their long soft settle, mostly still worked. As part of
+ * the card's own modifier chain it is an ancestor of the panes instead: it sees
+ * every gesture in the [PointerEventPass.Initial] pass, consumes none of it, and
+ * leaves the panes' own taps, menus and the edge cards' gate untouched.
+ *
+ * What counts as a tap is the **finger's** travel, corrected for the card sliding
+ * out from under it. Neither raw signal works alone: local pointer movement calls a
+ * stationary finger a drag during a settle, and the row's own displacement calls a
+ * flick a tap — a light flick is a few dozen px of finger over ~100 ms, and all the
+ * row movement it causes happens *after* the lift. Undoing the row's displacement
+ * from the local movement leaves the finger's own path, which a tap keeps inside
+ * the touch slop. A drag the row acted on is also consumed by its scroll, seen here
+ * in the [PointerEventPass.Final] pass, which is the row itself saying the same
+ * thing — and that is the precise half of the test, because the row scrolls only
+ * from a gesture it took. The travel test is the backstop, and its threshold is
+ * deliberately several times the slop: the row's position is republished once per
+ * layout while pointer events arrive between them, so the correction can be one
+ * frame of settle out of date, which at speed is tens of px.
+ *
+ * @param index        the card's index in the row.
+ * @param rowListState the row's list state, read for its motion and geometry.
+ * @param onCenter     centre the card at the given index — what a tap on a sliver
+ *   peeking in at the edge means.
+ * @param onTapAt      open whatever sits at the given fraction of the card, so a
+ *   multi-pane card opens the pane that was actually touched.
+ * @return this modifier, with the watcher attached.
+ * @see SwitcherCardRow
+ * @see visibleFraction
  */
-private const val CARD_TAP_SCROLL_TOLERANCE = 0.2f
+private fun Modifier.midSettleTapWatcher(
+    index: Int,
+    rowListState: LazyListState,
+    onCenter: (Int) -> Unit,
+    onTapAt: (Float, Float) -> Unit,
+): Modifier = pointerInput(index) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        // Decided at the press and only there: a tap on a row already at rest is
+        // the panes' own business, and stealing it is what broke them.
+        val movingAtPress = rowListState.isScrollInProgress
+        val focusAtDown = switcherFocusIndex(rowListState)
+        val stride = switcherStride(rowListState) ?: 0f
+        val travelLimit = viewConfiguration.touchSlop * CARD_TAP_TRAVEL_SLOPS
+        var dragged = false
+        var lift: PointerInputChange? = null
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Final)
+            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+            // The card slides under a stationary finger while the row settles, which
+            // arrives as local movement; the row's own displacement over the same
+            // interval is exactly that much, so subtracting it leaves the finger.
+            val rowShift = (switcherFocusIndex(rowListState) - focusAtDown) * stride
+            val travelX = change.position.x - down.position.x - rowShift
+            val travelY = change.position.y - down.position.y
+            if (abs(travelX) > travelLimit || abs(travelY) > travelLimit) dragged = true
+            if (change.positionChange() != Offset.Zero && change.isConsumed) dragged = true
+            if (!change.pressed) {
+                lift = change
+                break
+            }
+        }
+        val up = lift ?: return@awaitEachGesture
+        if (!movingAtPress || dragged) return@awaitEachGesture
+        if (up.uptimeMillis - down.uptimeMillis > CARD_TAP_MAX_HOLD_MS) return@awaitEachGesture
+        if (visibleFraction(rowListState, index) < CARD_TAP_DIVE_FRACTION) {
+            onCenter(index)
+            return@awaitEachGesture
+        }
+        onTapAt(up.position.x / size.width.toFloat(), up.position.y / size.height.toFloat())
+    }
+}
 
 /**
  * How much of the card at [index] is inside the row's viewport, 0..1.
@@ -753,78 +836,16 @@ private fun SwitcherCardRow(
                             width = 1.dp,
                             color = SidebarTextSecondary.copy(alpha = 0.22f),
                             shape = cardShape,
-                        ),
+                        )
+                        // Watches for a tap that lands while the row is moving.
+                        // On the card, NOT laid over it — see the modifier's doc.
+                        .midSettleTapWatcher(
+                            index = index,
+                            rowListState = rowListState,
+                            onCenter = onCenter,
+                        ) { fractionX, fractionY -> onDiveAt(tab, fractionX, fractionY) },
                 ) {
                     cardContent(tab)
-                    // A press that lands while the row is moving is the case that
-                    // fell through the cracks: it stops the scroll, and stopping the
-                    // scroll can cancel the press before either the pane's
-                    // combinedClickable or the gate below ever sees a click — so
-                    // tapping the card that fills the screen did nothing at all.
-                    //
-                    // This layer consumes nothing (a drag still scrolls the row) and
-                    // is composed unconditionally: gating it on "is scrolling" meant
-                    // it left composition the moment the press stopped the scroll,
-                    // cancelling the very gesture it was watching. Whether it acts is
-                    // decided from the state at the PRESS instead, and only then, so
-                    // a tap on a resting row is left to the handlers below.
-                    //
-                    // On lift it asks whether what happened was a tap: quick, and
-                    // with the row's position barely moved. Local pointer movement
-                    // cannot be that test — the card moves under a stationary finger
-                    // during a settle and follows the finger during a drag, so the
-                    // two are the wrong way round.
-                    Box(
-                        Modifier
-                            .matchParentSize()
-                            .pointerInput(index) {
-                                awaitEachGesture {
-                                    val down = awaitFirstDown(
-                                        requireUnconsumed = false,
-                                        pass = PointerEventPass.Initial,
-                                    )
-                                    val movingAtPress = rowListState.isScrollInProgress
-                                    val focusAtDown = switcherFocusIndex(rowListState)
-                                    var lift: PointerInputChange? = null
-                                    while (true) {
-                                        val event = awaitPointerEvent(PointerEventPass.Initial)
-                                        val change = event.changes
-                                            .firstOrNull { it.id == down.id } ?: break
-                                        if (!change.pressed) {
-                                            lift = change
-                                            break
-                                        }
-                                    }
-                                    val up = lift ?: return@awaitEachGesture
-                                    if (!movingAtPress) return@awaitEachGesture
-                                    val heldMs = up.uptimeMillis - down.uptimeMillis
-                                    val moved = abs(
-                                        switcherFocusIndex(rowListState) - focusAtDown,
-                                    )
-                                    if (heldMs > CARD_TAP_MAX_HOLD_MS ||
-                                        moved > CARD_TAP_SCROLL_TOLERANCE
-                                    ) {
-                                        return@awaitEachGesture
-                                    }
-                                    if (visibleFraction(rowListState, index) <
-                                        CARD_TAP_DIVE_FRACTION
-                                    ) {
-                                        onCenter(index)
-                                        return@awaitEachGesture
-                                    }
-                                    // Open what was actually touched. Diving "into
-                                    // the tab" picks its focused pane, which on a
-                                    // multi-pane card is the wrong terminal whenever
-                                    // the finger was on another one.
-                                    onDiveAt(
-                                        tab,
-                                        up.position.x / size.width.toFloat(),
-                                        up.position.y / size.height.toFloat(),
-                                    )
-                                }
-                            },
-                    )
-
                     if (index != centeredIndex) {
                         // A card that is not the centred one still gets a gate, so
                         // a pane's own taps and long-press menu cannot fire on a

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -138,8 +138,6 @@ import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.UnlistedT
  * the neighbours are reduced to a sliver at the edges. The row still snaps and
  * flings the same way.
  *
- * Also the horizontal end scale of the return gesture's flight when no card has
- * been measured yet (see `returnFlight`).
  */
 internal const val SWITCHER_CARD_FRACTION = 0.89f
 
@@ -154,7 +152,7 @@ internal const val SWITCHER_CARD_FRACTION = 0.89f
  */
 internal val SwitcherEdgeGap = 12.dp
 
-/** Corner radius of a switcher card, and of the return gesture's shrinking screen. */
+/** Corner radius of a switcher card. */
 internal val SwitcherCardCorner = 20.dp
 
 /**
@@ -272,6 +270,14 @@ fun OverviewContent(
     // While editing layout, Back leaves edit mode rather than the screen.
     BackHandler(enabled = editTabId != null) { vm.exitEdit() }
 
+    // A tab being edited can go away under us — closed or hidden from another
+    // client, or a world switch. Nothing would then render the banner or the edit
+    // surface, while Back kept being swallowed by the handler above, so the screen
+    // looked normal and refused to leave. Leaving edit mode is the only sane answer.
+    LaunchedEffect(editTabId, tabs) {
+        if (editTabId != null && tabs.none { it.id == editTabId }) vm.exitEdit()
+    }
+
     // Diving into a pane is the ONLY thing that commits a tab server-side:
     // activate the tab (browsing never did — see centeredIndex above), focus
     // the pane, and navigate immediately (openPane is synchronous, so the dive
@@ -280,12 +286,15 @@ fun OverviewContent(
     // Diving navigates, so it must happen once per gesture: while the row is
     // settling a tap is watched for at the card level as well as by the pane's own
     // handler (see SwitcherCardRow), and two navigations would stack two terminals
-    // on the back stack. Reset by leaving and re-entering the overview, which is
-    // exactly when a second dive becomes legitimate again.
-    var diveStarted by remember { mutableStateOf(false) }
+    // on the back stack. A short debounce rather than a latch, deliberately: a
+    // latch set before navigating stays set if that navigation is interrupted —
+    // Back pressed during the dive's fade leaves the tree composed — and then every
+    // later tap is swallowed with no way back.
+    var lastDiveNanos by remember { mutableStateOf(0L) }
     val divePane: (OverviewTab, OverviewPane) -> Unit = { tab, pane ->
-        if (!diveStarted) {
-            diveStarted = true
+        val now = System.nanoTime()
+        if (now - lastDiveNanos > DIVE_DEBOUNCE_NANOS) {
+            lastDiveNanos = now
             divePaneId = pane.leaf.id
             scope.launch {
                 if (!tab.isActive) vm.setActiveTab(tab.id)
@@ -364,6 +373,20 @@ fun OverviewContent(
                     centeredIndex = centeredIndex,
                     onCenter = { index -> scope.launch { rowListState.animateScrollToItem(index) } },
                     onDiveTab = diveIntoTab,
+                    onDiveAt = { tab, fractionX, fractionY ->
+                        // The exposé canvas lays panes out in fractions of its own
+                        // box, so a tap's fraction of the card lands in the same
+                        // space (the canvas' few dp of inset is far below a
+                        // fingertip). Whatever pane contains the point wins; a tap
+                        // on bare canvas falls back to the tab's own target.
+                        val touched = tab.panes
+                            .filter { pane ->
+                                fractionX >= pane.x && fractionX <= pane.x + pane.width &&
+                                    fractionY >= pane.y && fractionY <= pane.y + pane.height
+                            }
+                            .maxByOrNull { it.z }
+                        if (touched != null) divePane(tab, touched) else diveIntoTab(tab)
+                    },
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
@@ -453,28 +476,6 @@ fun OverviewContent(
     }
 }
 
-/**
- * The app-switcher card row: one rounded card per tab, ~70% of the surface
- * width at the surface's own aspect ratio, in a snapping [LazyRow] with free
- * momentum flinging — so moving across many tabs is one gesture, not one
- * swipe per tab. Neighbors peek in from both sides and shrink/dim slightly
- * with distance from center, matching the OS app switcher this replicates.
- *
- * Browsing is passive: only the centered card is interactive; tapping (or
- * long-pressing) a peeking card centers it and nothing else, so a fling can
- * never accidentally dive into a pane or open its menu. Selection semantics
- * live in the caller ([OverviewContent]).
- *
- * @param tabs          the tabs to render, one card each.
- * @param rowListState  the hoisted row state ([OverviewContent] re-keys it per
- *   world and drives centering from server echoes).
- * @param centeredIndex index of the card snapped to (or nearest) center; only
- *   it passes touches through to its panes.
- * @param onCenter      center the card at the given index.
- * @param modifier      layout modifier from the caller.
- * @param cardContent   the card's content for a tab (the tab's exposé canvas).
- */
-@OptIn(ExperimentalFoundationApi::class)
 /**
  * Velocity, in dp/s, above which a release is a *flick* rather than a let-go.
  * Deliberately tiny: the OS switcher moves on with the smallest deliberate
@@ -579,11 +580,22 @@ private const val CARD_TAP_DIVE_FRACTION = 0.55f
 private const val CARD_TAP_MAX_HOLD_MS = 500L
 
 /**
- * How far the row may move between press and lift — in cards — for the gesture to
- * still count as a tap rather than a drag. A press stops the settle, so a real tap
- * moves the row barely at all.
+ * How long after a dive another one is ignored. Long enough that the two handlers
+ * which can see one mid-settle tap cannot both navigate, short enough that a dive
+ * interrupted by Back does not leave the switcher unable to open anything.
  */
-private const val CARD_TAP_SCROLL_TOLERANCE = 0.04f
+private const val DIVE_DEBOUNCE_NANOS = 400_000_000L
+
+/**
+ * How far the row may move between press and lift — in cards — for the gesture to
+ * still count as a tap rather than a drag.
+ *
+ * Generous on purpose: a press cannot stop the settle before the next frame is
+ * produced, and at a brisk settle speed the row still travels a few percent of a
+ * card in that frame. A drag moves it far more than this, because the row follows
+ * the finger.
+ */
+private const val CARD_TAP_SCROLL_TOLERANCE = 0.2f
 
 /**
  * How much of the card at [index] is inside the row's viewport, 0..1.
@@ -665,6 +677,33 @@ private fun roomToEdge(rowListState: LazyListState, forward: Boolean): Float? {
     return room.coerceAtLeast(0f)
 }
 
+/**
+ * The app-switcher card row: one rounded card per tab, nearly filling the surface,
+ * in a snapping [LazyRow] with free momentum flinging — so moving across many tabs
+ * is one gesture, not one swipe per tab. The neighbours are reduced to slivers at
+ * the edges, because a card here is a terminal to be read rather than an app
+ * screenshot to be recognised.
+ *
+ * Browsing is passive: it never activates a tab server-side. What a tap does
+ * depends on how much of the card is on screen — a sliver only centres it, a card
+ * you can actually read opens it — and while the row is moving each card watches
+ * the pointer itself, because a press that stops a settle can be cancelled before
+ * any clickable sees it. Selection semantics live in the caller
+ * ([OverviewContent]); the motion constants are documented where they are declared.
+ *
+ * @param tabs          the tabs to render, one card each.
+ * @param rowListState  the hoisted row state ([OverviewContent] re-keys it per
+ *   world and drives centering from server echoes).
+ * @param centeredIndex index of the card the row is on; its panes take their own
+ *   taps, every other card is covered by a gate.
+ * @param onCenter      center the card at the given index.
+ * @param onDiveTab     open a tab's own target pane (its focused, else topmost).
+ * @param onDiveAt      open whatever pane sits at the given fraction of a card,
+ *   used by the mid-settle tap watcher so a multi-pane card opens what was touched.
+ * @param modifier      layout modifier from the caller.
+ * @param cardContent   the card's content for a tab (the tab's exposé canvas).
+ */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SwitcherCardRow(
     tabs: List<OverviewTab>,
@@ -672,6 +711,7 @@ private fun SwitcherCardRow(
     centeredIndex: Int,
     onCenter: (Int) -> Unit,
     onDiveTab: (OverviewTab) -> Unit,
+    onDiveAt: (OverviewTab, Float, Float) -> Unit,
     modifier: Modifier = Modifier,
     cardContent: @Composable (OverviewTab) -> Unit,
 ) {
@@ -682,9 +722,6 @@ private fun SwitcherCardRow(
         val cardHeight = maxHeight
         val sidePadding = (maxWidth - cardWidth) / 2
         val cardShape = RoundedCornerShape(SwitcherCardCorner)
-        // Whether the row is mid-drag, mid-fling or mid-settle. Changes twice per
-        // gesture, so reading it here costs nothing.
-        val scrolling = rowListState.isScrollInProgress
 
         LazyRow(
             state = rowListState,
@@ -719,61 +756,74 @@ private fun SwitcherCardRow(
                         ),
                 ) {
                     cardContent(tab)
-                    // While the row is moving, watch for a tap at the card level
-                    // too. A press during a settle is exactly the case that fell
-                    // through the cracks: it stops the scroll, and stopping the
+                    // A press that lands while the row is moving is the case that
+                    // fell through the cracks: it stops the scroll, and stopping the
                     // scroll can cancel the press before either the pane's
                     // combinedClickable or the gate below ever sees a click — so
                     // tapping the card that fills the screen did nothing at all.
                     //
-                    // This layer consumes nothing (a drag still scrolls the row);
-                    // it only decides, on lift, whether what happened was a tap:
-                    // quick, and with the row's position barely moved, which a drag
-                    // never is. Local pointer movement cannot be the test here — the
-                    // card moves under a stationary finger during a settle, and
-                    // follows the finger during a drag, so the two are the wrong way
-                    // round.
-                    if (scrolling) {
-                        Box(
-                            Modifier
-                                .matchParentSize()
-                                .pointerInput(index) {
-                                    awaitEachGesture {
-                                        val down = awaitFirstDown(
-                                            requireUnconsumed = false,
-                                            pass = PointerEventPass.Initial,
-                                        )
-                                        val focusAtDown = switcherFocusIndex(rowListState)
-                                        var lift: PointerInputChange? = null
-                                        while (true) {
-                                            val event = awaitPointerEvent(PointerEventPass.Initial)
-                                            val change = event.changes
-                                                .firstOrNull { it.id == down.id } ?: break
-                                            if (!change.pressed) {
-                                                lift = change
-                                                break
-                                            }
-                                        }
-                                        val up = lift ?: return@awaitEachGesture
-                                        val heldMs = up.uptimeMillis - down.uptimeMillis
-                                        val moved = abs(
-                                            switcherFocusIndex(rowListState) - focusAtDown,
-                                        )
-                                        if (heldMs <= CARD_TAP_MAX_HOLD_MS &&
-                                            moved <= CARD_TAP_SCROLL_TOLERANCE
-                                        ) {
-                                            if (visibleFraction(rowListState, index) >=
-                                                CARD_TAP_DIVE_FRACTION
-                                            ) {
-                                                onDiveTab(tab)
-                                            } else {
-                                                onCenter(index)
-                                            }
+                    // This layer consumes nothing (a drag still scrolls the row) and
+                    // is composed unconditionally: gating it on "is scrolling" meant
+                    // it left composition the moment the press stopped the scroll,
+                    // cancelling the very gesture it was watching. Whether it acts is
+                    // decided from the state at the PRESS instead, and only then, so
+                    // a tap on a resting row is left to the handlers below.
+                    //
+                    // On lift it asks whether what happened was a tap: quick, and
+                    // with the row's position barely moved. Local pointer movement
+                    // cannot be that test — the card moves under a stationary finger
+                    // during a settle and follows the finger during a drag, so the
+                    // two are the wrong way round.
+                    Box(
+                        Modifier
+                            .matchParentSize()
+                            .pointerInput(index) {
+                                awaitEachGesture {
+                                    val down = awaitFirstDown(
+                                        requireUnconsumed = false,
+                                        pass = PointerEventPass.Initial,
+                                    )
+                                    val movingAtPress = rowListState.isScrollInProgress
+                                    val focusAtDown = switcherFocusIndex(rowListState)
+                                    var lift: PointerInputChange? = null
+                                    while (true) {
+                                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                                        val change = event.changes
+                                            .firstOrNull { it.id == down.id } ?: break
+                                        if (!change.pressed) {
+                                            lift = change
+                                            break
                                         }
                                     }
-                                },
-                        )
-                    }
+                                    val up = lift ?: return@awaitEachGesture
+                                    if (!movingAtPress) return@awaitEachGesture
+                                    val heldMs = up.uptimeMillis - down.uptimeMillis
+                                    val moved = abs(
+                                        switcherFocusIndex(rowListState) - focusAtDown,
+                                    )
+                                    if (heldMs > CARD_TAP_MAX_HOLD_MS ||
+                                        moved > CARD_TAP_SCROLL_TOLERANCE
+                                    ) {
+                                        return@awaitEachGesture
+                                    }
+                                    if (visibleFraction(rowListState, index) <
+                                        CARD_TAP_DIVE_FRACTION
+                                    ) {
+                                        onCenter(index)
+                                        return@awaitEachGesture
+                                    }
+                                    // Open what was actually touched. Diving "into
+                                    // the tab" picks its focused pane, which on a
+                                    // multi-pane card is the wrong terminal whenever
+                                    // the finger was on another one.
+                                    onDiveAt(
+                                        tab,
+                                        up.position.x / size.width.toFloat(),
+                                        up.position.y / size.height.toFloat(),
+                                    )
+                                }
+                            },
+                    )
 
                     if (index != centeredIndex) {
                         // A card that is not the centred one still gets a gate, so
@@ -1241,7 +1291,6 @@ private fun leafKindOf(leaf: LeafNode): LeafKind = when (leaf.content) {
  * @param pane            the projected pane.
  * @param raised          whether to lift the card (used for the pane being
  *   dragged).
- * @param modifier        outermost modifier on the card's root box.
  * @param contentModifier modifier on the miniature *inside* the chrome —
  *   [ExposeCanvas] attaches the dive transition's shared bounds here, because
  *   the far end of that flight is the terminal's content box and only this box
@@ -1251,7 +1300,6 @@ private fun leafKindOf(leaf: LeafNode): LeafKind = when (leaf.content) {
 private fun MiniPane(
     pane: OverviewPane,
     raised: Boolean,
-    modifier: Modifier = Modifier,
     contentModifier: Modifier = Modifier,
 ) {
     val focused = pane.isFocused
@@ -1260,7 +1308,7 @@ private fun MiniPane(
     val shape = RoundedCornerShape(6.dp)
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .then(if (raised) Modifier.shadow(10.dp, shape) else Modifier)
             .clip(shape)

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -5,9 +5,11 @@
  * card per tab (each card a "scaled exposé" of that tab's pane layout) in a
  * free-flinging, center-snapping row — moving across many tabs is one gesture
  * — with a labelled tab dock at the bottom for orientation and direct jumps
- * (see [TabDock]). Browsing the row never changes server state; diving into a
- * pane (tap on the centered card) activates the tab, focuses the pane, and
- * drills into that pane's full-screen route.
+ * (see [TabDock]). Pinching the row zooms it between three card sizes
+ * ([SwitcherZoom]), from one card to read to a row to survey. Browsing the row
+ * never changes server state; diving into a pane (tap on the centered card)
+ * activates the tab, focuses the pane, and drills into that pane's full-screen
+ * route.
  *
  * Window management (issue #58):
  *  - Tapping a pane also makes it the tab's active/focused pane.
@@ -31,6 +33,8 @@ package se.soderbjorn.lunamux.android.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.TargetedFlingBehavior
@@ -42,6 +46,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.calculateCentroidSize
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -55,6 +61,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
@@ -87,8 +94,10 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -100,11 +109,13 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -114,11 +125,13 @@ import androidx.compose.ui.zIndex
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import se.soderbjorn.lunamux.FileBrowserContent
 import se.soderbjorn.lunamux.AgentContent
 import se.soderbjorn.lunamux.GitContent
 import se.soderbjorn.lunamux.LeafNode
+import se.soderbjorn.lunamux.android.data.AppLocalRepository
 import se.soderbjorn.lunamux.android.net.ConnectionHolder
 import se.soderbjorn.lunamux.client.closeTab
 import se.soderbjorn.lunamux.client.renamePane
@@ -131,16 +144,102 @@ import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.OverviewT
 import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.UnlistedTab
 
 /**
- * Fraction of the switcher row's width one card occupies.
+ * Fraction of the switcher row's width one card occupies at [SwitcherZoom.In] —
+ * the widest a card is ever drawn, and the reference every other level is a
+ * fraction of.
  *
- * Nearly all of it. The OS switcher spends a fifth of its width on peeking
- * neighbours because its cards are app screenshots you recognise at a glance; a
- * card here is a terminal you have to *read*, so the screen goes to the text and
- * the neighbours are reduced to a sliver at the edges. The row still snaps and
- * flings the same way.
- *
+ * This was once the only card size, on the reasoning that a card here is a
+ * terminal you have to read rather than an app screenshot you recognise at a
+ * glance. Reading one card is not what a switcher is for, though: at nearly the
+ * full width there is no seeing how many tabs there are or where you are among
+ * them, which is the whole point of the idiom. It is now the zoomed-*in*
+ * posture, and [SwitcherZoom.Default] — the OS switcher's own proportions — is
+ * what the row opens at.
  */
 internal const val SWITCHER_CARD_FRACTION = 0.89f
+
+/**
+ * The three postures the card row snaps between under a pinch, as the fraction
+ * of the row's width one card takes up **on screen**.
+ *
+ * Cards scale in BOTH dimensions, never width alone. A thumbnail fits its box by
+ * filling the height and cropping the columns that overflow the width (see
+ * [TerminalThumbnail]), so a card squeezed horizontally at full height would show
+ * *less of the terminal* the further you zoomed out — the exact opposite of what
+ * zooming out is for. Scaling uniformly keeps the same window of text in view at
+ * every level and only changes how large it is drawn.
+ *
+ * A level is a real layout — the cards are measured at its size, not drawn
+ * shrunken from a bigger one — and only the pinch that moves between two levels
+ * is a transform. [SwitcherCardRow] says why that distinction is load-bearing
+ * and what it costs to keep.
+ *
+ * What a level does change is the stride, and with it the scroll offset that
+ * centres a given card, so committing one re-centres the row. Everything else
+ * the row measures off its own geometry — the fling's edge maths, the dock's
+ * fractional focus, a tap's visible fraction — is expressed in strides and
+ * viewports and needs no adjusting at all.
+ *
+ * @property cardFraction the on-screen card width as a fraction of the row's.
+ */
+internal enum class SwitcherZoom(val cardFraction: Float) {
+    /**
+     * Both neighbours mostly in view either side of the centred card — a bit over
+     * two tabs on screen, read as shapes and colours (where the panes sit, which
+     * one is a wall of output) with their titles above them.
+     *
+     * Not smaller than this, however tempting three-across is. Cards keep their
+     * aspect, so the width you take off comes off the height too, and much below
+     * here the row is a thin band of postage stamps stranded in the middle of an
+     * empty screen.
+     */
+    Out(0.45f),
+
+    /**
+     * The OS switcher's own proportions, near enough: one card still large enough
+     * to read, with both neighbours showing at the edges — which is what says at
+     * a glance that there are more tabs and which way they lie.
+     */
+    Default(0.62f),
+
+    /** One card at nearly the full width — the reading posture. */
+    In(SWITCHER_CARD_FRACTION),
+    ;
+
+    /**
+     * How much of an [In] card this level's card measures, in **both**
+     * dimensions — the factor a card's height is taken down by, since its width
+     * is already [cardFraction] of a row whose height it no longer fills.
+     */
+    val cardScale: Float get() = cardFraction / SWITCHER_CARD_FRACTION
+
+    companion object {
+        /**
+         * The level [name] names, or [Default] for anything else.
+         *
+         * Deliberately total rather than throwing: the name comes off disk (see
+         * `LocalState.switcherZoom`), and a file written by a build with a
+         * different set of levels should land on the default, not crash the
+         * overview.
+         *
+         * @param name a persisted level name, or `null`/`""` when none was stored.
+         * @return the level to open at.
+         */
+        fun ofName(name: String?): SwitcherZoom =
+            entries.firstOrNull { it.name == name } ?: Default
+
+        /**
+         * The level whose [cardFraction] is nearest [fraction] — where a pinch
+         * lands when the fingers lift.
+         *
+         * @param fraction the card width the gesture ended on, as a fraction of
+         *   the row's.
+         * @return the level to settle to.
+         */
+        fun nearest(fraction: Float): SwitcherZoom =
+            entries.minByOrNull { abs(it.cardFraction - fraction) } ?: Default
+    }
+}
 
 /**
  * The switcher's vertical rhythm: the gap above the cards, between the cards and
@@ -148,13 +247,39 @@ internal const val SWITCHER_CARD_FRACTION = 0.89f
  *
  * The dock used to sit flush against the bottom edge with the card row's leftover
  * slack above it, so it read as stuck to the bottom of the screen rather than as
- * one of three evenly spaced bands. Cards now fill their row exactly and this is
- * the only vertical spacing in the switcher.
+ * one of three evenly spaced bands. This is now the only vertical spacing the
+ * switcher applies: the card row fills the band it is given, and the air around
+ * the cards inside it belongs to the zoom level (see [SwitcherZoom]).
  */
 internal val SwitcherEdgeGap = 12.dp
 
 /** Corner radius of a switcher card. */
 internal val SwitcherCardCorner = 20.dp
+
+/**
+ * Distance between two cards. Constant across the zoom levels rather than scaled
+ * with them: at [SwitcherZoom.Out] a proportional gap left the cards nearly
+ * touching, and what separates them there is a job for a fixed few dp.
+ */
+private val SwitcherCardGap = 16.dp
+
+/**
+ * Type size of the tab title drawn above a card.
+ *
+ * The title is what makes zooming out navigable: at [SwitcherZoom.Out] a card's
+ * text is closer to shape than to words, so its name is what says which tab you
+ * are looking at — the same job the app name does above a card in the OS
+ * switcher, and it goes in the same place.
+ * It has no room at [SwitcherZoom.In], where the card fills its row, and needs
+ * none: there is only the one card to be looking at.
+ */
+private val SwitcherLabelSize = 13.sp
+
+/** Gap between a card's top edge and its title. @see SwitcherLabelSize */
+private val SwitcherLabelGap = 7.dp
+
+/** Line height of a card's title. @see SwitcherLabelSize */
+private val SwitcherLabelHeight = 18.dp
 
 /**
  * The overview content: the switcher card row + bottom tab dock (or, while
@@ -218,6 +343,18 @@ fun OverviewContent(
     // Rename / close dialog targets raised from a tab chip's context menu.
     var renameTabTarget by remember { mutableStateOf<OverviewTab?>(null) }
     var closeTabTarget by remember { mutableStateOf<OverviewTab?>(null) }
+
+    // The zoom posture the switcher opens at, read from local state ONCE rather
+    // than observed: from here on the row owns the level (a pinch is the only
+    // thing that changes it), and a flow collected into the layout would fight
+    // the gesture that just wrote to it. Hydration is a file read started at
+    // process launch, long finished by the time there is a connection to show
+    // tabs from — and the fallback if it somehow is not is the default level the
+    // user would have been given anyway, so nothing can flash the wrong size.
+    val localRepository = remember { AppLocalRepository.instance }
+    val initialZoom = remember {
+        SwitcherZoom.ofName(localRepository.state.value?.switcherZoom)
+    }
 
     val tabs = state.tabs
     val activeIndex = tabs.indexOfFirst { it.isActive }.coerceAtLeast(0)
@@ -365,13 +502,18 @@ fun OverviewContent(
                     canvasFor(editingTab, true)
                 }
             } else {
-                // App-switcher card row: one card per tab at ~70% width in the
-                // screen's aspect, free momentum flinging with center snap,
-                // neighbors peeking in from both sides.
+                // App-switcher card row: one card per tab, at whichever of the
+                // three pinch levels the user last settled on, free momentum
+                // flinging with center snap, neighbours peeking in from both
+                // sides.
                 SwitcherCardRow(
                     tabs = tabs,
                     rowListState = rowListState,
                     centeredIndex = centeredIndex,
+                    initialZoom = initialZoom,
+                    onZoomChanged = { level ->
+                        scope.launch { localRepository.setSwitcherZoom(level.name) }
+                    },
                     onCenter = { index -> scope.launch { rowListState.animateScrollToItem(index) } },
                     onDiveTab = diveIntoTab,
                     onDiveAt = { tab, fractionX, fractionY ->
@@ -664,6 +806,12 @@ private fun Modifier.midSettleTapWatcher(
             val travelY = change.position.y - down.position.y
             if (abs(travelX) > travelLimit || abs(travelY) > travelLimit) dragged = true
             if (change.positionChange() != Offset.Zero && change.isConsumed) dragged = true
+            // A second finger means a pinch (see switcherPinch), never a tap. The
+            // consumption test above catches one that has already claimed the
+            // gesture, but a pinch still short of its slop has consumed nothing
+            // yet, and two fingers put down and lifted together would otherwise
+            // dive.
+            if (event.changes.count { it.pressed } > 1) dragged = true
             if (!change.pressed) {
                 lift = change
                 break
@@ -761,30 +909,72 @@ private fun roomToEdge(rowListState: LazyListState, forward: Boolean): Float? {
 }
 
 /**
- * The app-switcher card row: one rounded card per tab, nearly filling the surface,
- * in a snapping [LazyRow] with free momentum flinging — so moving across many tabs
- * is one gesture, not one swipe per tab. The neighbours are reduced to slivers at
- * the edges, because a card here is a terminal to be read rather than an app
- * screenshot to be recognised.
+ * Stiffness of the settle onto a zoom level when the fingers lift, and its
+ * damping ratio.
+ *
+ * Much firmer than the row's own settle ([SWITCHER_SNAP_STIFFNESS]): that spring
+ * is soft because it carries a card most of the way across the screen, while this
+ * one only closes the few percent of scale between where the pinch stopped and
+ * the nearest level. At the row's stiffness the cards went on creeping long after
+ * the fingers were gone.
+ */
+private const val SWITCHER_ZOOM_STIFFNESS = 400f
+
+/** Damping ratio of the zoom settle; 1 lands on the level without overshoot. */
+private const val SWITCHER_ZOOM_DAMPING = 1f
+
+/**
+ * The app-switcher card row: one rounded card per tab in a snapping [LazyRow]
+ * with free momentum flinging — so moving across many tabs is one gesture, not
+ * one swipe per tab — pinchable between the three [SwitcherZoom] levels.
+ *
+ * **A level is a real layout; only the gesture itself is a transform.** At rest
+ * the cards are *measured* at the level's size, so a thumbnail is drawn at that
+ * size rather than sampled down from a larger one, and — the reason it matters
+ * most — the dive's shared bounds are the card's true layout bounds. Shared
+ * elements take their bounds from the lookahead pass, which does not see an
+ * ancestor's [graphicsLayer], so a row left permanently scaled would fly the
+ * dive from a rect that is not the card you tapped.
+ *
+ * While a pinch is in flight the row instead previews the new size with exactly
+ * that transform, and lands the layout on it when the fingers lift. That keeps
+ * the gesture cheap — the cards' constraints never change during it, so no card
+ * is remeasured or recomposed while fingers are down, only re-placed — and the
+ * transform is gone (an exact identity) by the time anything can be tapped. The
+ * row is measured at the inverse of the preview so that the cards the transform
+ * is about to reveal are already composed, rather than sliding in from a blank
+ * margin at the commit.
+ *
+ * The commit changes the stride, which is the one thing zooming does that the
+ * row's own maths cannot absorb, so it re-centres in the same breath — with
+ * [LazyListState.requestScrollToItem], applied by the very measure pass the new
+ * size triggers, rather than by a scroll a frame later.
  *
  * Browsing is passive: it never activates a tab server-side. What a tap does
  * depends on how much of the card is on screen — a sliver only centres it, a card
- * you can actually read opens it — and while the row is moving each card watches
- * the pointer itself, because a press that stops a settle can be cancelled before
- * any clickable sees it. Selection semantics live in the caller
- * ([OverviewContent]); the motion constants are documented where they are declared.
+ * you can actually read opens it, which zoomed out is every card you can see, as
+ * in the OS switcher. While the row is moving each card watches the pointer
+ * itself, because a press that stops a settle can be cancelled before any
+ * clickable sees it. Selection semantics live in the caller ([OverviewContent]);
+ * the motion constants are documented where they are declared.
  *
  * @param tabs          the tabs to render, one card each.
  * @param rowListState  the hoisted row state ([OverviewContent] re-keys it per
  *   world and drives centering from server echoes).
  * @param centeredIndex index of the card the row is on; its panes take their own
- *   taps, every other card is covered by a gate.
+ *   taps, every other card is covered by a gate, and a zoom re-centres on it.
+ * @param initialZoom   the level to open at, read from local state by the caller.
+ *   The row owns the level from then on — a pinch is the only thing that moves it.
+ * @param onZoomChanged a pinch settled on a level other than the one it started
+ *   from; the caller persists it.
  * @param onCenter      center the card at the given index.
  * @param onDiveTab     open a tab's own target pane (its focused, else topmost).
  * @param onDiveAt      open whatever pane sits at the given fraction of a card,
  *   used by the mid-settle tap watcher so a multi-pane card opens what was touched.
  * @param modifier      layout modifier from the caller.
  * @param cardContent   the card's content for a tab (the tab's exposé canvas).
+ * @see SwitcherZoom
+ * @see switcherPinch
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -792,86 +982,258 @@ private fun SwitcherCardRow(
     tabs: List<OverviewTab>,
     rowListState: LazyListState,
     centeredIndex: Int,
+    initialZoom: SwitcherZoom,
+    onZoomChanged: (SwitcherZoom) -> Unit,
     onCenter: (Int) -> Unit,
     onDiveTab: (OverviewTab) -> Unit,
     onDiveAt: (OverviewTab, Float, Float) -> Unit,
     modifier: Modifier = Modifier,
     cardContent: @Composable (OverviewTab) -> Unit,
 ) {
+    // The level the row is laid out at, and the in-gesture preview of the next
+    // one as a multiple of it — exactly 1 whenever no pinch is in flight.
+    var zoom by remember { mutableStateOf(initialZoom) }
+    var preview by remember { mutableFloatStateOf(1f) }
+    val zoomScope = rememberCoroutineScope()
+    // The settle after a pinch, held so the next pinch can take the scale back
+    // off it mid-flight instead of the two writing over each other.
+    var settle by remember { mutableStateOf<Job?>(null) }
+
+    // The level the titles are dressed for. Set the moment a pinch is released
+    // rather than when the layout lands on it, so a title fades out over the
+    // settle instead of after it — at In there is no slack above a card, and a
+    // title still fading there would be doing it above the row entirely.
+    var titledZoom by remember { mutableStateOf(initialZoom) }
+
+    // Faded rather than popped, and held as a State read in the *draw* phase, so
+    // the fade costs no recomposition of the cards it is drawn over.
+    val labelAlpha = animateFloatAsState(
+        targetValue = if (titledZoom == SwitcherZoom.In) 0f else 1f,
+        label = "switcher-card-title",
+    )
+
     BoxWithConstraints(modifier) {
-        val cardWidth = maxWidth * SWITCHER_CARD_FRACTION
-        // The card fills the row it is given; the breathing room around the
-        // switcher is [SwitcherEdgeGap], applied once by the caller.
-        val cardHeight = maxHeight
-        val sidePadding = (maxWidth - cardWidth) / 2
+        val cardWidth = maxWidth * zoom.cardFraction
+        // Both dimensions, always: see SwitcherZoom for what happens to a
+        // thumbnail in a card narrowed at full height.
+        val cardHeight = maxHeight * zoom.cardScale
+        // Sized against the preview so the row composes what the preview reveals;
+        // at rest `preview` is 1 and these are the surface itself.
+        val rowWidth = maxWidth / preview
+        val rowHeight = maxHeight / preview
+        // Symmetric padding of (viewport - card)/2 makes item offset 0 the
+        // centered position, so snap positions and scrollToItem(i) both
+        // land cards dead-center — including the first and last.
+        val sidePadding = (rowWidth - cardWidth) / 2
         val cardShape = RoundedCornerShape(SwitcherCardCorner)
 
-        LazyRow(
-            state = rowListState,
-            flingBehavior = rememberSwitcherFlingBehavior(rowListState),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            // Symmetric padding of (viewport - card)/2 makes item offset 0 the
-            // centered position, so snap positions and scrollToItem(i) both
-            // land cards dead-center — including the first and last.
-            contentPadding = PaddingValues(horizontal = sidePadding),
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            itemsIndexed(tabs, key = { _, tab -> tab.id }) { index, tab ->
-                // No distance-from-centre scale or fade: the carousel effect was
-                // one more thing moving during a fling, and it read as the row
-                // fighting its own settle rather than as depth. Cards are flat and
-                // identical; the dock carries the depth cue instead.
-                Box(
-                    modifier = Modifier
-                        .width(cardWidth)
-                        .height(cardHeight)
-                        .clip(cardShape)
-                        .background(SidebarSurface.copy(alpha = 0.35f))
-                        // A hairline, never the accent: the panes inside draw
-                        // their own outline (accented when focused), so an
-                        // accent ring around the card read as a double border.
-                        // Which tab is server-active is said by its dock chip.
-                        .border(
-                            width = 1.dp,
-                            color = SidebarTextSecondary.copy(alpha = 0.22f),
-                            shape = cardShape,
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .requiredSize(rowWidth, rowHeight)
+                .graphicsLayer {
+                    scaleX = preview
+                    scaleY = preview
+                }
+                .switcherPinch(
+                    onPinch = { step ->
+                        settle?.cancel()
+                        // Clamped in the level's own terms: the preview may reach
+                        // the outermost and innermost levels and no further, so a
+                        // pinch pushed past one stops dead rather than banking up
+                        // travel it would have to give back before responding.
+                        preview = (preview * step).coerceIn(
+                            SwitcherZoom.Out.cardFraction / zoom.cardFraction,
+                            SwitcherZoom.In.cardFraction / zoom.cardFraction,
                         )
-                        // Watches for a tap that lands while the row is moving.
-                        // On the card, NOT laid over it — see the modifier's doc.
-                        .midSettleTapWatcher(
-                            index = index,
-                            rowListState = rowListState,
-                            onCenter = onCenter,
-                        ) { fractionX, fractionY -> onDiveAt(tab, fractionX, fractionY) },
-                ) {
-                    cardContent(tab)
-                    if (index != centeredIndex) {
-                        // A card that is not the centred one still gets a gate, so
-                        // a pane's own taps and long-press menu cannot fire on a
-                        // card the row is not on. What the gate DOES depends on how
-                        // much of that card you can see: a sliver at the edge only
-                        // centres, but a card already filling most of the screen —
-                        // which is what the incoming card looks like for the whole
-                        // length of a settle — opens, because tapping the thing you
-                        // are looking at should not have to wait for an animation.
-                        Box(
-                            Modifier
-                                .matchParentSize()
-                                .combinedClickable(
-                                    onClick = {
-                                        if (visibleFraction(rowListState, index) >= CARD_TAP_DIVE_FRACTION) {
-                                            onDiveTab(tab)
-                                        } else {
-                                            onCenter(index)
-                                        }
-                                    },
-                                    onLongClick = { onCenter(index) },
+                    },
+                    onPinchEnd = {
+                        val target = SwitcherZoom.nearest(zoom.cardFraction * preview)
+                        titledZoom = target
+                        settle = zoomScope.launch {
+                            animate(
+                                initialValue = preview,
+                                targetValue = target.cardFraction / zoom.cardFraction,
+                                animationSpec = spring(
+                                    dampingRatio = SWITCHER_ZOOM_DAMPING,
+                                    stiffness = SWITCHER_ZOOM_STIFFNESS,
                                 ),
+                            ) { value, _ -> preview = value }
+                            // Hand the preview over to the layout. Both writes land
+                            // before the next frame is composed, so the transform is
+                            // never seen off a size it no longer matches; the
+                            // re-centre rides the measure pass they trigger, because
+                            // a new card width is a new stride and the scroll offset
+                            // that centred this card is no longer the same number.
+                            val changed = target != zoom
+                            zoom = target
+                            preview = 1f
+                            rowListState.requestScrollToItem(centeredIndex)
+                            if (changed) onZoomChanged(target)
+                        }
+                    },
+                ),
+        ) {
+            LazyRow(
+                state = rowListState,
+                flingBehavior = rememberSwitcherFlingBehavior(rowListState),
+                horizontalArrangement = Arrangement.spacedBy(SwitcherCardGap),
+                verticalAlignment = Alignment.CenterVertically,
+                contentPadding = PaddingValues(horizontal = sidePadding),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                itemsIndexed(tabs, key = { _, tab -> tab.id }) { index, tab ->
+                    // No distance-from-centre scale or fade: the carousel effect was
+                    // one more thing moving during a fling, and it read as the row
+                    // fighting its own settle rather than as depth. Cards are flat and
+                    // identical; the dock carries the depth cue instead.
+                    Box(
+                        modifier = Modifier
+                            .width(cardWidth)
+                            .height(cardHeight),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(cardShape)
+                                .background(SidebarSurface.copy(alpha = 0.35f))
+                                // A hairline, never the accent: the panes inside draw
+                                // their own outline (accented when focused), so an
+                                // accent ring around the card read as a double border.
+                                // Which tab is server-active is said by its dock chip.
+                                .border(
+                                    width = 1.dp,
+                                    color = SidebarTextSecondary.copy(alpha = 0.22f),
+                                    shape = cardShape,
+                                )
+                                // Watches for a tap that lands while the row is moving.
+                                // On the card, NOT laid over it — see the modifier's doc.
+                                .midSettleTapWatcher(
+                                    index = index,
+                                    rowListState = rowListState,
+                                    onCenter = onCenter,
+                                ) { fractionX, fractionY -> onDiveAt(tab, fractionX, fractionY) },
+                        ) {
+                            cardContent(tab)
+                            if (index != centeredIndex) {
+                                // A card that is not the centred one still gets a gate, so
+                                // a pane's own taps and long-press menu cannot fire on a
+                                // card the row is not on. What the gate DOES depends on how
+                                // much of that card you can see: a sliver at the edge only
+                                // centres, but a card already filling most of the screen —
+                                // which is what the incoming card looks like for the whole
+                                // length of a settle, and what every neighbour looks like
+                                // once zoomed out — opens, because tapping the thing you
+                                // are looking at should not have to wait for an animation.
+                                Box(
+                                    Modifier
+                                        .matchParentSize()
+                                        .combinedClickable(
+                                            onClick = {
+                                                if (visibleFraction(rowListState, index) >= CARD_TAP_DIVE_FRACTION) {
+                                                    onDiveTab(tab)
+                                                } else {
+                                                    onCenter(index)
+                                                }
+                                            },
+                                            onLongClick = { onCenter(index) },
+                                        ),
+                                )
+                            }
+                        }
+
+                        // The tab's name, in the slack above the card that every
+                        // level but In leaves. Offset out of the card rather than
+                        // laid out above it, so the card's box stays exactly the
+                        // card — which is what a tap's fractions and the dive's
+                        // shared bounds are measured against.
+                        Text(
+                            text = tab.title,
+                            color = SidebarTextSecondary,
+                            fontSize = SwitcherLabelSize,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .offset(y = -(SwitcherLabelGap + SwitcherLabelHeight))
+                                .padding(horizontal = SwitcherCardCorner)
+                                .graphicsLayer { alpha = labelAlpha.value },
                         )
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Watch for a two-finger pinch and report it, taking the gesture off the row it
+ * is attached to for as long as one lasts.
+ *
+ * Sits on the row's container rather than over it: pointer events reach an
+ * ancestor in the [PointerEventPass.Initial] pass before the [LazyRow] inside
+ * ever sees them, so this can claim a gesture the row would otherwise scroll on
+ * without an overlay swallowing everything else (see [midSettleTapWatcher] for
+ * what an overlay costs here).
+ *
+ * A pinch has to earn the gesture. Until the fingers' separation has changed by
+ * more than the touch slop, relative to how far apart they are, nothing is
+ * consumed and the row scrolls as usual — two fingers dragging together are a
+ * scroll, and treating every second finger as a zoom made the row jitter whenever
+ * a thumb brushed it. Once it *is* a pinch it stays one until every finger is up,
+ * even while only one of them is left: handing the tail of the gesture back would
+ * fling the row out from under a zoom the user is still finishing.
+ *
+ * Reported as a per-event *step* rather than as a total, so a pinch picks up from
+ * wherever the row is drawn — mid-settle from the last one included — and so a
+ * pinch held past a limit has no travel banked up to undo before it responds
+ * again in the other direction.
+ *
+ * The callbacks are held through [rememberUpdatedState] rather than keyed into
+ * [pointerInput]: they close over the row's live state, and a key that changed
+ * with them would tear down the gesture loop mid-pinch, while a stale copy would
+ * settle the zoom against whatever the row looked like when the switcher opened.
+ *
+ * @param onPinch    a frame's scale change, as a multiplier of the current scale.
+ * @param onPinchEnd every finger is up and the scale should settle onto a level.
+ * @return this modifier, with the watcher attached.
+ * @see SwitcherCardRow
+ */
+@Composable
+private fun Modifier.switcherPinch(
+    onPinch: (Float) -> Unit,
+    onPinchEnd: () -> Unit,
+): Modifier {
+    val pinch by rememberUpdatedState(onPinch)
+    val pinchEnd by rememberUpdatedState(onPinchEnd)
+    return pointerInput(Unit) {
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            var ratio = 1f
+            var pinching = false
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                if (event.changes.none { it.pressed }) break
+                if (event.changes.count { it.pressed } >= 2) {
+                    // Both helpers ignore a pointer that was not already down last
+                    // event, so the frame a second finger arrives reports no change
+                    // rather than a jump from a one-finger "distance" of zero.
+                    val step = event.calculateZoom()
+                    ratio *= step
+                    if (!pinching) {
+                        val span = event.calculateCentroidSize(useCurrent = false)
+                        if (span > 0f && abs(1f - ratio) * span > viewConfiguration.touchSlop) {
+                            pinching = true
+                        }
+                    } else if (step != 1f) {
+                        pinch(step)
+                    }
+                }
+                if (pinching) {
+                    event.changes.forEach { if (it.positionChanged()) it.consume() }
+                }
+            }
+            if (pinching) pinchEnd()
         }
     }
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -153,6 +153,15 @@ fun OverviewContent(
         onDispose { miniTerminals.close() }
     }
 
+    // Theme the headless thumbnail emulators: their default fg/bg/cursor slots
+    // are Termux stock until overridden (the full-screen terminal gets the same
+    // treatment via applyTerminalColors). Re-runs when the resolved theme
+    // changes so existing thumbnails repaint.
+    val thumbnailTheme = rememberTerminalPalette(client, "overview-thumbnails")
+    LaunchedEffect(miniTerminals, thumbnailTheme) {
+        miniTerminals.setDefaultColors(thumbnailTheme)
+    }
+
     // Rename / close dialog targets raised from a pane's context menu.
     var renameTarget by remember { mutableStateOf<LeafNode?>(null) }
     var closeTarget by remember { mutableStateOf<LeafNode?>(null) }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/OverviewScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -161,6 +162,14 @@ fun OverviewContent(
     LaunchedEffect(miniTerminals, thumbnailTheme) {
         miniTerminals.setDefaultColors(thumbnailTheme)
     }
+
+    // The single pane whose card anchors the dive transition (see
+    // DiveTransition.kt). Set at tap time, before navigation, so the shared
+    // bounds are registered when the flight starts; saveable so the restored
+    // overview re-attaches the same anchor for the reverse flight on pop.
+    // Keyed by leaf id, not session id: linked panes share a session, and two
+    // cards registering one shared-bounds key would clash.
+    var divePaneId by rememberSaveable { mutableStateOf<String?>(null) }
 
     // Rename / close dialog targets raised from a pane's context menu.
     var renameTarget by remember { mutableStateOf<LeafNode?>(null) }
@@ -247,7 +256,11 @@ fun OverviewContent(
                         tab = tab,
                         editing = editTabId == tab.id,
                         drag = drag?.takeIf { it.tabId == tab.id },
+                        divePaneId = divePaneId,
                         onOpenPane = { pane ->
+                            // Anchor the dive before navigating (openPane fires
+                            // synchronously; the focus round-trip stays async).
+                            divePaneId = pane.leaf.id
                             scope.launch { vm.focusPane(tab.id, pane.leaf.id) }
                             openPane(pane.leaf, onOpenTerminal, onOpenFileBrowser, onOpenGit)
                         },
@@ -350,6 +363,8 @@ private fun openPane(
  * @param tab              the tab to render.
  * @param editing          whether this tab is in edit-layout mode.
  * @param drag             the live drag iff it targets a pane in this tab.
+ * @param divePaneId       leaf id of the pane anchoring the dive transition
+ *   (the last-tapped card); only that card attaches [diveSharedBounds].
  * @param onOpenPane       focus + drill into a pane.
  * @param onToggleMaximize maximize/restore a pane.
  * @param onMinimize       dock a pane.
@@ -367,6 +382,7 @@ private fun ExposeCanvas(
     tab: OverviewTab,
     editing: Boolean,
     drag: Drag?,
+    divePaneId: String?,
     onOpenPane: (OverviewPane) -> Unit,
     onToggleMaximize: (OverviewPane) -> Unit,
     onMinimize: (OverviewPane) -> Unit,
@@ -411,7 +427,29 @@ private fun ExposeCanvas(
                                 .then(if (draggingThis) Modifier.zIndex(1f) else Modifier)
                                 .padding(3.dp),
                         ) {
-                            MiniPane(pane = pane, raised = draggingThis)
+                            // Only the tapped terminal-like pane carries the
+                            // shared-bounds anchor: unique key per flight, and
+                            // git/files panes navigate to non-terminal routes
+                            // where the other end never exists.
+                            val diveModifier =
+                                if (pane.leaf.id == divePaneId && leafKindOf(pane.leaf) == LeafKind.TERMINAL) {
+                                    Modifier.diveSharedBounds(diveKey(pane.leaf.sessionId))
+                                } else {
+                                    Modifier
+                                }
+                            // The anchor goes on the pane's CONTENT, not the whole
+                            // card: the other end of the flight is the terminal's
+                            // content box, and a card rect that also contains a
+                            // title bar and a border is a different rectangle. Fly
+                            // the whole card and the text lands a title-bar's height
+                            // off and a few percent small, which is exactly the jump
+                            // the transition looked broken for. The card's chrome
+                            // stays behind and fades with the route.
+                            MiniPane(
+                                pane = pane,
+                                raised = draggingThis,
+                                contentModifier = diveModifier,
+                            )
 
                             if (editing) {
                                 // Whole-pane move drag.
@@ -731,13 +769,21 @@ private fun leafKindOf(leaf: LeafNode): LeafKind = when (leaf.content) {
  * type-specific live miniature, and the focused/accent outline. Purely visual —
  * input is layered on by [ExposeCanvas].
  *
- * @param pane   the projected pane.
- * @param raised whether to lift the card (used for the pane being dragged).
+ * @param pane            the projected pane.
+ * @param raised          whether to lift the card (used for the pane being
+ *   dragged).
+ * @param modifier        outermost modifier on the card's root box.
+ * @param contentModifier modifier on the miniature *inside* the chrome —
+ *   [ExposeCanvas] attaches the dive transition's shared bounds here, because
+ *   the far end of that flight is the terminal's content box and only this box
+ *   is the same rectangle.
  */
 @Composable
 private fun MiniPane(
     pane: OverviewPane,
     raised: Boolean,
+    modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier,
 ) {
     val focused = pane.isFocused
     val borderColor = if (focused || raised) SidebarAccent else SidebarTextSecondary.copy(alpha = 0.35f)
@@ -745,7 +791,7 @@ private fun MiniPane(
     val shape = RoundedCornerShape(6.dp)
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .then(if (raised) Modifier.shadow(10.dp, shape) else Modifier)
             .clip(shape)
@@ -779,7 +825,7 @@ private fun MiniPane(
             }
             HorizontalDivider(thickness = 1.dp, color = SidebarBorder)
             Box(
-                modifier = Modifier
+                modifier = contentModifier
                     .weight(1f)
                     .fillMaxWidth()
                     .clipToBounds(),

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
@@ -81,38 +81,68 @@ internal const val DOCK_CHIP_GAP_DP = 6f
 internal const val DOCK_FALLOFF = 1f
 
 /**
- * Scratch for the dock's scaled-width walk, memoised on the focus it was computed
- * for.
+ * Scratch for the dock's scaled-width walk, memoised on the inputs it was computed
+ * from.
  *
  * Every slot's `graphicsLayer` needs the whole centres array, and within one frame
  * they all ask about the same focus, so the answer is computed once and handed out.
  * Not thread-safe and does not need to be: it is only ever touched from the draw
  * phase of one dock.
+ *
+ * The cache is keyed on the widths as well as the focus, and that is not
+ * belt-and-braces: the widths are zero until the strip has been placed, so the
+ * first draw of a freshly composed dock asks about a row of empty chips. Keyed on
+ * the focus alone, that answer stuck — every chip drawn at the dock's centre, in a
+ * heap, until the row was moved and the focus changed. Which is what starting the
+ * app, or coming back from a terminal, looks like.
  */
 private class DockWalk {
     private var focus = Float.NaN
+    private var gapPx = Float.NaN
+    private var widths = FloatArray(0)
     private var centres = FloatArray(0)
 
     /**
      * The visual centre of every slot when the row sits at [focus].
      *
-     * @param focus  the row's fractional card index.
-     * @param widths each slot's measured width, in px.
-     * @param gapPx  the gap to leave between slots, in px.
+     * @param focus      the row's fractional card index.
+     * @param slotWidths each slot's measured width, in px.
+     * @param gapPx      the gap to leave between slots, in px.
      * @return the centres, one per slot; the array is reused between calls and must
      *   not be retained.
      */
-    fun centresFor(focus: Float, widths: List<Float>, gapPx: Float): FloatArray {
-        if (focus == this.focus && centres.size == widths.size) return centres
-        if (centres.size != widths.size) centres = FloatArray(widths.size)
+    fun centresFor(focus: Float, slotWidths: List<Float>, gapPx: Float): FloatArray {
+        if (isCurrent(focus, slotWidths, gapPx)) return centres
+        if (widths.size != slotWidths.size) {
+            widths = FloatArray(slotWidths.size)
+            centres = FloatArray(slotWidths.size)
+        }
         var left = 0f
-        for (i in widths.indices) {
-            val scaled = widths[i] * dockChipScale(i, focus)
+        for (i in slotWidths.indices) {
+            val width = slotWidths[i]
+            widths[i] = width
+            val scaled = width * dockChipScale(i, focus)
             centres[i] = left + scaled / 2f
             left += scaled + gapPx
         }
         this.focus = focus
+        this.gapPx = gapPx
         return centres
+    }
+
+    /**
+     * Whether the cached centres were computed from exactly these inputs.
+     *
+     * @param focus      the row's fractional card index.
+     * @param slotWidths each slot's measured width, in px.
+     * @param gapPx      the gap between slots, in px.
+     * @return true when [centres] can be handed out as-is.
+     */
+    private fun isCurrent(focus: Float, slotWidths: List<Float>, gapPx: Float): Boolean {
+        if (focus != this.focus || gapPx != this.gapPx) return false
+        if (widths.size != slotWidths.size) return false
+        for (i in widths.indices) if (widths[i] != slotWidths[i]) return false
+        return true
     }
 }
 
@@ -239,15 +269,15 @@ fun TabDock(
         // a hole on each side, and since the titles differ in length a wide chip
         // left a bigger hole than a narrow one — the gaps came out uneven. Walking
         // the scaled widths instead keeps every visible gap equal to [gapPx].
-        // Memoised per focus value, not per chip: every slot's layer needs the whole
-        // array, and they all read the same focus within one frame, so the first to
-        // draw computes it and the rest reuse it. Recomputing per slot made dock
-        // layout O(slots²) with an allocation each, every frame of every fling.
+        // Memoised per (focus, widths), not per chip: every slot's layer needs the
+        // whole array, and they all read the same focus within one frame, so the
+        // first to draw computes it and the rest reuse it. Recomputing per slot made
+        // dock layout O(slots²) with an allocation each, every frame of every fling.
         val walk = remember(slotCount) { DockWalk() }
         val visualCentres: () -> FloatArray = {
             walk.centresFor(
                 focus = focusIndex(),
-                widths = slotWidths,
+                slotWidths = slotWidths,
                 gapPx = gapPx,
             )
         }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
@@ -81,6 +81,42 @@ internal const val DOCK_CHIP_GAP_DP = 6f
 internal const val DOCK_FALLOFF = 1f
 
 /**
+ * Scratch for the dock's scaled-width walk, memoised on the focus it was computed
+ * for.
+ *
+ * Every slot's `graphicsLayer` needs the whole centres array, and within one frame
+ * they all ask about the same focus, so the answer is computed once and handed out.
+ * Not thread-safe and does not need to be: it is only ever touched from the draw
+ * phase of one dock.
+ */
+private class DockWalk {
+    private var focus = Float.NaN
+    private var centres = FloatArray(0)
+
+    /**
+     * The visual centre of every slot when the row sits at [focus].
+     *
+     * @param focus  the row's fractional card index.
+     * @param widths each slot's measured width, in px.
+     * @param gapPx  the gap to leave between slots, in px.
+     * @return the centres, one per slot; the array is reused between calls and must
+     *   not be retained.
+     */
+    fun centresFor(focus: Float, widths: List<Float>, gapPx: Float): FloatArray {
+        if (focus == this.focus && centres.size == widths.size) return centres
+        if (centres.size != widths.size) centres = FloatArray(widths.size)
+        var left = 0f
+        for (i in widths.indices) {
+            val scaled = widths[i] * dockChipScale(i, focus)
+            centres[i] = left + scaled / 2f
+            left += scaled + gapPx
+        }
+        this.focus = focus
+        return centres
+    }
+}
+
+/**
  * How far out of focus the chip at [index] is when the row sits at [focus], as
  * 1 (fully focused) down to 0.
  *
@@ -167,19 +203,24 @@ fun TabDock(
     // The tab chip whose context menu is currently open (by tab id).
     var menuTabId by remember { mutableStateOf<String?>(null) }
 
-    // Each chip's measured width and the centre the Row placed it at, reported as
+    // Each slot's measured width and the centre the Row placed it at, reported as
     // they are placed. Both are needed because the chips are drawn somewhere else
     // than they are laid out: the widths drive the scaled-width walk that decides
     // where a chip *should* appear, and the layout centres say how far to slide it
     // from where it actually is.
-    val chipWidths = remember(tabs.size) { mutableStateListOf<Float>() }
-    val chipLayoutCentres = remember(tabs.size) { mutableStateListOf<Float>() }
-    if (chipWidths.size != tabs.size) {
-        chipWidths.clear()
-        chipLayoutCentres.clear()
-        repeat(tabs.size) {
-            chipWidths.add(0f)
-            chipLayoutCentres.add(0f)
+    // One slot per chip, plus a last one for the trailing `⋮`. The overflow menu
+    // has to travel with the strip like everything else: left at its raw layout
+    // position it sat past the dock's right edge, where clipToBounds erased it —
+    // and with it the only route back to a hidden tab.
+    val slotCount = tabs.size + 1
+    val slotWidths = remember(slotCount) { mutableStateListOf<Float>() }
+    val slotLayoutCentres = remember(slotCount) { mutableStateListOf<Float>() }
+    if (slotWidths.size != slotCount) {
+        slotWidths.clear()
+        slotLayoutCentres.clear()
+        repeat(slotCount) {
+            slotWidths.add(0f)
+            slotLayoutCentres.add(0f)
         }
     }
 
@@ -198,25 +239,56 @@ fun TabDock(
         // a hole on each side, and since the titles differ in length a wide chip
         // left a bigger hole than a narrow one — the gaps came out uneven. Walking
         // the scaled widths instead keeps every visible gap equal to [gapPx].
+        // Memoised per focus value, not per chip: every slot's layer needs the whole
+        // array, and they all read the same focus within one frame, so the first to
+        // draw computes it and the rest reuse it. Recomputing per slot made dock
+        // layout O(slots²) with an allocation each, every frame of every fling.
+        val walk = remember(slotCount) { DockWalk() }
         val visualCentres: () -> FloatArray = {
-            val focus = focusIndex()
-            val centres = FloatArray(tabs.size)
-            var left = 0f
-            for (i in tabs.indices) {
-                val scaled = chipWidths.getOrElse(i) { 0f } * dockChipScale(i, focus)
-                centres[i] = left + scaled / 2f
-                left += scaled + gapPx
-            }
-            centres
+            walk.centresFor(
+                focus = focusIndex(),
+                widths = slotWidths,
+                gapPx = gapPx,
+            )
         }
         // The point the dock centres on: one chip's visual centre, or a blend of
-        // two while the row is between cards.
+        // two while the row is between cards. Only the tab slots can be focused —
+        // the `⋮` is chrome that rides along at the end.
         val focusCentre: (FloatArray) -> Float = { centres ->
             val position = focusIndex().coerceIn(0f, (tabs.size - 1).toFloat())
             val low = floor(position).toInt().coerceIn(0, tabs.size - 1)
             val high = (low + 1).coerceAtMost(tabs.size - 1)
             val fraction = position - low
             centres[low] * (1f - fraction) + centres[high] * fraction
+        }
+        // What every slot does with that: report where it was placed, then slide
+        // from there to where the walk says it belongs, scaled and dimmed by how far
+        // out of focus it is.
+        val slotModifier: (Int) -> Modifier = { index ->
+            Modifier
+                .onPlaced { coords ->
+                    val width = coords.size.width.toFloat()
+                    val centre = coords.positionInParent().x + width / 2f
+                    if (index < slotWidths.size) {
+                        if (slotWidths[index] != width) slotWidths[index] = width
+                        if (slotLayoutCentres[index] != centre) {
+                            slotLayoutCentres[index] = centre
+                        }
+                    }
+                }
+                .graphicsLayer {
+                    val focus = focusIndex()
+                    val scale = dockChipScale(index, focus)
+                    scaleX = scale
+                    scaleY = scale
+                    alpha = DOCK_SIBLING_ALPHA +
+                        (1f - DOCK_SIBLING_ALPHA) * dockChipEmphasis(index, focus)
+                    val centres = visualCentres()
+                    if (index < centres.size && index < slotLayoutCentres.size) {
+                        translationX = dockCentre - focusCentre(centres) + centres[index] -
+                            slotLayoutCentres[index]
+                    }
+                }
         }
 
     Row(
@@ -234,35 +306,7 @@ fun TabDock(
             // sits — smaller, dimmer, drawn in towards the focus. Nothing here
             // animates on its own; the motion *is* the row's, which is why it can
             // neither lag the drag nor fight the settle.
-            Box(
-                Modifier
-                    .onPlaced { coords ->
-                        val width = coords.size.width.toFloat()
-                        val centre = coords.positionInParent().x + width / 2f
-                        if (index < chipWidths.size) {
-                            if (chipWidths[index] != width) chipWidths[index] = width
-                            if (chipLayoutCentres[index] != centre) {
-                                chipLayoutCentres[index] = centre
-                            }
-                        }
-                    }
-                    .graphicsLayer {
-                        val focus = focusIndex()
-                        val scale = dockChipScale(index, focus)
-                        scaleX = scale
-                        scaleY = scale
-                        val siblingAlpha = DOCK_SIBLING_ALPHA
-                        alpha = siblingAlpha + (1f - siblingAlpha) * dockChipEmphasis(index, focus)
-                        // Slide from where the Row placed this chip to where the
-                        // scaled-width walk says it belongs, with the focus point
-                        // parked in the dock's middle.
-                        val centres = visualCentres()
-                        if (index < centres.size && index < chipLayoutCentres.size) {
-                            translationX = dockCentre - focusCentre(centres) + centres[index] -
-                                chipLayoutCentres[index]
-                        }
-                    },
-            ) {
+            Box(slotModifier(index)) {
                 CompositionLocalProvider(
                     LocalMinimumInteractiveComponentSize provides 0.dp,
                 ) {
@@ -334,7 +378,9 @@ fun TabDock(
         // OverviewBackingViewModel.project). Mirrors the web/Mac far-right
         // overflow menu. Only rendered when some tabs are unlisted.
         if (unlistedTabs.isNotEmpty()) {
-            UnlistedTabsMenu(unlistedTabs = unlistedTabs, onSelect = onActivateUnlisted)
+            Box(slotModifier(tabs.size)) {
+                UnlistedTabsMenu(unlistedTabs = unlistedTabs, onSelect = onActivateUnlisted)
+            }
         }
     }
     }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TabDock.kt
@@ -1,0 +1,341 @@
+/**
+ * Bottom tab dock for the switcher-style overview.
+ *
+ * The overview renders tabs as an app-switcher card row ([SwitcherCardRow] in
+ * OverviewScreen.kt); this dock is the analog of the OS switcher's app-icon
+ * row beneath the cards: one compact labelled chip per tab, so every tab stays
+ * visible and directly reachable no matter where the card row is flung.
+ *
+ * Semantics mirror the row's browse-vs-commit split:
+ *  - tapping a **non-centered** chip only centers that tab's card (no server
+ *    command);
+ *  - tapping the **centered** chip dives into that tab's focused pane — the
+ *    same commit a tap on the centered card performs;
+ *  - long-pressing a chip opens the tab context menu (rename / listing
+ *    toggles / close), unchanged from the old tab strip;
+ *  - a trailing `⋮` lists unlisted (hidden) tabs, selecting one activates it
+ *    server-side so it surfaces in the row.
+ *
+ * This replaces the former top `OverviewTabStrip`; the strip's context menu
+ * and unlisted-tabs menu composables are reused as-is (now internal in
+ * OverviewScreen.kt).
+ *
+ * @see OverviewContent
+ * @see TabContextMenu
+ * @see UnlistedTabsMenu
+ */
+package se.soderbjorn.lunamux.android.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.floor
+import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.OverviewTab
+import se.soderbjorn.lunamux.client.viewmodel.OverviewBackingViewModel.UnlistedTab
+
+/** Scale of a chip a full card away from the focus. */
+internal const val DOCK_SIBLING_SCALE = 0.78f
+
+/** Opacity of a chip a full card away from the focus. */
+internal const val DOCK_SIBLING_ALPHA = 0.50f
+
+/** Gap between chips, in dp. Uniform whatever their scale — see [TabDock]. */
+internal const val DOCK_CHIP_GAP_DP = 6f
+
+/**
+ * How quickly focus falls off with distance, per card. 1 hands the emphasis over
+ * completely across one card's worth of row movement.
+ */
+internal const val DOCK_FALLOFF = 1f
+
+/**
+ * How far out of focus the chip at [index] is when the row sits at [focus], as
+ * 1 (fully focused) down to 0.
+ *
+ * @param index the chip's index.
+ * @param focus the row's fractional card index.
+ * @return the emphasis, 0..1.
+ */
+private fun dockChipEmphasis(index: Int, focus: Float): Float =
+    (1f - abs(index - focus) * DOCK_FALLOFF).coerceIn(0f, 1f)
+
+/**
+ * The scale the chip at [index] is drawn at when the row sits at [focus]: full
+ * size at the focus, [DOCK_SIBLING_SCALE] a card away.
+ *
+ * Also what the strip's layout is computed from, so the two can never disagree.
+ *
+ * @param index the chip's index.
+ * @param focus the row's fractional card index.
+ * @return the scale factor.
+ */
+private fun dockChipScale(index: Int, focus: Float): Float {
+    val sibling = DOCK_SIBLING_SCALE
+    return sibling + (1f - sibling) * dockChipEmphasis(index, focus)
+}
+
+/**
+ * The switcher's bottom tab dock: one chip per tab (status dot + title), the
+ * focused tab at the front, with the tab context menu on long-press and the
+ * unlisted-tabs `⋮` at the end.
+ *
+ * The strip is not a scroller. It follows the card row's *continuous* position:
+ * the chip under the visible card sits in the middle of the dock, and while a
+ * drag or fling is in flight the whole strip slides with it, the focus handing
+ * over between two chips fractionally rather than jumping when the centred card
+ * changes. That is what the OS switcher does, and it is why this is a plain [Row]
+ * translated at draw time rather than a lazy row being animate-scrolled: one
+ * scroll animation per centred-card change was both the snappiness and the
+ * stutter a multi-card fling showed.
+ *
+ * Composed by [OverviewContent] below the card row (hidden while editing a
+ * layout, whose gestures own the screen).
+ *
+ * @param tabs           the visible tabs, in row order.
+ * @param unlistedTabs   hidden tabs not in [tabs]; surfaced via the trailing
+ *   `⋮` menu so they can be re-activated. Empty hides the menu.
+ * @param focusIndex     the card row's position as a *fractional* tab index, read
+ *   at draw time so following it costs no recomposition. 1.4 means "40% of the way
+ *   from tab 1 to tab 2".
+ * @param centeredIndex  index of the card-row's centered tab; its chip's tap
+ *   dives instead of centering.
+ * @param closeEnabled   whether "Close tab" is offered (false for the last tab).
+ * @param onCenter       center the card at the given index (no server command).
+ * @param onDive         dive into the given tab's focused pane (commits the tab).
+ * @param onActivateUnlisted activate an unlisted tab by id (server round-trip;
+ *   the tab then surfaces in the row).
+ * @param onRename       open the rename dialog for the long-pressed tab.
+ * @param onToggleHidden flip the long-pressed tab's hidden-from-tab-strip
+ *   ("unlisted") flag.
+ * @param onToggleSidebarHidden flip the long-pressed tab's hidden-from-sidebar
+ *   flag (also hides it from the sessions list, which mirrors the sidebar).
+ * @param onClose        confirm + close the long-pressed tab.
+ * @param modifier       layout modifier from [OverviewContent], which spaces the
+ *   dock evenly between the cards above it and the screen's bottom edge.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun TabDock(
+    tabs: List<OverviewTab>,
+    unlistedTabs: List<UnlistedTab>,
+    focusIndex: () -> Float,
+    centeredIndex: Int,
+    closeEnabled: Boolean,
+    onCenter: (Int) -> Unit,
+    onDive: (OverviewTab) -> Unit,
+    onActivateUnlisted: (String) -> Unit,
+    onRename: (OverviewTab) -> Unit,
+    onToggleHidden: (OverviewTab) -> Unit,
+    onToggleSidebarHidden: (OverviewTab) -> Unit,
+    onClose: (OverviewTab) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (tabs.isEmpty()) return
+
+    // The tab chip whose context menu is currently open (by tab id).
+    var menuTabId by remember { mutableStateOf<String?>(null) }
+
+    // Each chip's measured width and the centre the Row placed it at, reported as
+    // they are placed. Both are needed because the chips are drawn somewhere else
+    // than they are laid out: the widths drive the scaled-width walk that decides
+    // where a chip *should* appear, and the layout centres say how far to slide it
+    // from where it actually is.
+    val chipWidths = remember(tabs.size) { mutableStateListOf<Float>() }
+    val chipLayoutCentres = remember(tabs.size) { mutableStateListOf<Float>() }
+    if (chipWidths.size != tabs.size) {
+        chipWidths.clear()
+        chipLayoutCentres.clear()
+        repeat(tabs.size) {
+            chipWidths.add(0f)
+            chipLayoutCentres.add(0f)
+        }
+    }
+
+    BoxWithConstraints(
+        modifier
+            .fillMaxWidth()
+            .background(SidebarBackground)
+            .clipToBounds(),
+    ) {
+        val density = LocalDensity.current
+        val dockCentre = with(density) { maxWidth.toPx() } / 2f
+        val gapPx = with(density) { DOCK_CHIP_GAP_DP.dp.toPx() }
+        // Where every chip should *appear*, given that the out-of-focus ones are
+        // drawn smaller. Laying the strip out from scaled widths is the whole
+        // point: a chip shrunk about its own centre leaves half its lost width as
+        // a hole on each side, and since the titles differ in length a wide chip
+        // left a bigger hole than a narrow one — the gaps came out uneven. Walking
+        // the scaled widths instead keeps every visible gap equal to [gapPx].
+        val visualCentres: () -> FloatArray = {
+            val focus = focusIndex()
+            val centres = FloatArray(tabs.size)
+            var left = 0f
+            for (i in tabs.indices) {
+                val scaled = chipWidths.getOrElse(i) { 0f } * dockChipScale(i, focus)
+                centres[i] = left + scaled / 2f
+                left += scaled + gapPx
+            }
+            centres
+        }
+        // The point the dock centres on: one chip's visual centre, or a blend of
+        // two while the row is between cards.
+        val focusCentre: (FloatArray) -> Float = { centres ->
+            val position = focusIndex().coerceIn(0f, (tabs.size - 1).toFloat())
+            val low = floor(position).toInt().coerceIn(0, tabs.size - 1)
+            val high = (low + 1).coerceAtMost(tabs.size - 1)
+            val fraction = position - low
+            centres[low] * (1f - fraction) + centres[high] * fraction
+        }
+
+    Row(
+        modifier = Modifier
+            .wrapContentWidth(align = Alignment.Start, unbounded = true)
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(DOCK_CHIP_GAP_DP.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        tabs.forEachIndexed { index, tab ->
+            val centered = index == centeredIndex
+            // Depth, computed entirely at draw time from the row's fractional
+            // position: the chip the row is on stands at the front, full size and
+            // brightness, and the further a chip is from it the further back it
+            // sits — smaller, dimmer, drawn in towards the focus. Nothing here
+            // animates on its own; the motion *is* the row's, which is why it can
+            // neither lag the drag nor fight the settle.
+            Box(
+                Modifier
+                    .onPlaced { coords ->
+                        val width = coords.size.width.toFloat()
+                        val centre = coords.positionInParent().x + width / 2f
+                        if (index < chipWidths.size) {
+                            if (chipWidths[index] != width) chipWidths[index] = width
+                            if (chipLayoutCentres[index] != centre) {
+                                chipLayoutCentres[index] = centre
+                            }
+                        }
+                    }
+                    .graphicsLayer {
+                        val focus = focusIndex()
+                        val scale = dockChipScale(index, focus)
+                        scaleX = scale
+                        scaleY = scale
+                        val siblingAlpha = DOCK_SIBLING_ALPHA
+                        alpha = siblingAlpha + (1f - siblingAlpha) * dockChipEmphasis(index, focus)
+                        // Slide from where the Row placed this chip to where the
+                        // scaled-width walk says it belongs, with the focus point
+                        // parked in the dock's middle.
+                        val centres = visualCentres()
+                        if (index < centres.size && index < chipLayoutCentres.size) {
+                            translationX = dockCentre - focusCentre(centres) + centres[index] -
+                                chipLayoutCentres[index]
+                        }
+                    },
+            ) {
+                CompositionLocalProvider(
+                    LocalMinimumInteractiveComponentSize provides 0.dp,
+                ) {
+                    FilterChip(
+                        selected = centered,
+                        onClick = {},
+                        label = {
+                            Text(
+                                tab.title,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.widthIn(max = 120.dp),
+                            )
+                        },
+                        leadingIcon = { StatusDot(state = tab.aggregateState, boxDp = 12) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = SidebarBackground,
+                            // The server-active tab's label carries the accent even
+                            // when the row is browsing elsewhere — the only cue left
+                            // for it once the cards stopped ringing themselves in
+                            // accent, and distinct from the centred chip's filled
+                            // container + accent border.
+                            labelColor = if (tab.isActive) {
+                                SidebarAccent
+                            } else {
+                                SidebarTextSecondary
+                            },
+                            selectedContainerColor = SidebarAccent.copy(alpha = 0.18f),
+                            selectedLabelColor = SidebarAccent,
+                        ),
+                        border = FilterChipDefaults.filterChipBorder(
+                            enabled = true,
+                            selected = centered,
+                            borderColor = SidebarTextSecondary.copy(alpha = 0.4f),
+                            selectedBorderColor = SidebarAccent,
+                            borderWidth = 1.dp,
+                            selectedBorderWidth = 2.dp,
+                        ),
+                    )
+                }
+                // Transparent overlay that catches the tap and the long-press,
+                // sitting above the chip so its own click never fires. Tap on
+                // the centered chip commits (dive); on any other it centers.
+                Box(
+                    Modifier
+                        .matchParentSize()
+                        .clip(RoundedCornerShape(8.dp))
+                        .combinedClickable(
+                            onClick = { if (centered) onDive(tab) else onCenter(index) },
+                            onLongClick = { menuTabId = tab.id },
+                        ),
+                )
+                TabContextMenu(
+                    expanded = menuTabId == tab.id,
+                    isHidden = tab.isHidden,
+                    isHiddenFromSidebar = tab.isHiddenFromSidebar,
+                    closeEnabled = closeEnabled,
+                    onDismiss = { menuTabId = null },
+                    onRename = { menuTabId = null; onRename(tab) },
+                    onToggleHidden = { menuTabId = null; onToggleHidden(tab) },
+                    onToggleSidebarHidden = { menuTabId = null; onToggleSidebarHidden(tab) },
+                    onClose = { menuTabId = null; onClose(tab) },
+                )
+            }
+        }
+
+        // Trailing `⋮` menu listing the unlisted (hidden) tabs. Tapping a row
+        // activates that tab — it then surfaces temporarily in the dock (see
+        // OverviewBackingViewModel.project). Mirrors the web/Mac far-right
+        // overflow menu. Only rendered when some tabs are unlisted.
+        if (unlistedTabs.isNotEmpty()) {
+            UnlistedTabsMenu(unlistedTabs = unlistedTabs, onSelect = onActivateUnlisted)
+        }
+    }
+    }
+}

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFont.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFont.kt
@@ -1,7 +1,7 @@
 /**
  * The face terminal content is drawn with, shared by every view that shows PTY output:
  * the full-screen Termux [com.termux.view.TerminalView] in [TerminalScreen] and the
- * [MiniTerminalPane] miniatures in the overview/tiled grid.
+ * [TerminalThumbnail] miniatures in the overview/tiled grid.
  *
  * It lives in one place because the font is not just a look: it carries the per-glyph
  * fallback chain that keeps terminal symbols out of the colour emoji font (issue #141).
@@ -65,7 +65,7 @@ object TerminalFont {
      * rebuild the collection on every recomposition.
      *
      * Called by the [com.termux.view.TerminalView] factory in [TerminalScreen] and by
-     * [MiniTerminalPane].
+     * [TerminalThumbnail].
      *
      * @param context supplies the [android.content.res.AssetManager] the fonts are read from;
      *   only the application context is retained.

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFrame.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFrame.kt
@@ -1,0 +1,312 @@
+/**
+ * Immutable, style-resolved snapshot of a live terminal screen, plus the
+ * extraction that produces one from a headless Termux emulator.
+ *
+ * A [TerminalFrame] is what a terminal thumbnail draws: the current screen
+ * buffer (never scrollback) as rows of same-style runs whose colors are
+ * already resolved to ARGB — palette lookups, bright-bold, inverse video and
+ * dim are applied here, at snapshot time, so the renderer is a dumb painter.
+ * Snapshots are deep-immutable and safe to hand across threads; the mutable
+ * emulator is only touched inside [snapshotFrame], which the caller must run
+ * on the emulator's own dispatcher under its lock (see [MiniTerminalRegistry]).
+ *
+ * The run extraction follows the server's `GridSerializer.rowRuns` rules
+ * (split when the packed style long changes, keep surrogates/combining marks/
+ * wide glyphs intact, trim trailing default-styled blanks) but not its code:
+ * the server asks `findStartOfColumn` per cell, which restarts from column 0
+ * on every call, while this walk carries a running char index — a snapshot
+ * runs at up to 10 fps per visible session here, so the per-row cost has to be
+ * linear. The color resolution is a port of the vendored
+ * `TerminalRenderer.drawTextRun` (terminal-view) including DECSCNM reverse
+ * video — ported rather than referenced because that code is welded to its
+ * Canvas pass and vendored files stay unmodified.
+ *
+ * @see MiniTerminalRegistry
+ * @see TerminalThumbnail
+ */
+package se.soderbjorn.lunamux.android.ui
+
+import com.termux.terminal.TerminalEmulator
+import com.termux.terminal.TerminalRow
+import com.termux.terminal.TextStyle
+import com.termux.terminal.WcWidth
+
+/**
+ * A run of consecutive same-style cells within one screen row.
+ *
+ * Produced by [snapshotFrame]; drawn by [TerminalThumbnail]. Colors are fully
+ * resolved ARGB — no palette indices survive past extraction.
+ *
+ * @property startCol  0-based grid column the run starts at (background rects
+ *   and text are both anchored here, so grid alignment survives any glyph
+ *   advance drift inside the run).
+ * @property widthCols number of grid cells the run covers (wide glyphs count
+ *   their real cell width).
+ * @property text      the run's characters; empty for an SGR-invisible run,
+ *   whose background still paints.
+ * @property fg        resolved ARGB foreground (bright-bold, inverse and dim
+ *   already applied).
+ * @property bg        resolved ARGB background (inverse already applied).
+ * @property bold          whether to draw with fake-bold.
+ * @property underline     whether to underline.
+ * @property italic        whether to skew the glyphs (SGR 3).
+ * @property strikethrough whether to strike the glyphs through (SGR 9).
+ */
+data class ThumbRun(
+    val startCol: Int,
+    val widthCols: Int,
+    val text: String,
+    val fg: Int,
+    val bg: Int,
+    val bold: Boolean,
+    val underline: Boolean,
+    val italic: Boolean,
+    val strikethrough: Boolean,
+)
+
+/**
+ * One immutable snapshot of a live terminal screen (current buffer only — for
+ * an alt-screen TUI this is the alt screen, which is exactly what the session
+ * looks like).
+ *
+ * @property cols        the grid width the frame was captured at (the server's
+ *   authoritative PTY width — a thumbnail never votes its own).
+ * @property rows        the grid height the frame was captured at.
+ * @property defaultBg   resolved ARGB default background; fills the letterbox
+ *   and every cell no run covers (the default *foreground* when the session
+ *   has DECSCNM reverse video on, mirroring the real renderer's canvas fill).
+ * @property lines       exactly [rows] entries; each row's runs are ordered by
+ *   [ThumbRun.startCol] with trailing default-styled blanks trimmed (an empty
+ *   list is a blank row).
+ * @property cursorRow   cursor row, or -1 when the cursor is hidden (DECTCEM).
+ * @property cursorCol   cursor column (meaningless when [cursorRow] is -1).
+ * @property cursorColor resolved ARGB cursor color.
+ * @property revision    monotonic per-session counter; makes [equals] cheap for
+ *   StateFlow conflation and stamps frames for debugging.
+ */
+data class TerminalFrame(
+    val cols: Int,
+    val rows: Int,
+    val defaultBg: Int,
+    val lines: List<List<ThumbRun>>,
+    val cursorRow: Int,
+    val cursorCol: Int,
+    val cursorColor: Int,
+    val revision: Long,
+) {
+    /**
+     * Cheap equality via [revision]: two frames published by one session's
+     * publisher never share a revision, so identity of stamp implies identity
+     * of content — which is what the frame [kotlinx.coroutines.flow.StateFlow]
+     * conflates on.
+     *
+     * Valid only *within* one publisher's stream. Revisions restart at 0 for a
+     * rebuilt registry entry and two sessions number theirs independently, so
+     * never compare frames across sessions or registry generations (no such
+     * comparison exists today — see [MiniTerminalRegistry.frameFor], which
+     * hands every generation its own flow).
+     *
+     * @param other the value to compare against.
+     * @return true when [other] is a frame with the same revision and grid size.
+     */
+    override fun equals(other: Any?): Boolean =
+        other is TerminalFrame && other.revision == revision && other.cols == cols && other.rows == rows
+
+    /**
+     * Hash consistent with [equals] — the revision alone, for the same reason.
+     *
+     * @return the revision's hash.
+     */
+    override fun hashCode(): Int = revision.hashCode()
+}
+
+/**
+ * Snapshot [emulator]'s current screen into an immutable [TerminalFrame].
+ *
+ * MUST be called on the emulator's single-thread dispatcher while holding the
+ * emulator lock — it reads live rows that the PTY event collector mutates.
+ * Called only by [MiniTerminalRegistry]'s per-entry publisher.
+ *
+ * @param emulator the headless, externally-fed emulator to read.
+ * @param revision monotonic stamp for the produced frame.
+ * @return the resolved snapshot; rows out of bounds degrade to blank rather
+ *   than throwing (a read-only observer must never take the preview down).
+ */
+internal fun snapshotFrame(emulator: TerminalEmulator, revision: Long): TerminalFrame {
+    val palette = emulator.mColors.mCurrentColors
+    // DECSCNM (`ESC [ ?5h`, replayed by the server's attach epilogue) is a
+    // whole-screen fg/bg swap. The vendored renderer applies it by filling the
+    // canvas with the default *foreground* and flipping every run's inverse
+    // bit (TerminalRenderer.drawText/drawTextRun); the snapshot does the same,
+    // or a reverse-video session thumbnails as its own negative.
+    val reverseVideo = emulator.isReverseVideo
+    val defaultBg =
+        palette[if (reverseVideo) TextStyle.COLOR_INDEX_FOREGROUND else TextStyle.COLOR_INDEX_BACKGROUND]
+    val rows = emulator.mRows
+    val cols = emulator.mColumns
+    val screen = emulator.screen
+    val lines = ArrayList<List<ThumbRun>>(rows)
+    for (y in 0 until rows) {
+        val row = runCatching { screen.getRow(y) }.getOrNull()
+        lines.add(if (row == null) emptyList() else rowRuns(row, cols, palette, reverseVideo))
+    }
+    val cursorVisible = emulator.shouldCursorBeVisible()
+    return TerminalFrame(
+        cols = cols,
+        rows = rows,
+        defaultBg = defaultBg,
+        lines = lines,
+        cursorRow = if (cursorVisible) emulator.cursorRow else -1,
+        cursorCol = emulator.cursorCol,
+        cursorColor = palette[TextStyle.COLOR_INDEX_CURSOR],
+        revision = revision,
+    )
+}
+
+/**
+ * Convert one screen row into resolved [ThumbRun]s in a single left-to-right
+ * pass: split when the packed style changes, and emit each run only up to its
+ * last content cell so trailing default-styled blanks (padding) are dropped. A
+ * styled trailing space — a colored status bar, say — is content: a
+ * non-default style makes every cell in the run count.
+ *
+ * The walk carries a running char index instead of calling
+ * `TerminalRow.findStartOfColumn` per cell. That lookup restarts from column 0
+ * on every call, which made a row O(cols²) — millions of codepoint-width steps
+ * per second across the overview at 10 fps and 200+ server columns, all while
+ * holding the emulator lock the PTY collector needs. The vendored
+ * `TerminalRenderer`'s own row loop keeps the same running index.
+ *
+ * @param row          the live row to read.
+ * @param cols         the emulator's width, clamped to what the row actually has
+ *   (a mid-reflow row can be narrower; degrade to a short row, never throw).
+ * @param palette      the emulator's current 256+3 color table.
+ * @param reverseVideo whether DECSCNM is set, flipping every run's inverse bit.
+ * @return the row's runs, empty for a blank row.
+ */
+private fun rowRuns(row: TerminalRow, cols: Int, palette: IntArray, reverseVideo: Boolean): List<ThumbRun> {
+    val width = minOf(cols, row.columnCount)
+    if (width <= 0) return emptyList()
+    val text = row.mText
+    val charLimit = row.spaceUsed
+    val runs = ArrayList<ThumbRun>()
+    val sb = StringBuilder()
+    var runStyle = row.getStyle(0)
+    var runIsDefaultStyle = isDefaultStyle(runStyle)
+    var runStartCol = 0
+    // The current run's last content cell: its exclusive end column and the
+    // matching prefix length of [sb]. Both stay 0 for an all-blank run, which
+    // is then never emitted.
+    var contentEndCol = 0
+    var contentLen = 0
+    var col = 0
+    var charIndex = 0
+    while (col < width && charIndex < charLimit) {
+        val style = row.getStyle(col)
+        if (style != runStyle) {
+            if (contentLen > 0) {
+                runs.add(resolveRun(runStartCol, contentEndCol - runStartCol, sb.substring(0, contentLen), runStyle, palette, reverseVideo))
+            }
+            sb.setLength(0)
+            contentLen = 0
+            contentEndCol = 0
+            runStartCol = col
+            runStyle = style
+            runIsDefaultStyle = isDefaultStyle(style)
+        }
+        // One cell: its code point plus the zero-width combining marks that
+        // follow it, so surrogate pairs and marks stay welded to their glyph
+        // (and a mark is never read as the next cell's content).
+        val cellStart = charIndex
+        val first = text[charIndex]
+        val isHighSurrogate = Character.isHighSurrogate(first)
+        val cp = if (isHighSurrogate) Character.toCodePoint(first, text[charIndex + 1]) else first.code
+        charIndex += if (isHighSurrogate) 2 else 1
+        while (charIndex < charLimit && WcWidth.width(text, charIndex) <= 0) {
+            charIndex += if (Character.isHighSurrogate(text[charIndex])) 2 else 1
+        }
+        var w = WcWidth.width(cp)
+        if (w < 1) w = 1
+        sb.append(text, cellStart, charIndex - cellStart)
+        col += w
+        if (cp != ' '.code || !runIsDefaultStyle) {
+            contentEndCol = col
+            contentLen = sb.length
+        }
+    }
+    if (contentLen > 0) {
+        runs.add(resolveRun(runStartCol, contentEndCol - runStartCol, sb.substring(0, contentLen), runStyle, palette, reverseVideo))
+    }
+    return runs
+}
+
+/**
+ * Resolve one run's packed style long into a [ThumbRun] with final ARGB
+ * colors. Port of the color pipeline in `TerminalRenderer.drawTextRun`
+ * (terminal-view): indexed → palette with bright-bold promotion, inverse
+ * fg/bg swap (SGR 7 xor DECSCNM, as the renderer's `reverseVideoHere`), xterm
+ * dim (×2/3 RGB), invisible → empty text, and the bold/underline/italic/
+ * strikethrough flags the painter applies verbatim.
+ *
+ * @param startCol     grid column the run starts at.
+ * @param widthCols    grid cells the run covers.
+ * @param text         the run's characters.
+ * @param style        the packed Termux style long shared by every cell in the run.
+ * @param palette      the emulator's current color table.
+ * @param reverseVideo whether DECSCNM is set, flipping the run's inverse bit.
+ * @return the resolved run.
+ */
+private fun resolveRun(
+    startCol: Int,
+    widthCols: Int,
+    text: String,
+    style: Long,
+    palette: IntArray,
+    reverseVideo: Boolean,
+): ThumbRun {
+    var fg = TextStyle.decodeForeColor(style)
+    var bg = TextStyle.decodeBackColor(style)
+    val effect = TextStyle.decodeEffect(style)
+    val bold = (effect and (TextStyle.CHARACTER_ATTRIBUTE_BOLD or TextStyle.CHARACTER_ATTRIBUTE_BLINK)) != 0
+    val underline = (effect and TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE) != 0
+    val italic = (effect and TextStyle.CHARACTER_ATTRIBUTE_ITALIC) != 0
+    val strikethrough = (effect and TextStyle.CHARACTER_ATTRIBUTE_STRIKETHROUGH) != 0
+    val invisible = (effect and TextStyle.CHARACTER_ATTRIBUTE_INVISIBLE) != 0
+    if ((fg and -0x1000000) != -0x1000000) {
+        // Indexed color; bold promotes the first 8 to their bright variants.
+        if (bold && fg in 0..7) fg += 8
+        fg = palette[fg]
+    }
+    if ((bg and -0x1000000) != -0x1000000) {
+        bg = palette[bg]
+    }
+    if (((effect and TextStyle.CHARACTER_ATTRIBUTE_INVERSE) != 0) xor reverseVideo) {
+        val tmp = fg
+        fg = bg
+        bg = tmp
+    }
+    if ((effect and TextStyle.CHARACTER_ATTRIBUTE_DIM) != 0) {
+        // xterm/libvte dim: scale each channel to 2/3.
+        val red = (fg shr 16 and 0xFF) * 2 / 3
+        val green = (fg shr 8 and 0xFF) * 2 / 3
+        val blue = (fg and 0xFF) * 2 / 3
+        fg = -0x1000000 + (red shl 16) + (green shl 8) + blue
+    }
+    return ThumbRun(
+        startCol = startCol,
+        widthCols = widthCols,
+        text = if (invisible) "" else text,
+        fg = fg,
+        bg = bg,
+        bold = bold,
+        underline = underline,
+        italic = italic,
+        strikethrough = strikethrough,
+    )
+}
+
+/** Whether [style] is the default style (default fg/bg indices, no effects). */
+private fun isDefaultStyle(style: Long): Boolean =
+    TextStyle.decodeForeColor(style) == TextStyle.COLOR_INDEX_FOREGROUND &&
+        TextStyle.decodeBackColor(style) == TextStyle.COLOR_INDEX_BACKGROUND &&
+        TextStyle.decodeEffect(style) == 0

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFrame.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalFrame.kt
@@ -133,6 +133,15 @@ data class TerminalFrame(
  *   than throwing (a read-only observer must never take the preview down).
  */
 internal fun snapshotFrame(emulator: TerminalEmulator, revision: Long): TerminalFrame {
+    // One builder for the whole frame: [rowRuns] used to allocate its own, so a
+    // 50-row grid threw away 50 of them per snapshot, ten times a second, per
+    // visible session. What remains is a ThumbRun and a String per style run — the
+    // bulk of the churn, and not removable without changing the DTO to carry a
+    // shared CharArray plus offsets (and the painter to Canvas.drawText(char[],…)),
+    // or dropping the neighbours' publish rate below the centred card's. Measure
+    // before doing either; the allocations are off the main thread and ART absorbs
+    // short-lived garbage cheaply.
+    val text = StringBuilder()
     val palette = emulator.mColors.mCurrentColors
     // DECSCNM (`ESC [ ?5h`, replayed by the server's attach epilogue) is a
     // whole-screen fg/bg swap. The vendored renderer applies it by filling the
@@ -148,7 +157,7 @@ internal fun snapshotFrame(emulator: TerminalEmulator, revision: Long): Terminal
     val lines = ArrayList<List<ThumbRun>>(rows)
     for (y in 0 until rows) {
         val row = runCatching { screen.getRow(y) }.getOrNull()
-        lines.add(if (row == null) emptyList() else rowRuns(row, cols, palette, reverseVideo))
+        lines.add(if (row == null) emptyList() else rowRuns(row, cols, palette, reverseVideo, text))
     }
     val cursorVisible = emulator.shouldCursorBeVisible()
     return TerminalFrame(
@@ -182,15 +191,22 @@ internal fun snapshotFrame(emulator: TerminalEmulator, revision: Long): Terminal
  *   (a mid-reflow row can be narrower; degrade to a short row, never throw).
  * @param palette      the emulator's current 256+3 color table.
  * @param reverseVideo whether DECSCNM is set, flipping every run's inverse bit.
+ * @param sb           scratch builder owned by [snapshotFrame], reset per row.
  * @return the row's runs, empty for a blank row.
  */
-private fun rowRuns(row: TerminalRow, cols: Int, palette: IntArray, reverseVideo: Boolean): List<ThumbRun> {
+private fun rowRuns(
+    row: TerminalRow,
+    cols: Int,
+    palette: IntArray,
+    reverseVideo: Boolean,
+    sb: StringBuilder,
+): List<ThumbRun> {
     val width = minOf(cols, row.columnCount)
     if (width <= 0) return emptyList()
     val text = row.mText
     val charLimit = row.spaceUsed
     val runs = ArrayList<ThumbRun>()
-    val sb = StringBuilder()
+    sb.setLength(0)
     var runStyle = row.getStyle(0)
     var runIsDefaultStyle = isDefaultStyle(runStyle)
     var runStartCol = 0
@@ -219,7 +235,9 @@ private fun rowRuns(row: TerminalRow, cols: Int, palette: IntArray, reverseVideo
         // (and a mark is never read as the next cell's content).
         val cellStart = charIndex
         val first = text[charIndex]
-        val isHighSurrogate = Character.isHighSurrogate(first)
+        // A high surrogate whose partner is past the row's used length would index
+        // out of bounds; treat the half on its own, which is what it renders as.
+        val isHighSurrogate = Character.isHighSurrogate(first) && charIndex + 1 < charLimit
         val cp = if (isHighSurrogate) Character.toCodePoint(first, text[charIndex + 1]) else first.code
         charIndex += if (isHighSurrogate) 2 else 1
         while (charIndex < charLimit && WcWidth.width(text, charIndex) <= 0) {

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -71,6 +73,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -91,6 +94,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import se.soderbjorn.lunamux.android.net.ConnectionHolder
 import se.soderbjorn.lunamux.client.MirrorFit
@@ -475,6 +479,19 @@ fun TerminalScreen(
         }
     }
 
+    // Whether the view has painted this session's own output yet. Until it has,
+    // the last known screen is painted over it (see the dive placeholder below).
+    var firstOutputPainted by remember(sessionId) { mutableStateOf(false) }
+
+    // Safety net for the placeholder: a session that sends nothing at all after
+    // attach — or whose attach never completes — must not keep a stale screen on
+    // top of the live one for ever.
+    var placeholderExpired by remember(sessionId) { mutableStateOf(false) }
+    LaunchedEffect(sessionId) {
+        delay(1500)
+        placeholderExpired = true
+    }
+
     // Scroll-pause: whether the user has scrolled up off the bottom (drives the
     // floating "jump to bottom" pill) and whether fresh output arrived while
     // they were scrolled up (switches the pill to a "New output" hint).
@@ -658,6 +675,10 @@ fun TerminalScreen(
                 } else {
                     view.onScreenUpdated()
                 }
+                // The view has this session's content now, so the placeholder can
+                // go. Released from inside the post (not from the collector) so it
+                // never uncovers a view that has not drawn yet.
+                firstOutputPainted = true
             }
             // Debounce a resume-restore: re-armed on every chunk, it fires once
             // output goes quiet so we land after the whole replay has been fed.
@@ -746,13 +767,32 @@ fun TerminalScreen(
         terminalViewRef.value?.requestLayout()
     }
 
-    BackHandler { onBack() }
+    // Leaving the terminal snapshots its screen into the shared frame cache. The
+    // overview seeds every card from that cache, so this is what makes the
+    // reverse flight land on the screen the user was just looking at instead of
+    // the one from before the dive — the registry is closed the whole time a
+    // terminal is on screen, so nothing else can publish it.
+    //
+    // Deliberately synchronous, on the caller's thread: the flight starts in the
+    // same frame, so a snapshot dispatched onto the emulator's own thread could
+    // not land in time. The lock is held for one pass over the screen grid — the
+    // price is waiting out at most one in-flight output chunk.
+    val leaveFrameRevision = remember(sessionId) { AtomicLong(0) }
+    val leaveTerminal: () -> Unit = {
+        val frame = synchronized(emulator) {
+            snapshotFrame(emulator, leaveFrameRevision.incrementAndGet())
+        }
+        MiniTerminalRegistry.putFrame(sessionId, frame)
+        onBack()
+    }
+
+    BackHandler { leaveTerminal() }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = leaveTerminal) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",
@@ -830,7 +870,13 @@ fun TerminalScreen(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                    // Terminal end of the dive: the overview card's bounds morph
+                    // into this box. ScaleToBounds (the helper's default) means
+                    // the AndroidView below is measured once at final bounds —
+                    // the flight only scales the layer, so the layout listener
+                    // (and its size vote) fires exactly as often as today.
+                    .diveSharedBounds(diveKey(sessionId)),
             ) {
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
@@ -1005,6 +1051,113 @@ fun TerminalScreen(
                         if (view.topRow < 0) view.invalidate() else view.onScreenUpdated()
                     },
                 )
+
+                // The session's last known screen, painted OVER the still-empty
+                // TerminalView until its own output lands. Two things needed it:
+                // the dive transition grew an empty box (the card's thumbnail fades
+                // out while the destination has nothing to show yet, so the text
+                // only appeared once the flight was over), and a terminal opened
+                // cold showed a blank screen for the whole attach round trip. The
+                // thumbnail shares the mirror's fit — fill the height, crop the
+                // overflow — so the live view takes over at nearly the same
+                // geometry, and the cache is fresh: the overview publishes while it
+                // is on screen, and the return gesture snapshots on the way out.
+                val divePlaceholder = remember(sessionId) {
+                    MiniTerminalRegistry.lastFrameFor(sessionId)
+                }
+                // Pin the placeholder to the geometry the live view will draw at.
+                // Both fill the height, but the view's font size is an integer px
+                // with up to a line of slack centred around it, while a fitted
+                // thumbnail scales continuously — and those couple of percent were
+                // exactly what shifted and resized at the handoff.
+                //
+                // Until the server's Size frame lands there is no mirror window to
+                // read, so the fit is predicted from the cached frame's own grid:
+                // a session's width almost never changes between leaving it and
+                // coming back, so the prediction is the answer the real window
+                // gives moments later. A grid this phone's own width is not
+                // mirrored at all and keeps the user's font.
+                val placeholderGeometry: ThumbViewGeometry? = remember(
+                    divePlaceholder,
+                    viewBox,
+                    mirrorWindow,
+                    localGrid,
+                    userFontSize,
+                ) {
+                    val frame = divePlaceholder
+                    val box = viewBox
+                    if (frame == null || box == null) {
+                        null
+                    } else {
+                        val metricsFor = cellMetricsProvider(TerminalFont.typeface(ctx))
+                        val window = mirrorWindow
+                        val predictedPassive = PtyPresentation.isPassive(
+                            naturalCols = localGrid?.cols ?: 0,
+                            serverCols = frame.cols,
+                        )
+                        val fontPx = when {
+                            window != null -> window.fontPx
+                            predictedPassive -> MirrorFit.solveFillHeightFont(
+                                viewHeightPx = box.second,
+                                serverRows = frame.rows,
+                                minPx = MIRROR_FONT_MIN_PX,
+                                maxPx = MIRROR_FONT_MAX_PX,
+                                metrics = metricsFor,
+                            )
+                            else -> userFontSize
+                        }
+                        val cell = metricsFor(fontPx)
+                        val offsetY = when {
+                            window != null -> window.offsetY
+                            predictedPassive -> MirrorFit.centreOffsetY(box.second, frame.rows, cell)
+                            else -> 0f
+                        }
+                        if (cell.lineSpacingPx <= 0) {
+                            null
+                        } else {
+                            ThumbViewGeometry(
+                                fontPx = fontPx,
+                                cellWidthPx = cell.cellWidthPx,
+                                lineSpacingPx = cell.lineSpacingPx,
+                                lineSpacingAndAscentPx = cell.lineSpacingAndAscentPx,
+                                contentOffsetY = offsetY,
+                                // A terminal is always freshly opened while its
+                                // placeholder is up, so the view has not panned.
+                                panX = 0f,
+                            )
+                        }
+                    }
+                }
+                // Held until the view has content AND is showing its final font,
+                // then faded out rather than cut. The mirror's fitted size arrives
+                // one recomposition after the server's Size frame, so releasing on
+                // content alone could uncover a frame or two at the user's own
+                // (larger) font — a rescale at exactly the end of the dive.
+                val placeholderPredictedPassive = divePlaceholder?.let { frame ->
+                    PtyPresentation.isPassive(
+                        naturalCols = localGrid?.cols ?: 0,
+                        serverCols = frame.cols,
+                    )
+                } ?: false
+                val viewFontSettled = mirrorWindow != null || !placeholderPredictedPassive
+                val placeholderVisible = divePlaceholder != null &&
+                    !placeholderExpired &&
+                    !(firstOutputPainted && viewFontSettled)
+                val placeholderAlpha by animateFloatAsState(
+                    targetValue = if (placeholderVisible) 1f else 0f,
+                    animationSpec = tween(durationMillis = 120),
+                    label = "divePlaceholder",
+                )
+                if (divePlaceholder != null && placeholderAlpha > 0f) {
+                    TerminalThumbnail(
+                        frame = divePlaceholder,
+                        fallbackBackground = bgComposeColor,
+                        modifier = Modifier
+                            .matchParentSize()
+                            .graphicsLayer { alpha = placeholderAlpha },
+                        pinnedTo = placeholderGeometry,
+                    )
+                }
 
                 // Take-over badge: shown while another device drives the PTY (this
                 // phone is passive). Tapping it is an explicit, input-free take-over

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
@@ -779,10 +779,14 @@ fun TerminalScreen(
     // price is waiting out at most one in-flight output chunk.
     val leaveFrameRevision = remember(sessionId) { AtomicLong(0) }
     val leaveTerminal: () -> Unit = {
-        val frame = synchronized(emulator) {
-            snapshotFrame(emulator, leaveFrameRevision.incrementAndGet())
-        }
-        MiniTerminalRegistry.putFrame(sessionId, frame)
+        // Best-effort: a snapshot is a read of live rows, and a card that is missing
+        // its last frame is a cosmetic loss. Turning a back-press into a crash over
+        // it would not be.
+        runCatching {
+            synchronized(emulator) {
+                snapshotFrame(emulator, leaveFrameRevision.incrementAndGet())
+            }
+        }.onSuccess { frame -> MiniTerminalRegistry.putFrame(sessionId, frame) }
         onBack()
     }
 
@@ -1061,7 +1065,7 @@ fun TerminalScreen(
                 // thumbnail shares the mirror's fit — fill the height, crop the
                 // overflow — so the live view takes over at nearly the same
                 // geometry, and the cache is fresh: the overview publishes while it
-                // is on screen, and the return gesture snapshots on the way out.
+                // is on screen, and leaving a terminal snapshots on the way out.
                 val divePlaceholder = remember(sessionId) {
                     MiniTerminalRegistry.lastFrameFor(sessionId)
                 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThemeResolver.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThemeResolver.kt
@@ -6,12 +6,16 @@
  * per-screen as a fallback) for the current system dark/light mode and
  * returns it.
  *
- * [applyTerminalColors] mutates a [TerminalEmulator]'s default colour
- * indices (what SGR 0 / "default" resolves to) so existing rows repaint
- * on the next `onScreenUpdated()`, and sets the [TerminalView]'s own
- * background so the letterbox around the text grid matches.
+ * [applyDefaultColors] mutates a [TerminalEmulator]'s default colour
+ * indices (what SGR 0 / "default" resolves to) so existing rows repaint on the
+ * next paint; [applyTerminalColors] adds the [TerminalView]'s own background so
+ * the letterbox around the full-screen text grid matches. The headless
+ * thumbnail emulators need the colour half without a view, so they call
+ * [applyDefaultColors] directly (see [MiniTerminalRegistry.setDefaultColors]) —
+ * one derivation of the theme trio, one mutation, three call sites.
  *
  * @see TerminalScreen
+ * @see MiniTerminalRegistry
  */
 package se.soderbjorn.lunamux.android.ui
 
@@ -60,21 +64,44 @@ internal fun rememberTerminalPalette(
 }
 
 /**
- * Paint the terminal with the resolved theme. Mutates the emulator's
- * default foreground/background and cursor colour indices so existing
- * rows repaint on the next onScreenUpdated(), and sets the view's own
- * background so the letterbox around the text grid matches.
+ * Write the resolved theme's default foreground/background/cursor into
+ * [emulator]'s colour table — the three slots SGR 0 and "default" resolve
+ * through, so existing rows repaint in the theme on the next paint.
+ *
+ * The single place that knows how a [ResolvedTheme] maps onto the emulator's
+ * palette. Called by [applyTerminalColors] for the full-screen view's emulator,
+ * and by [MiniTerminalRegistry] for each headless thumbnail emulator (which has
+ * no view, and which must re-apply after every RIS the server sends).
+ *
+ * Caller contract for the registry: run this on the emulator's own dispatcher
+ * while holding its lock.
+ *
+ * @param emulator the emulator whose colour table is themed.
+ * @param theme    the resolved theme to take text/bg/accent from.
+ */
+internal fun applyDefaultColors(
+    emulator: TerminalEmulator,
+    theme: ResolvedTheme,
+) {
+    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_FOREGROUND] = theme.text.toInt()
+    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND] = theme.bg.toInt()
+    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] = theme.accent.toInt()
+}
+
+/**
+ * Paint the full-screen terminal with the resolved theme: [applyDefaultColors]
+ * for the emulator's default colour indices, plus the view's own background so
+ * the letterbox around the text grid matches.
+ *
+ * @param view     the terminal view whose background is set.
+ * @param emulator the view's emulator, themed via [applyDefaultColors].
+ * @param theme    the resolved theme to apply.
  */
 internal fun applyTerminalColors(
     view: TerminalView,
     emulator: TerminalEmulator,
     theme: ResolvedTheme,
 ) {
-    val fg = theme.text.toInt()
-    val bg = theme.bg.toInt()
-    val cursor = theme.accent.toInt()
-    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_FOREGROUND] = fg
-    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND] = bg
-    emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] = cursor
-    view.setBackgroundColor(bg)
+    applyDefaultColors(emulator, theme)
+    view.setBackgroundColor(theme.bg.toInt())
 }

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThumbnail.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThumbnail.kt
@@ -1,0 +1,190 @@
+/**
+ * Miniature "screenshot" renderer for a terminal screen snapshot.
+ *
+ * [TerminalThumbnail] draws a [TerminalFrame] as the terminal's exact colored
+ * cell grid — the server's cols×rows, the session's real wrapping, per-run
+ * ANSI colors and the cursor — scaled to *fill the height* with every row, with
+ * the columns that do not fit cropped away.
+ *
+ * That fit is not a choice about looks; it is parity with the full-screen
+ * terminal. A phone mirroring a laptop-width session fills its height with the
+ * session's rows and pans over the overflowing columns
+ * (`MirrorFit.solveFillHeightFont` in TerminalScreen). A thumbnail that fitted
+ * *both* axes instead squeezed those same 200 columns into a card's width,
+ * leaving a thin band of unreadable text between two empty halves — and the dive
+ * transition then had to jump from that band to the height-filled real thing.
+ * Cropping from the right matches where the mirror's pan starts, so a preview
+ * and the terminal it dives into show the same window of the session.
+ *
+ * Drawing goes straight to the native canvas with a pair of remembered
+ * [android.graphics.Paint]s: glyph metrics are measured once per typeface at a
+ * fixed reference size, the whole grid is laid out in those reference units,
+ * and a single canvas scale maps it into the box. Runs are column-anchored
+ * (`startCol × cellW`), so grid alignment is exact at run granularity even
+ * where glyph advances drift within a run (wide glyphs, emoji) — invisible at
+ * thumbnail scale.
+ *
+ * @see TerminalFrame
+ * @see MiniTerminalPane
+ */
+package se.soderbjorn.lunamux.android.ui
+
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Reference font size (px) the grid is laid out at before the uniform
+ * scale-to-fit. Any value works — metrics and scale cancel out — but a
+ * moderate size keeps glyph rasterization crisp after downscaling.
+ */
+private const val THUMB_REF_FONT_PX = 16f
+
+/** Immutable per-typeface glyph metrics for the reference layout. */
+private class ThumbMetrics(typeface: Typeface) {
+    /** Paint used for glyphs (color/flags mutated per run while drawing). */
+    val textPaint = Paint().apply {
+        this.typeface = typeface
+        textSize = THUMB_REF_FONT_PX
+        isAntiAlias = true
+    }
+
+    /** Paint used for background/cursor rects. */
+    val rectPaint = Paint()
+
+    /** One grid cell's width in reference units. */
+    val cellW: Float = textPaint.measureText("X")
+
+    /** One grid cell's height in reference units. */
+    val cellH: Float
+
+    /** Baseline offset from a cell's top edge. */
+    val baseline: Float
+
+    init {
+        val fm = textPaint.fontMetrics
+        cellH = fm.descent - fm.ascent
+        baseline = -fm.ascent
+    }
+}
+
+/**
+ * Draw [frame] as the terminal's exact colored cell grid, uniformly scaled to
+ * fit this composable's box and letterboxed with the frame's default
+ * background.
+ *
+ * Composed by [MiniTerminalPane] (and by any future card surface that needs a
+ * truthful terminal snapshot). Render-only: no gesture handling, no state.
+ *
+ * @param frame              the snapshot to draw; while `null` (before the
+ *   first frame arrives after attach) the box is filled with
+ *   [fallbackBackground] only.
+ * @param fallbackBackground fill color used until the first frame lands,
+ *   normally the resolved theme background so the placeholder matches the
+ *   frame that replaces it.
+ * @param modifier           layout modifier from the enclosing pane.
+ */
+@Composable
+fun TerminalThumbnail(
+    frame: TerminalFrame?,
+    fallbackBackground: Color,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val metrics = remember(context) { ThumbMetrics(TerminalFont.typeface(context)) }
+    val fallbackArgb = fallbackBackground.toArgb()
+    Box(
+        modifier.drawBehind {
+            val canvas = drawContext.canvas.nativeCanvas
+            val bg = frame?.defaultBg ?: fallbackArgb
+            metrics.rectPaint.color = bg
+            canvas.drawRect(0f, 0f, size.width, size.height, metrics.rectPaint)
+            if (frame == null || frame.cols <= 0 || frame.rows <= 0) return@drawBehind
+
+            val gridW = frame.cols * metrics.cellW
+            val gridH = frame.rows * metrics.cellH
+            // Every row, filling the height — the full-screen mirror's own fit.
+            val scale = size.height / gridH
+            val scaledW = gridW * scale
+            // Wider than the box: keep the left edge, crop the overflow, which is
+            // the window the mirror's pan opens on. Narrower (a session at this
+            // phone's own width): center it, so the letterbox is symmetric.
+            val dx = if (scaledW <= size.width) (size.width - scaledW) / 2f else 0f
+            val save = canvas.save()
+            try {
+                canvas.clipRect(0f, 0f, size.width, size.height)
+                canvas.translate(dx, 0f)
+                canvas.scale(scale, scale)
+                drawFrame(canvas, frame, metrics)
+            } finally {
+                canvas.restoreToCount(save)
+            }
+        },
+    )
+}
+
+/**
+ * Paint [frame] onto [canvas] in reference units (the caller has already
+ * applied the fit transform): non-default background rects, the cursor block,
+ * then glyph runs.
+ *
+ * @param canvas  the transformed native canvas.
+ * @param frame   the snapshot to paint.
+ * @param metrics the reference glyph metrics + paints.
+ */
+private fun drawFrame(canvas: android.graphics.Canvas, frame: TerminalFrame, metrics: ThumbMetrics) {
+    val cellW = metrics.cellW
+    val cellH = metrics.cellH
+    val rectPaint = metrics.rectPaint
+    val textPaint = metrics.textPaint
+
+    // Background rects first, only where a run's bg differs from the default
+    // (the box fill already painted the default everywhere).
+    frame.lines.forEachIndexed { rowIdx, runs ->
+        val top = rowIdx * cellH
+        for (run in runs) {
+            if (run.bg != frame.defaultBg) {
+                rectPaint.color = run.bg
+                val left = run.startCol * cellW
+                canvas.drawRect(left, top, left + run.widthCols * cellW, top + cellH, rectPaint)
+            }
+        }
+    }
+
+    // Cursor block under the text, like the real renderer's block cursor. The
+    // real renderer also inverts the glyph inside a block cursor; splitting a
+    // run to repaint that one cell is not worth it at thumbnail scale, so a
+    // theme whose cursor color equals its foreground hides that character
+    // behind a solid block — which still reads correctly as a cursor.
+    if (frame.cursorRow in 0 until frame.rows) {
+        rectPaint.color = frame.cursorColor
+        val left = frame.cursorCol * cellW
+        val top = frame.cursorRow * cellH
+        canvas.drawRect(left, top, left + cellW, top + cellH, rectPaint)
+    }
+
+    // Glyph runs, column-anchored so grid alignment survives advance drift.
+    frame.lines.forEachIndexed { rowIdx, runs ->
+        val y = rowIdx * cellH + metrics.baseline
+        for (run in runs) {
+            if (run.text.isEmpty()) continue
+            textPaint.color = run.fg
+            textPaint.isFakeBoldText = run.bold
+            textPaint.isUnderlineText = run.underline
+            // Same skew the real renderer uses for SGR 3; a preview that dropped
+            // it lost the distinction between an agent's italic asides and its
+            // ordinary output.
+            textPaint.textSkewX = if (run.italic) -0.35f else 0f
+            textPaint.isStrikeThruText = run.strikethrough
+            canvas.drawText(run.text, run.startCol * cellW, y, textPaint)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThumbnail.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalThumbnail.kt
@@ -48,12 +48,18 @@ import androidx.compose.ui.platform.LocalContext
  */
 private const val THUMB_REF_FONT_PX = 16f
 
-/** Immutable per-typeface glyph metrics for the reference layout. */
-private class ThumbMetrics(typeface: Typeface) {
+/**
+ * Paints plus the cell geometry they imply, at one font size.
+ *
+ * Built at [THUMB_REF_FONT_PX] for the scale-to-fit path, and at the terminal
+ * view's own font size for the pinned path (see [ThumbViewGeometry]), where the
+ * cell numbers are overridden with the view's rather than derived here.
+ */
+private class ThumbMetrics(typeface: Typeface, textSizePx: Float = THUMB_REF_FONT_PX) {
     /** Paint used for glyphs (color/flags mutated per run while drawing). */
     val textPaint = Paint().apply {
         this.typeface = typeface
-        textSize = THUMB_REF_FONT_PX
+        textSize = textSizePx
         isAntiAlias = true
     }
 
@@ -77,9 +83,38 @@ private class ThumbMetrics(typeface: Typeface) {
 }
 
 /**
- * Draw [frame] as the terminal's exact colored cell grid, uniformly scaled to
- * fit this composable's box and letterboxed with the frame's default
- * background.
+ * The exact geometry a live [com.termux.view.TerminalView] draws its grid at, so
+ * a thumbnail can be pinned to it instead of fitting the frame itself.
+ *
+ * Used for the terminal screen's own placeholder. Both renderings fill the
+ * height, but not identically: the view's font size is an *integer* px chosen by
+ * `MirrorFit.solveFillHeightFont`, which leaves up to a line of slack that
+ * `MirrorFit.centreOffsetY` then centres, while a fitted thumbnail scales
+ * continuously and fills the box exactly. The couple of percent between them is
+ * what made the placeholder visibly shift and resize as it handed over to the
+ * live view at the end of a dive. Pinned, the two are the same pixels.
+ *
+ * @property fontPx                 the view's applied font size in px.
+ * @property cellWidthPx            `TerminalRenderer.fontWidth` at that size.
+ * @property lineSpacingPx          `TerminalRenderer.fontLineSpacing` — one row's height.
+ * @property lineSpacingAndAscentPx `TerminalRenderer.fontLineSpacingAndAscent` —
+ *   the grid's top inset, and the offset that turns a row into a text baseline.
+ * @property contentOffsetY         the view's `setContentOffsetY` (the centring slack).
+ * @property panX                   the view's horizontal pan; 0 for a freshly
+ *   opened terminal, which is the only time a placeholder is on screen.
+ */
+data class ThumbViewGeometry(
+    val fontPx: Int,
+    val cellWidthPx: Float,
+    val lineSpacingPx: Int,
+    val lineSpacingAndAscentPx: Int,
+    val contentOffsetY: Float,
+    val panX: Float,
+)
+
+/**
+ * Draw [frame] as the terminal's exact colored cell grid — scaled to fill this
+ * composable's box, or pinned to a live view's geometry when [pinnedTo] is given.
  *
  * Composed by [MiniTerminalPane] (and by any future card surface that needs a
  * truthful terminal snapshot). Render-only: no gesture handling, no state.
@@ -91,15 +126,27 @@ private class ThumbMetrics(typeface: Typeface) {
  *   normally the resolved theme background so the placeholder matches the
  *   frame that replaces it.
  * @param modifier           layout modifier from the enclosing pane.
+ * @param pinnedTo           when non-null, draw at exactly this view geometry
+ *   (same font size, cell grid and centring) instead of fitting the box — the
+ *   terminal screen's placeholder does this so its handoff to the live view moves
+ *   nothing.
  */
 @Composable
 fun TerminalThumbnail(
     frame: TerminalFrame?,
     fallbackBackground: Color,
     modifier: Modifier = Modifier,
+    pinnedTo: ThumbViewGeometry? = null,
 ) {
     val context = LocalContext.current
-    val metrics = remember(context) { ThumbMetrics(TerminalFont.typeface(context)) }
+    val metrics = remember(context, pinnedTo?.fontPx) {
+        val typeface = TerminalFont.typeface(context)
+        if (pinnedTo == null) {
+            ThumbMetrics(typeface)
+        } else {
+            ThumbMetrics(typeface, pinnedTo.fontPx.toFloat())
+        }
+    }
     val fallbackArgb = fallbackBackground.toArgb()
     Box(
         modifier.drawBehind {
@@ -109,21 +156,42 @@ fun TerminalThumbnail(
             canvas.drawRect(0f, 0f, size.width, size.height, metrics.rectPaint)
             if (frame == null || frame.cols <= 0 || frame.rows <= 0) return@drawBehind
 
-            val gridW = frame.cols * metrics.cellW
-            val gridH = frame.rows * metrics.cellH
-            // Every row, filling the height — the full-screen mirror's own fit.
-            val scale = size.height / gridH
-            val scaledW = gridW * scale
-            // Wider than the box: keep the left edge, crop the overflow, which is
-            // the window the mirror's pan opens on. Narrower (a session at this
-            // phone's own width): center it, so the letterbox is symmetric.
-            val dx = if (scaledW <= size.width) (size.width - scaledW) / 2f else 0f
             val save = canvas.save()
             try {
                 canvas.clipRect(0f, 0f, size.width, size.height)
-                canvas.translate(dx, 0f)
-                canvas.scale(scale, scale)
-                drawFrame(canvas, frame, metrics)
+                if (pinnedTo != null) {
+                    // The view's own origin: pan, centring slack, and the grid's
+                    // top inset. Row r's cell then starts at r * lineSpacing, and
+                    // its baseline sits (lineSpacing - lineSpacingAndAscent) —
+                    // i.e. -ascent — below the cell top, exactly as
+                    // TerminalRenderer walks its rows.
+                    canvas.translate(
+                        -pinnedTo.panX,
+                        pinnedTo.contentOffsetY + pinnedTo.lineSpacingAndAscentPx,
+                    )
+                    drawFrame(
+                        canvas = canvas,
+                        frame = frame,
+                        metrics = metrics,
+                        cellW = pinnedTo.cellWidthPx,
+                        cellH = pinnedTo.lineSpacingPx.toFloat(),
+                        baseline = (pinnedTo.lineSpacingPx - pinnedTo.lineSpacingAndAscentPx).toFloat(),
+                    )
+                } else {
+                    val gridW = frame.cols * metrics.cellW
+                    val gridH = frame.rows * metrics.cellH
+                    // Every row, filling the height — the full-screen mirror's own fit.
+                    val scale = size.height / gridH
+                    val scaledW = gridW * scale
+                    // Wider than the box: keep the left edge, crop the overflow,
+                    // which is the window the mirror's pan opens on. Narrower (a
+                    // session at this phone's own width): center it, so the
+                    // letterbox is symmetric.
+                    val dx = if (scaledW <= size.width) (size.width - scaledW) / 2f else 0f
+                    canvas.translate(dx, 0f)
+                    canvas.scale(scale, scale)
+                    drawFrame(canvas, frame, metrics, metrics.cellW, metrics.cellH, metrics.baseline)
+                }
             } finally {
                 canvas.restoreToCount(save)
             }
@@ -132,17 +200,25 @@ fun TerminalThumbnail(
 }
 
 /**
- * Paint [frame] onto [canvas] in reference units (the caller has already
- * applied the fit transform): non-default background rects, the cursor block,
- * then glyph runs.
+ * Paint [frame] onto [canvas] in cell units (the caller has already applied the
+ * fit or pin transform): non-default background rects, the cursor block, then
+ * glyph runs.
  *
- * @param canvas  the transformed native canvas.
- * @param frame   the snapshot to paint.
- * @param metrics the reference glyph metrics + paints.
+ * @param canvas   the transformed native canvas.
+ * @param frame    the snapshot to paint.
+ * @param metrics  the paints to draw with.
+ * @param cellW    one cell's width in the canvas' current units.
+ * @param cellH    one cell's height.
+ * @param baseline distance from a cell's top edge to its text baseline.
  */
-private fun drawFrame(canvas: android.graphics.Canvas, frame: TerminalFrame, metrics: ThumbMetrics) {
-    val cellW = metrics.cellW
-    val cellH = metrics.cellH
+private fun drawFrame(
+    canvas: android.graphics.Canvas,
+    frame: TerminalFrame,
+    metrics: ThumbMetrics,
+    cellW: Float,
+    cellH: Float,
+    baseline: Float,
+) {
     val rectPaint = metrics.rectPaint
     val textPaint = metrics.textPaint
 
@@ -173,7 +249,7 @@ private fun drawFrame(canvas: android.graphics.Canvas, frame: TerminalFrame, met
 
     // Glyph runs, column-anchored so grid alignment survives advance drift.
     frame.lines.forEachIndexed { rowIdx, runs ->
-        val y = rowIdx * cellH + metrics.baseline
+        val y = rowIdx * cellH + baseline
         for (run in runs) {
             if (run.text.isEmpty()) continue
             textPaint.color = run.fg

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TreeScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TreeScreen.kt
@@ -451,10 +451,17 @@ fun TreeScreen(
     }
     LaunchedEffect(overviewVm) { overviewVm?.run() }
 
-    // The active (non-hidden) tab and its on-canvas pane count drive the
-    // overview toolbar actions (add pane → this tab; layout miniatures →
-    // this pane count). Derived from the already-collected config + minimized
-    // set so we don't need a second state subscription.
+    // The card the overview is browsing, reported by OverviewContent (null
+    // whenever the overview is not composed — list mode, or a dive in
+    // progress). Browsing the switcher row deliberately never activates a tab
+    // server-side, so this is what the toolbar must target: without it, "new
+    // pane" and the layout presets land on the off-screen active tab.
+    var browsedTabId by remember { mutableStateOf<String?>(null) }
+
+    // The tab the overview toolbar acts on, and its on-canvas pane count (add
+    // pane → this tab; layout miniatures → this pane count). Derived from the
+    // already-collected config + minimized set so we don't need a second state
+    // subscription.
     // Resolve the active world once (its tabs / activeTabId are the source of
     // truth for >=1.9 clients); fall back to the legacy flat fields when the
     // config carries no worlds.
@@ -465,8 +472,13 @@ fun TreeScreen(
         worldActiveTabId?.takeIf { id -> worldTabs.any { it.id == id && !it.isHidden } }
             ?: worldTabs.firstOrNull { !it.isHidden }?.id
     }
-    val overviewActivePaneCount = worldTabs
-        .firstOrNull { it.id == overviewActiveTabId }
+    // The browsed card wins over the server-active tab, but only while it is
+    // still a tab of this world (a close or a world switch falls back).
+    val overviewTargetTabId = browsedTabId
+        ?.takeIf { id -> worldTabs.any { it.id == id } }
+        ?: overviewActiveTabId
+    val overviewTargetPaneCount = worldTabs
+        .firstOrNull { it.id == overviewTargetTabId }
         ?.panes?.count { it.leaf.id !in minimizedPaneIds } ?: 0
 
     // The active tab's persisted layout preset, read from the toolkit-owned
@@ -476,7 +488,7 @@ fun TreeScreen(
     // re-applying; one-shot presets relax to "custom" on the next manual edit
     // (issue #59). Null when no preset is recorded for the tab.
     val rawLayout by client.windowState.rawLayoutState.collectAsStateWithLifecycle()
-    val overviewActivePreset = overviewActiveTabId?.let { tabId ->
+    val overviewTargetPreset = overviewTargetTabId?.let { tabId ->
         WindowLayoutState.parse(rawLayout).presetByTab[tabId]?.let { LayoutPreset.fromKey(it) }
     }
 
@@ -614,11 +626,11 @@ fun TreeScreen(
 
     if (showLayoutSheet) {
         LayoutSheet(
-            paneCount = overviewActivePaneCount,
-            activePreset = overviewActivePreset,
+            paneCount = overviewTargetPaneCount,
+            activePreset = overviewTargetPreset,
             onSelect = { preset ->
                 showLayoutSheet = false
-                val tabId = overviewActiveTabId ?: return@LayoutSheet
+                val tabId = overviewTargetTabId ?: return@LayoutSheet
                 scope.launch { overviewVm?.applyLayout(tabId, preset) }
             },
             onDismiss = { showLayoutSheet = false },
@@ -643,7 +655,7 @@ fun TreeScreen(
             },
             onNewPane = { kind ->
                 showCreateSheet = false
-                val tabId = overviewActiveTabId
+                val tabId = overviewTargetTabId
                 if (tabId != null) {
                     scope.launch { overviewVm?.addPane(tabId, kind) }
                 }
@@ -868,6 +880,7 @@ fun TreeScreen(
                         onOpenTerminal = onOpenTerminal,
                         onOpenFileBrowser = onOpenFileBrowser,
                         onOpenGit = onOpenGit,
+                        onBrowsedTabChanged = { id -> browsedTabId = id },
                     )
                 }
                 SessionsViewMode.LIST -> {

--- a/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/storage/LocalRepository.kt
+++ b/client/src/commonMain/kotlin/se/soderbjorn/lunamux/client/storage/LocalRepository.kt
@@ -77,6 +77,10 @@ const val LOCAL_STATE_FILE_NAME: String = "local_state.json"
  *   suppressed; cleared by [LocalRepository.clearDismissed].
  * @property lastCheckEpochMillis epoch-millis of the last completed news/update
  *   check, or `null` if none has completed.
+ * @property switcherZoom the overview switcher's zoom posture, by name (Android's
+ *   `SwitcherZoom`), or `""` for "never chosen". Stored as the name rather than a
+ *   number so the file stays readable and so a level added or renamed later
+ *   degrades to the default instead of to whatever else that number now means.
  * @see LocalRepository
  */
 @Serializable
@@ -86,6 +90,7 @@ data class LocalState(
     val dismissedNewsIds: Set<String> = emptySet(),
     val dismissedUpdateVersionCode: Long? = null,
     val lastCheckEpochMillis: Long? = null,
+    val switcherZoom: String = "",
 )
 
 /**
@@ -309,6 +314,20 @@ class LocalRepository(
     @Throws(CancellationException::class, Exception::class)
     suspend fun setOnboardingSeen(seen: Boolean) {
         mutate { it.copy(onboardingSeen = seen) }
+    }
+
+    /**
+     * Persist the overview switcher's zoom posture so it survives a restart.
+     *
+     * Called by the Android overview when a pinch settles on a new level; a
+     * posture the user has chosen is theirs until they change it, not something
+     * to relearn every launch.
+     *
+     * @param level the level's name, or `""` to forget the choice.
+     */
+    @Throws(CancellationException::class, Exception::class)
+    suspend fun setSwitcherZoom(level: String) {
+        mutate { it.copy(switcherZoom = level) }
     }
 
     /**

--- a/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LinkThumbnailRenderer.kt
+++ b/web/src/jsMain/kotlin/se/soderbjorn/lunamux/LinkThumbnailRenderer.kt
@@ -63,8 +63,12 @@ internal const val THUMBNAIL_FONT_FAMILY = "Menlo, Monaco, 'Courier New', monosp
 // --- Cross-platform consolidation opportunity --------------------------------
 // The terminal-thumbnail pipeline is currently reimplemented once per platform:
 //
-//   Android  MiniTerminalRegistry.extractRecentLines  (TerminalEmulator.transcriptText)
-//            + MiniTerminalPane  (reverseLayout LazyColumn; Compose Text auto-wraps)
+//   Android  NO LONGER PART OF THIS SHAPE. Android now snapshots the emulator's
+//            *screen* into a resolved colour grid (TerminalFrame/snapshotFrame) and
+//            paints that grid on a canvas (TerminalThumbnail), so it re-wraps no
+//            text at all and shares nothing with the transform below. Reconcile
+//            toward the grid approach when these previews are next touched, rather
+//            than hoisting a transform two platforms use and one has left.
 //   iOS      MiniTerminalRegistry.extractRecentLines  (SwiftTerm.getBufferAsData)
 //            + MiniTerminalPane  (bottom-aligned overlay; SwiftUI Text auto-wraps)
 //   Web      readLogicalLines + wrapLine + renderThumbnail  (xterm.js buffer → canvas)


### PR DESCRIPTION
Makes the Android overview behave like the OS app switcher: a card per tab, flung sideways over a dock that follows the row, pinchable between three card sizes, with a shared-element dive into the full-screen terminal — and previews that show the session's real screen rather than re-wrapped text.

Everything is in `androidApp/`, bar one field in the shared `LocalState` for the persisted zoom level. **No server changes**, and no changes to the vendored Termux modules.

### Review order

The commits are meant to be read in order, and the first three each stand on their own:

1. **Render terminal previews as the real screen** — `TerminalFrame`/`ThumbRun` + `snapshotFrame`, the registry publishing frames, `TerminalThumbnail` painting them, and the height-fill fit that gives preview/terminal parity.
2. **Dive into a terminal, and fly its content there** — `DiveTransition.kt`, the placeholder the flight actually flies, the content-box anchor, the crossfade handoff, and the placeholder pinned to the live view's geometry.
3. **Make the overview the app switcher** — `SwitcherCardRow` + `TabDock`, browse-≠-commit, the fling/settle tuning, the dock riding the drag, and the mid-settle tap fix.
4. **Fix what the review found** — a self-review pass over the three above: RIS/DECSCNM theme handling, an O(cols²) row walk rewritten to O(cols), a bounded registry (8 live entries, oldest unsubscribed retired first), and a dive-debounce that no longer depends on wall-clock time.
5. **Stop the tap watcher swallowing taps, and the dock caching an empty strip** — three regressions commit 4 introduced, caught on device: an overlay pointer modifier is not hit-transparent, so a watcher that declined a gesture swallowed it (dead taps on a resting card); the tap test asked how far the *row* had moved rather than the *finger*, so a flick dived; and the dock's scaled-width walk cached the answer for a not-yet-measured strip.
6. **Open the switcher zoomed out, and let a pinch change that** — the cards were 89% of the width, which is a size for reading one tab, not for seeing how many there are. The row now opens at the OS switcher's proportions and pinches between three levels (0.45 / 0.62 / 0.89 of the width), the old full-width card among them, persisted so a posture is chosen once. Details below.

### What to look at

- **Read-only invariant.** Previews never call `resize`/`send`, so a thumbnail can never shrink the shared PTY. `ScaleToBounds` is load-bearing for the same reason: the terminal end of the dive wraps an `AndroidView` whose relayout would vote a size to the server, so the flight only ever scales a layer.
- **A zoom level is a layout, not a permanent transform.** The cheap implementation — leave the row scaled by a `graphicsLayer` and keep one layout — is wrong here: shared elements take their bounds from the lookahead pass, which does not see an ancestor's layer, so a scaled row would fly the dive from a rect that is not the card you tapped. So the cards are *measured* at the level's size and only the pinch itself is a transform: it previews the next size while the cards' constraints hold still (nothing is remeasured or recomposed with fingers down), and the layout lands on it at lift. The commit changes the stride, so it re-centres via `requestScrollToItem` in the very measure pass that follows.
- **Cards scale in both dimensions, never width alone.** A thumbnail fills its box's height and crops the columns that overflow, so a card narrowed at full height would show *less* of the terminal the further you zoomed out. Uniform scaling leaves vertical slack instead, which carries the tab title — the thing that makes the smallest level navigable, and where the OS switcher puts the app name.
- **One layering wart.** `net/ConnectionHolder` imports `MiniTerminalRegistry` from `ui` to evict the frame cache on disconnect. Happy to invert it behind a listener if you'd rather.
- **Motion constants that look arbitrary and are not.** Settle stiffness 50 at damping 1.2, an 80 dp/s flick threshold, dock scale 0.78 / opacity 0.50 / gap 6dp, and the three zoom fractions: all chosen on the device against a screen recording of the OS switcher, via a slider panel that was removed once they settled. Each carries a comment saying so.
- **Main-thread emulator lock.** Leaving a terminal snapshots its screen synchronously under the emulator's monitor, because the flight starts in the same frame and an async hop cannot land in time. It is one pass over the screen grid; the price is waiting out at most one in-flight output chunk.

### Deliberately not included

- **`emitCell`/`isDefaultStyle` still duplicate the server's `GridSerializer`.** Sharing them needs a new file in the vendored `:terminal-core` plus server changes, and the O(cols) rewrite has since diverged the walk anyway.
- **Snapshot allocation is not optimised.** The frame DTO allocates ~1.6k short-lived objects per publish (~10⁵/s while flinging three cards). It is nursery garbage with no observed jank, and it replaces a registry that rebuilt the *entire* transcript string on every PTY event, unthrottled. `TerminalFrame.kt` names the two real mitigations and says to measure first. Zooming out attaches a card or two more, and so publishes a little more; still gated per attached card, and still worth measuring before touching.
- **The pinch is the only way to change zoom.** No control, no menu item — undiscoverable, but the level persists, so it is a once-ever gesture rather than a daily one. Easy to add an affordance if you disagree.
- **No unit tests**: `androidApp` has no test source set, and adding one is not this PR's job. Everything here was verified on device instead — several rounds of it.

### Device testing

Built and sideloaded repeatedly through development against a laptop server, on a passive-mirror session (the phone showing a laptop-width grid). Exercised: previews coming up themed on first attach and after reconnect; new pane / layout preset landing on the browsed card; fling, flick, edge-of-row and tap-during-settle; pinching between all three levels and the dive from each of them; the dive's reverse; a tab whose every pane is docked; and a terminal opened from list view, which has no cached frame and so still flies blank — expected, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
