### PR TITLE
Make the Android terminal's native text actions work

### DIFF
--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/MiniTerminalRegistry.kt
@@ -116,6 +116,12 @@ class MiniTerminalRegistry(
             // thumbnail sizes its emulator directly in the Size collector below.
             // A thumbnail never takes input, so the input handler is a no-op.
             serverGridPin = java.util.concurrent.atomic.AtomicReference(null),
+            // No clipboard for a thumbnail. It replays the same output stream as the
+            // real pane, OSC 52 included, so honouring a program's clipboard request
+            // here would let merely opening the overview overwrite what the user
+            // copied — once per thumbnail of the session. There is no selection bar
+            // to paste from either.
+            appContext = null,
             handleInput = {},
         )
         val emulator = createSyncedEmulator(session)

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalClipboard.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalClipboard.kt
@@ -1,0 +1,132 @@
+/**
+ * System-clipboard bridge for the Android terminal.
+ *
+ * The Termux view and emulator both hand clipboard work to their session's
+ * [com.termux.terminal.TerminalOutput] callbacks rather than touching
+ * [ClipboardManager] themselves: the text-selection action bar calls
+ * `onCopyTextToClipboard` / `onPasteTextFromClipboard`, and a program's OSC 52
+ * sequence calls `onCopyTextToClipboard` from inside the emulator. Lunamux's
+ * session (see [createExternalTerminalSession]) is the only implementation of
+ * those callbacks in this app, and this object is what it delegates to.
+ *
+ * Everything here runs on the main thread. Two reasons: the emulator's OSC 52
+ * path arrives on the background emulator dispatcher, and [Toast] needs a
+ * looper; and `ClipboardManager` is a UI-thread API in practice — several OEM
+ * implementations post internally and misbehave off it.
+ *
+ * @see createExternalTerminalSession
+ * @see TerminalScreen
+ */
+package se.soderbjorn.lunamux.android.ui
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
+
+/**
+ * Reads and writes the system clipboard on behalf of the terminal session.
+ *
+ * Called by the [com.termux.terminal.TerminalSession] subclass built in
+ * [createExternalTerminalSession] — which is reached from the text-selection
+ * action bar ("Copy" / "Paste") and from the emulator's OSC 52 handler.
+ */
+internal object TerminalClipboard {
+
+    /** Label attached to the clip, shown by the system's clipboard UI. */
+    private const val CLIP_LABEL = "Lunamux terminal"
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Put [text] on the system clipboard.
+     *
+     * Below API 33 the platform gives no visible acknowledgement, so a short
+     * toast is shown — without it a successful copy is indistinguishable from
+     * the no-op this used to be. From API 33 onwards Android shows its own
+     * clipboard confirmation and an app toast would merely duplicate it.
+     *
+     * @param context any context; the application context is enough.
+     * @param text the text to copy. Null or empty is ignored — a program can
+     *   legitimately clear its OSC 52 selection, and there is nothing to say
+     *   about it.
+     * @see readFromClipboard
+     */
+    fun copyToClipboard(context: Context, text: String?) {
+        if (text.isNullOrEmpty()) return
+        onMainThread {
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                ?: return@onMainThread
+            runCatching { clipboard.setPrimaryClip(ClipData.newPlainText(CLIP_LABEL, text)) }
+                .onSuccess {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                    }
+                }
+        }
+    }
+
+    /**
+     * Read the clipboard and hand its text to [sink].
+     *
+     * Asynchronous because the caller may be on the emulator dispatcher; [sink]
+     * always runs on the main thread. It is not invoked at all when the
+     * clipboard holds nothing usable, so callers need no empty-case branch.
+     *
+     * @param context any context; the application context is enough.
+     * @param sink receives the clipboard text, on the main thread.
+     * @see copyToClipboard
+     */
+    fun readFromClipboard(context: Context, sink: (String) -> Unit) {
+        onMainThread {
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                ?: return@onMainThread
+            // coerceToText rather than getText: a clip can carry an intent, a URI or
+            // styled HTML, and every one of those has a sensible text rendering that a
+            // terminal can accept. Wrapped because reading the clipboard is an IPC into
+            // the system service and a dead source app can surface as an exception.
+            val text = runCatching {
+                clipboard.primaryClip
+                    ?.takeIf { it.itemCount > 0 }
+                    ?.getItemAt(0)
+                    ?.coerceToText(context)
+                    ?.toString()
+            }.getOrNull()
+            if (!text.isNullOrEmpty()) sink(text)
+        }
+    }
+
+    /**
+     * Whether the clipboard currently holds something [readFromClipboard] could
+     * return, used to enable or grey out the selection bar's "Paste" item.
+     *
+     * Must be called on the main thread — the action-mode callbacks that ask are
+     * already there. Note that from API 29 the platform answers false whenever
+     * the app is not focused; that is exactly when no action bar is up, so it
+     * costs nothing here.
+     *
+     * @param context any context; the application context is enough.
+     * @return true if a paste would produce text.
+     */
+    fun hasText(context: Context): Boolean {
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            ?: return false
+        return runCatching { clipboard.hasPrimaryClip() }.getOrDefault(false)
+    }
+
+    /**
+     * Run [block] on the main thread, inline when already there.
+     *
+     * Inline rather than always posting so that a copy triggered from the action
+     * bar completes before the action mode is torn down.
+     *
+     * @param block the work to run.
+     */
+    private inline fun onMainThread(crossinline block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) block()
+        else mainHandler.post { block() }
+    }
+}

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalEmulatorHolder.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalEmulatorHolder.kt
@@ -16,6 +16,7 @@
  */
 package se.soderbjorn.lunamux.android.ui
 
+import android.content.Context
 import com.termux.terminal.TerminalEmulator
 import com.termux.terminal.TerminalSession
 import com.termux.view.TerminalView
@@ -71,6 +72,26 @@ import java.util.concurrent.atomic.AtomicReference
  * grid) before the bytes are sent; while driving, it just sends. Keeping that
  * policy in [TerminalScreen] (where the mode state lives) is why this indirects
  * through a callback rather than sending directly.
+ *
+ * **Clipboard.** The Termux view and emulator do not touch the system clipboard
+ * themselves — they call the session's `onCopyTextToClipboard` /
+ * `onPasteTextFromClipboard`, which is why the text-selection action bar's Copy
+ * and Paste (and a program's OSC 52) were dead for as long as this session
+ * stubbed them out. Both are implemented here against
+ * [TerminalClipboard]; paste deliberately goes through
+ * [TerminalEmulator.paste] rather than writing the bytes directly, so that
+ * bracketed-paste mode is honoured and the text lands on the same
+ * [handleInput] path as typing — meaning a paste into a mirrored pane takes
+ * the PTY over first, exactly as a keystroke would.
+ *
+ * @param appContext application context, used only to reach the system
+ *   clipboard service. Deliberately the *application* context: this session
+ *   outlives configuration changes. **Null means this session has no clipboard**
+ *   — which is what a headless mirror wants, not merely a convenience. A
+ *   thumbnail in [MiniTerminalRegistry] replays the same output stream as the
+ *   real pane, OSC 52 included; honouring it there would let simply opening the
+ *   overview overwrite the user's clipboard, once per thumbnail of the session.
+ *   It has no selection bar to paste from either.
  */
 internal fun createExternalTerminalSession(
     scope: CoroutineScope,
@@ -78,6 +99,7 @@ internal fun createExternalTerminalSession(
     terminalViewRef: MutableState<TerminalView?>,
     ptySocket: PtySocket,
     serverGridPin: AtomicReference<Pair<Int, Int>?>,
+    appContext: Context?,
     handleInput: suspend (ByteArray) -> Unit,
 ): TerminalSession {
     return object : TerminalSession(
@@ -139,10 +161,42 @@ internal fun createExternalTerminalSession(
         // but we passed null for that, so we must override all of them or
         // they'll NPE. Even reset() inside the emulator ctor calls onColorsChanged.
         override fun titleChanged(oldTitle: String?, newTitle: String?) = Unit
-        override fun onCopyTextToClipboard(text: String?) = Unit
-        override fun onPasteTextFromClipboard() = Unit
         override fun onBell() = Unit
         override fun onColorsChanged() = Unit
+
+        /**
+         * Copy [text] to the system clipboard.
+         *
+         * Called by the text-selection action bar's "Copy" (on the main thread)
+         * and by the emulator's OSC 52 handler when a remote program sets the
+         * selection (on the emulator dispatcher). [TerminalClipboard] absorbs
+         * that thread difference. A null [appContext] means this session is a
+         * headless mirror and must leave the clipboard alone.
+         */
+        override fun onCopyTextToClipboard(text: String?) {
+            val ctx = appContext ?: return
+            TerminalClipboard.copyToClipboard(ctx, text)
+        }
+
+        /**
+         * Paste the system clipboard into the terminal.
+         *
+         * Called by the text-selection action bar's "Paste". Routed through
+         * [TerminalEmulator.paste] so DECSET 2004 bracketed paste is applied and
+         * the resulting bytes travel the ordinary write path — i.e. through
+         * [handleInput], which takes the PTY over first when this phone is only
+         * mirroring.
+         */
+        override fun onPasteTextFromClipboard() {
+            val ctx = appContext ?: return
+            TerminalClipboard.readFromClipboard(ctx) { text ->
+                val e = externalEmulator ?: return@readFromClipboard
+                // Same monitor the resize and append paths take: paste reads the
+                // emulator's DECSET bits, and a background append must not be
+                // rewriting them underneath the read.
+                synchronized(e) { runCatching { e.paste(text) } }
+            }
+        }
 
         override fun writeCodePoint(prependEscape: Boolean, codePoint: Int) {
             val out = java.io.ByteArrayOutputStream(5)

--- a/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
+++ b/androidApp/src/main/kotlin/se/soderbjorn/lunamux/android/ui/TerminalScreen.kt
@@ -492,6 +492,7 @@ fun TerminalScreen(
             terminalViewRef = terminalViewRef,
             ptySocket = ptySocket,
             serverGridPin = serverGridPin,
+            appContext = ctx.applicationContext,
             handleInput = handleInput,
         )
     }

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -2,7 +2,6 @@ package com.termux.view;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -21,7 +20,6 @@ import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
-import android.view.Menu;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -35,7 +33,6 @@ import android.view.inputmethod.InputConnection;
 import android.widget.OverScroller;
 import android.widget.Scroller;
 
-import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import com.termux.terminal.KeyHandler;
@@ -592,14 +589,6 @@ public final class TerminalView extends View {
         if (mAccessibilityEnabled) setContentDescription(getText());
     }
 
-    /** This must be called by the hosting activity in {@link Activity#onContextMenuClosed(Menu)}
-     * when context menu for the {@link TerminalView} is started by
-     * {@link TextSelectionCursorController#ACTION_MORE} is closed. */
-    public void onContextMenuClosed(Menu menu) {
-        // Unset the stored text since it shouldn't be used anymore and should be cleared from memory
-        unsetStoredSelectedText();
-    }
-
     /**
      * Sets the text size, which in turn sets the number of rows and columns.
      *
@@ -884,6 +873,11 @@ public final class TerminalView extends View {
             return true;
         } else if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {
             if (event.isButtonPressed(MotionEvent.BUTTON_SECONDARY)) {
+                // LUNAMUX: no-op in this app, and left as-is deliberately. showContextMenu()
+                // needs a host that overrides onCreateContextMenu, which a Compose activity does
+                // not provide -- the same reason the selection bar's "More…" was dead. This is
+                // the hardware-mouse path though, so there is nothing to see on a phone and no
+                // behaviour worth changing blind. Wire it up if a mouse ever matters here.
                 if (action == MotionEvent.ACTION_DOWN) showContextMenu();
                 return true;
             } else if (event.isButtonPressed(MotionEvent.BUTTON_TERTIARY)) {
@@ -1717,17 +1711,6 @@ public final class TerminalView extends View {
             return mTextSelectionCursorController.getSelectedText();
         else
             return null;
-    }
-
-    /** Get the selected text stored before "MORE" button was pressed on the context menu. */
-    @Nullable
-    public String getStoredSelectedText() {
-        return mTextSelectionCursorController != null ? mTextSelectionCursorController.getStoredSelectedText() : null;
-    }
-
-    /** Unset the selected text stored before "MORE" button was pressed on the context menu. */
-    public void unsetStoredSelectedText() {
-        if (mTextSelectionCursorController != null) mTextSelectionCursorController.unsetStoredSelectedText();
     }
 
     private ActionMode getTextSelectionActionMode() {

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
@@ -1,12 +1,10 @@
 package com.termux.view.textselection;
 
-import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.graphics.Rect;
 import android.text.TextUtils;
 import android.view.ActionMode;
-import android.view.InputDevice;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -23,7 +21,6 @@ public class TextSelectionCursorController implements CursorController {
 
     private final TerminalView terminalView;
     private final TextSelectionHandleView mStartHandle, mEndHandle;
-    private String mStoredSelectedText;
     private boolean mIsSelectingText = false;
     private long mShowStartTime = System.currentTimeMillis();
 
@@ -33,7 +30,23 @@ public class TextSelectionCursorController implements CursorController {
     private ActionMode mActionMode;
     public final int ACTION_COPY = 1;
     public final int ACTION_PASTE = 2;
-    public final int ACTION_MORE = 3;
+
+    /** Whether "Paste" was last built enabled, so a refresh can skip a no-op menu rebuild. */
+    private boolean mPasteEnabled;
+
+    /**
+     * Set when the system clipboard has changed under a live selection bar, so the next
+     * {@code onPrepareActionMode} re-reads it. Event-driven rather than polled: {@link #render()}
+     * invalidates the action mode on every frame, and {@code hasPrimaryClip()} is a binder call
+     * into the clipboard service -- asking it per frame would put a synchronous IPC in the draw
+     * path. It is also the only accurate way to do it, since from API 29 the clipboard reads as
+     * empty whenever the app is unfocused.
+     */
+    private boolean mClipboardDirty;
+
+    /** Registered for the lifetime of the action mode; null when nothing is listening. */
+    @Nullable
+    private ClipboardManager.OnPrimaryClipChangedListener mClipChangedListener;
 
     public TextSelectionCursorController(TerminalView terminalView) {
         this.terminalView = terminalView;
@@ -114,16 +127,32 @@ public class TextSelectionCursorController implements CursorController {
             public boolean onCreateActionMode(ActionMode mode, Menu menu) {
                 int show = MenuItem.SHOW_AS_ACTION_IF_ROOM | MenuItem.SHOW_AS_ACTION_WITH_TEXT;
 
-                ClipboardManager clipboard = (ClipboardManager) terminalView.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                mPasteEnabled = clipboardHasText();
                 menu.add(Menu.NONE, ACTION_COPY, Menu.NONE, R.string.copy_text).setShowAsAction(show);
-                menu.add(Menu.NONE, ACTION_PASTE, Menu.NONE, R.string.paste_text).setEnabled(clipboard != null && clipboard.hasPrimaryClip()).setShowAsAction(show);
-                menu.add(Menu.NONE, ACTION_MORE, Menu.NONE, R.string.text_selection_more);
+                menu.add(Menu.NONE, ACTION_PASTE, Menu.NONE, R.string.paste_text).setEnabled(mPasteEnabled).setShowAsAction(show);
                 return true;
             }
 
             @Override
             public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-                return false;
+                // LUNAMUX: keep "Paste" in step with the clipboard for the life of the
+                // selection. Upstream built the item once and returned false forever, so a
+                // selection begun with an empty clipboard kept a greyed-out Paste even after
+                // the user had copied something -- a disabled button being indistinguishable
+                // from a dead one (LMX-120).
+                //
+                // render() invalidates the mode on every frame, so the common path here must
+                // cost nothing and must claim a change only when there is one: returning true
+                // unconditionally rebuilds and re-animates the floating bar every frame. The
+                // clipboard is therefore only re-read when its change listener has said so.
+                if (!mClipboardDirty) return false;
+                mClipboardDirty = false;
+                boolean pasteEnabled = clipboardHasText();
+                if (pasteEnabled == mPasteEnabled) return false;
+                mPasteEnabled = pasteEnabled;
+                MenuItem paste = menu.findItem(ACTION_PASTE);
+                if (paste != null) paste.setEnabled(pasteEnabled);
+                return true;
             }
 
             @Override
@@ -142,16 +171,6 @@ public class TextSelectionCursorController implements CursorController {
                     case ACTION_PASTE:
                         terminalView.stopTextSelectionMode();
                         terminalView.mTermSession.onPasteTextFromClipboard();
-                        break;
-                    case ACTION_MORE:
-                        // We first store the selected text in case TerminalViewClient needs the
-                        // selected text before MORE button was pressed since we are going to
-                        // stop selection mode
-                        mStoredSelectedText = getSelectedText();
-                        // The text selection needs to be stopped before showing context menu,
-                        // otherwise handles will show above popup
-                        terminalView.stopTextSelectionMode();
-                        terminalView.showContextMenu();
                         break;
                 }
 
@@ -182,15 +201,25 @@ public class TextSelectionCursorController implements CursorController {
 
             @Override
             public void onDestroyActionMode(ActionMode mode) {
-                // Ignore.
+                // LUNAMUX: the action mode's own teardown is the reliable place to drop the
+                // clipboard listener -- hide() can bail out early (its 300ms guard), whereas
+                // this fires however the mode ends, including when the system replaces it.
+                unregisterClipChangedListener();
             }
 
             @Override
             public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
-                int x1 = Math.round(mSelX1 * terminalView.mRenderer.getFontWidth());
-                int x2 = Math.round(mSelX2 * terminalView.mRenderer.getFontWidth());
-                int y1 = Math.round((mSelY1 - 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
-                int y2 = Math.round((mSelY2 + 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
+                // LUNAMUX: go through the view's own cell -> pixel helpers instead of
+                // multiplying out the cell metrics here. onDraw translates the canvas by
+                // (-panX, contentOffsetY) to pan a grid wider than the view and to centre one
+                // that does not fill its height; getPointX/getPointY undo exactly those two
+                // offsets, and this rect -- which is what the floating bar anchors to -- did
+                // not, so the bar drifted away from the selection it belongs to as soon as the
+                // pane was panned or vertically centred.
+                int x1 = terminalView.getPointX(mSelX1);
+                int x2 = terminalView.getPointX(mSelX2);
+                int y1 = terminalView.getPointY(mSelY1 - 1);
+                int y2 = terminalView.getPointY(mSelY2 + 1);
 
                 if (x1 > x2) {
                     int tmp = x1;
@@ -207,6 +236,85 @@ public class TextSelectionCursorController implements CursorController {
                 outRect.set(x1, top, x2, bottom);
             }
         }, ActionMode.TYPE_FLOATING);
+
+        registerClipChangedListener();
+    }
+
+    /**
+     * LUNAMUX: start watching the system clipboard so the bar's "Paste" item can follow it.
+     *
+     * Called when the action mode is created; torn down again by
+     * {@link #unregisterClipChangedListener()} from {@code onDestroyActionMode}. The listener
+     * only marks state dirty and asks the mode to refresh -- reading the clipboard is left to
+     * {@code onPrepareActionMode}, which runs on the UI thread.
+     *
+     * @see #mClipboardDirty
+     */
+    private void registerClipChangedListener() {
+        if (mClipChangedListener != null) return;
+        ClipboardManager clipboard = clipboardManager();
+        if (clipboard == null) return;
+        mClipChangedListener = () -> {
+            mClipboardDirty = true;
+            if (mActionMode != null) mActionMode.invalidate();
+        };
+        try {
+            clipboard.addPrimaryClipChangedListener(mClipChangedListener);
+        } catch (Exception e) {
+            // Nothing to watch with; "Paste" simply keeps the state it was built with.
+            mClipChangedListener = null;
+        }
+    }
+
+    /**
+     * LUNAMUX: stop watching the system clipboard.
+     *
+     * Called from {@code onDestroyActionMode} and {@link #onDetached()}. Idempotent, because
+     * both can run for the same selection.
+     *
+     * @see #registerClipChangedListener()
+     */
+    private void unregisterClipChangedListener() {
+        if (mClipChangedListener == null) return;
+        ClipboardManager clipboard = clipboardManager();
+        if (clipboard != null) {
+            try {
+                clipboard.removePrimaryClipChangedListener(mClipChangedListener);
+            } catch (Exception e) {
+                // Already gone as far as the service is concerned; nothing to undo.
+            }
+        }
+        mClipChangedListener = null;
+        mClipboardDirty = false;
+    }
+
+    /**
+     * LUNAMUX: the system clipboard service, or null if this device does not expose one.
+     *
+     * @return the {@link ClipboardManager}, or null.
+     */
+    @Nullable
+    private ClipboardManager clipboardManager() {
+        return (ClipboardManager) terminalView.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+    }
+
+    /**
+     * LUNAMUX: whether a paste would produce anything, used to enable the bar's "Paste" item.
+     *
+     * @return true if the system clipboard holds a primary clip. Note that from API 29 the
+     * platform answers false whenever this app is unfocused -- which is precisely when no
+     * selection bar is up, so it costs nothing here.
+     */
+    private boolean clipboardHasText() {
+        ClipboardManager clipboard = clipboardManager();
+        if (clipboard == null) return false;
+        try {
+            return clipboard.hasPrimaryClip();
+        } catch (Exception e) {
+            // Reading the clipboard is an IPC into the system service; a dead source app can
+            // surface here, and a greyed-out Paste is a better outcome than a crash.
+            return false;
+        }
     }
 
     @Override
@@ -347,6 +455,9 @@ public class TextSelectionCursorController implements CursorController {
 
     @Override
     public void onDetached() {
+        // LUNAMUX: the view is going away; make sure the clipboard service is not left holding
+        // a listener that closes over it.
+        unregisterClipChangedListener();
     }
 
     @Override
@@ -368,17 +479,6 @@ public class TextSelectionCursorController implements CursorController {
     /** Get the currently selected text. */
     public String getSelectedText() {
         return terminalView.mEmulator.getSelectedText(mSelX1, mSelY1, mSelX2, mSelY2);
-    }
-
-    /** Get the selected text stored before "MORE" button was pressed on the context menu. */
-    @Nullable
-    public String getStoredSelectedText() {
-        return mStoredSelectedText;
-    }
-
-    /** Unset the selected text stored before "MORE" button was pressed on the context menu. */
-    public void unsetStoredSelectedText() {
-        mStoredSelectedText = null;
     }
 
     public ActionMode getActionMode() {

--- a/terminal-view/src/main/res/values/strings.xml
+++ b/terminal-view/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
   <string name="paste_text">Paste</string>
   <string name="copy_text">Copy</string>
-  <string name="text_selection_more">More…</string>
 </resources>


### PR DESCRIPTION
Long-pressing the terminal on Android raises the floating text-selection bar, and **every button on it is dead**. Two separate causes, which is why it looked like several bugs.

Tracked as LMX-158 (consolidating LMX-120 "paste noops" and LMX-121 "More noops").

## Why Copy and Paste did nothing

The Termux view never touches the clipboard itself — it calls its session's `onCopyTextToClipboard` / `onPasteTextFromClipboard`. `TerminalEmulatorHolder`'s session stubbed both out as `= Unit`.

The stub was there for a real reason, and the comment above it says so: the session passes `null` for Termux's client, so every callback must be overridden or it NPEs — `reset()` inside the emulator constructor already calls one. But two of them needed bodies rather than silence.

The same stub also swallowed **OSC 52**, so a program on the far end could not set the phone's clipboard either.

## Why "More…" did nothing

It called `showContextMenu()`, which needs a host overriding `onCreateContextMenu`. That is how Termux's activity-based UI is built; `MainActivity` is Compose and provides no such thing, so the item could never work on any device.

I removed it rather than giving the activity a context menu to satisfy one button. The bar is now **Copy and Paste** — both of which work, and no overflow. I did try Select all and Share in that slot; both were cut on review (a "Select all" that stops at the visible screen reads as a bug rather than a scope, and the handles already do that job; Share did not earn a button).

## The rest

- Paste goes through `TerminalEmulator.paste` rather than writing bytes directly, so bracketed-paste is honoured and the text lands on the ordinary write path — a paste into a pane the phone is only *mirroring* takes the PTY over first, exactly as a keystroke would.
- Below API 33 a short toast confirms a copy; from 33 up Android shows its own clipboard confirmation and ours would just duplicate it.
- New `TerminalClipboard` marshals to the main thread, because OSC 52 arrives on the emulator dispatcher while the selection bar arrives on the UI thread, and `ClipboardManager` is a UI-thread API in practice.

## Two more defects found in the same code

- **Paste stayed greyed out.** Built enabled-or-not once, with `onPrepareActionMode` returning `false` forever — so a selection begun with an empty clipboard kept a disabled Paste even after the user had copied something, a disabled button being indistinguishable from the dead one beside it. Now follows the clipboard via `OnPrimaryClipChangedListener` rather than polling: `render()` invalidates the action mode every frame and `hasPrimaryClip()` is a binder call, so a per-frame check would put a synchronous IPC in the draw path.
- **The bar anchored to the wrong place.** `onGetContentRect` multiplied out cell metrics by hand, making it the one pixel↔cell conversion that never learnt about the mirror's horizontal pan and vertical centring — the four in `TerminalView` carry a comment saying they must. Now goes through `getPointX`/`getPointY`.

## Removals worth a second look

Dropping "More…" orphaned `mStoredSelectedText`, whose whole purpose was that flow: stash the text before stopping the selection, so the handles do not float above the context menu that is about to need it. With no such flow, `getStoredSelectedText()` could only return null and `TerminalView.onContextMenuClosed()` could only clear nothing — and its javadoc pointed at the now-deleted `ACTION_MORE`. Both are gone, with three imports they were the last users of.

The one remaining `showContextMenu()` call — hardware-mouse right-click — is left behaving **exactly** as before, with a comment noting it is the same dead affordance. It is unreachable on a phone and not worth changing on a path I cannot test here.

## Deliberate: thumbnails get no clipboard

`appContext` is nullable, and `MiniTerminalRegistry` passes `null`. The overview's miniatures replay the same output stream as the real pane, OSC 52 included, so honouring it there would let merely *opening the overview* overwrite what the user copied — once per thumbnail of the session. They have no selection bar to paste from either.

## Testing

`:terminal-core:test` passes and the release APK builds. **Verified on device** (Pixel, sideloaded release build): copy, paste, and the paste-into-a-mirrored-pane take-over all behave.

Known and unrelated: Gboard's spacebar-slide cursor gesture does nothing in the terminal, because `onCreateInputConnection` reports `inputType = TYPE_NULL` and that gesture is built on the rich text-editing API. Reproduces in Termux for the same reason; filed separately as LMX-159 rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)